### PR TITLE
Add Codex plugin support

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "diagram-design",
+  "description": "Editorial-quality technical and product diagrams - 13 types rendered as standalone HTML with inline SVG, skinnable to match your brand",
+  "version": "1.0.0",
+  "author": {
+    "name": "Cathryn Lavery",
+    "url": "https://github.com/cathrynlavery"
+  },
+  "homepage": "https://github.com/cathrynlavery/diagram-design",
+  "repository": "https://github.com/cathrynlavery/diagram-design",
+  "license": "MIT",
+  "keywords": [
+    "diagrams",
+    "svg",
+    "architecture",
+    "flowchart",
+    "visualization",
+    "editorial"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Diagram Design",
+    "shortDescription": "Create editorial technical and product diagrams as standalone HTML.",
+    "longDescription": "Generate architecture, flowchart, sequence, state machine, ER, timeline, swimlane, quadrant, nested, tree, layers, venn, and pyramid diagrams with an opinionated editorial design system.",
+    "developerName": "Cathryn Lavery",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/cathrynlavery/diagram-design",
+    "defaultPrompt": [
+      "Make an architecture diagram of my app.",
+      "Create a flowchart for this decision process.",
+      "Build a sequence diagram for this workflow."
+    ],
+    "brandColor": "#b5523a"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Quicker to install — but the skill lives in the plugin cache, so edits to `ref
 
 **Claude Cowork:** Customize → Directory → Plugins → **+** → paste `cathrynlavery/diagram-design` → Sync, then install from the Personal list.
 
+**Codex:**
+```
+/plugin marketplace add cathrynlavery/diagram-design
+/plugin install diagram-design@diagram-design
+```
+
 ---
 
 ## Onboarding — make it look like *your* brand

--- a/skills/diagram-design/SKILL.md
+++ b/skills/diagram-design/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: diagram-design
+description: Create technical and product diagrams - architecture, flowchart, sequence, state machine, ER / data model, timeline, swimlane, quadrant, nested, tree, layer stack, venn, pyramid - as standalone HTML files with inline SVG. Ships with a neutral editorial skin and a first-run gate that prompts users to customize the style guide before generating.
+license: MIT
+metadata:
+  version: "1.0"
+---
+
+# Diagram Design
+
+This is the Codex plugin wrapper for the root skill.
+
+Before creating a diagram, open and follow `../../SKILL.md`. Resolve all referenced paths from the repository root, including `../../references/` and `../../assets/`.


### PR DESCRIPTION
## Summary
- Add a Codex plugin manifest under .codex-plugin/plugin.json
- Document Codex plugin install commands alongside the existing Claude plugin instructions

## Validation
- python3 -m json.tool .codex-plugin/plugin.json