### PR TITLE
feat(onboard): add automated brand onboarding CLI tool scripts/onboard.py

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, or DP security matrix diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, or DP security matrix diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, or DP security matrix diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, or DP security matrix diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,9 @@ jobs:
         id: geometry_tests
         run: python scripts/test-verify-geometry.py
 
+      - name: Verify onboarding CLI script
+        run: python3 scripts/verify-onboarding.py
+
       - name: Verify generated icon assets
         if: always()
         id: icons

--- a/scripts/onboard.py
+++ b/scripts/onboard.py
@@ -18,6 +18,7 @@ import json
 import os
 import pathlib
 import re
+import shutil
 import sys
 import tempfile
 import urllib.error
@@ -25,12 +26,17 @@ import urllib.request
 from typing import NamedTuple
 from urllib.parse import urlparse
 
+# Python minimum version check (3.10+)
+if sys.version_info < (3, 10):
+    sys.exit("Error: scripts/onboard.py requires Python 3.10 or higher.")
+
 REPO = pathlib.Path(__file__).resolve().parent.parent
 DEFAULT_STYLE_GUIDE = REPO / "skills" / "diagram-design" / "references" / "style-guide.md"
 
 HEX_RE = re.compile(r"#(?:[0-9a-fA-F]{3}){1,2}\b")
 VAR_RE = re.compile(r"--([\w-]+)\s*:\s*([^;]+);")
 SCSS_VAR_RE = re.compile(r"\$([\w-]+)\s*:\s*([^;]+);")
+TABLE_HEADER_PATTERN = re.compile(r"\| Role \| Purpose \| Default \(light\) \| Default \(dark\) \|")
 
 
 class Color(NamedTuple):
@@ -140,11 +146,16 @@ def fetch_url_content(url: str, max_bytes: int = 5 * 1024 * 1024) -> str:
         url,
         headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
     )
-    with urllib.request.urlopen(req, timeout=15) as resp:
+    resp = None
+    try:
+        resp = urllib.request.urlopen(req, timeout=15)
         content_bytes = resp.read(max_bytes + 1)
         if len(content_bytes) > max_bytes:
             raise ValueError(f"Response size exceeds maximum permitted cap of {max_bytes // (1024*1024)}MB.")
         return content_bytes.decode("utf-8", errors="ignore")
+    finally:
+        if resp is not None:
+            resp.close()
 
 
 def extract_css_from_folder(folder_path: pathlib.Path) -> str:
@@ -163,7 +174,7 @@ def extract_css_from_folder(folder_path: pathlib.Path) -> str:
 
 
 def extract_json_tokens(text: str) -> dict[str, str]:
-    """Format-aware JSON design token parser for nested token objects."""
+    """Format-aware JSON design token parser supporting arbitrary nested token object paths ($value, value, hex)."""
     found: dict[str, str] = {}
 
     def walk_json(obj: object, path: str = "") -> None:
@@ -173,20 +184,41 @@ def extract_json_tokens(text: str) -> dict[str, str]:
                 if isinstance(v, str):
                     m = HEX_RE.search(v)
                     if m:
-                        found[new_path.lower()] = m.group(0).lower()
+                        hex_val = m.group(0).lower()
+                        found[new_path.lower()] = hex_val
+                        # Normalize nested paths like color.primary.$value -> color.primary and primary
+                        parts = [p.lower() for p in new_path.split(".") if p.lower() not in ("$value", "value", "hex", "val", "color")]
+                        if parts:
+                            normalized_path = ".".join(parts)
+                            found[normalized_path] = hex_val
+                            found[parts[-1]] = hex_val
                 else:
                     walk_json(v, new_path)
         elif isinstance(obj, list):
             for i, item in enumerate(obj):
                 walk_json(item, f"{path}[{i}]")
 
-    # Try parsing text blocks as JSON
-    for block in re.findall(r"\{[^{}]+\}", text):
-        try:
-            data = json.loads(block)
-            walk_json(data)
-        except Exception:
-            pass
+    # 1. Parse entire text if it is valid JSON
+    try:
+        data = json.loads(text)
+        walk_json(data)
+    except Exception:
+        pass
+
+    # 2. Extract nested JSON blocks using balanced brace scan
+    stack: list[int] = []
+    for idx, char in enumerate(text):
+        if char == "{":
+            stack.append(idx)
+        elif char == "}" and stack:
+            start_idx = stack.pop()
+            if not stack:  # Outer-most JSON block found
+                block = text[start_idx : idx + 1]
+                try:
+                    data = json.loads(block)
+                    walk_json(data)
+                except Exception:
+                    pass
 
     return found
 
@@ -225,14 +257,30 @@ def extract_tokens(text: str) -> tuple[dict[str, str], list[str]]:
     accent_hex: str | None = None
     muted_hex: str | None = None
 
+    # Priority matching: exact key matches take precedence over partial substring matches
+    role_keywords = {
+        "paper": ["bg", "background", "paper", "surface"],
+        "ink": ["text", "ink", "foreground", "body"],
+        "accent": ["accent", "brand", "primary", "cta"],
+        "muted": ["muted", "secondary", "caption"],
+    }
+
+    # Pass 1: Exact matches (e.g. "primary", "bg", "text", "muted")
     for name, val in vars_found.items():
-        if not paper_hex and any(k in name for k in ("bg", "background", "paper", "surface")):
+        if name in role_keywords["paper"] and not paper_hex: paper_hex = val
+        if name in role_keywords["ink"] and not ink_hex: ink_hex = val
+        if name in role_keywords["accent"] and not accent_hex: accent_hex = val
+        if name in role_keywords["muted"] and not muted_hex: muted_hex = val
+
+    # Pass 2: Substring matches (e.g. "brand-primary", "color-bg")
+    for name, val in vars_found.items():
+        if not paper_hex and any(k in name for k in role_keywords["paper"]):
             paper_hex = val
-        elif not ink_hex and any(k in name for k in ("text", "ink", "foreground", "body")):
+        elif not ink_hex and any(k in name for k in role_keywords["ink"]):
             ink_hex = val
-        elif not accent_hex and any(k in name for k in ("accent", "brand", "primary", "cta")):
+        elif not accent_hex and any(k in name for k in role_keywords["accent"]):
             accent_hex = val
-        elif not muted_hex and any(k in name for k in ("muted", "secondary", "caption")):
+        elif not muted_hex and any(k in name for k in role_keywords["muted"]):
             muted_hex = val
 
     # Fallback to frequency ranking if variables were incomplete
@@ -269,7 +317,7 @@ def extract_tokens(text: str) -> tuple[dict[str, str], list[str]]:
 
 
 def compute_derived_roles(tokens: dict[str, str]) -> tuple[dict[str, dict[str, str]], list[str]]:
-    """Compute light and dark variants for all 9 semantic roles with double-ended WCAG contrast enforcement."""
+    """Compute light and dark variants for all 10 semantic roles with double-ended WCAG contrast enforcement."""
     contrast_notes: list[str] = []
     paper_c = Color.from_hex(tokens["paper"])
     ink_c = Color.from_hex(tokens["ink"])
@@ -293,7 +341,11 @@ def compute_derived_roles(tokens: dict[str, str]) -> tuple[dict[str, dict[str, s
         int(ink_c.b * 0.4 + muted_c.b * 0.6)
     )
     rule_str = f"rgba({ink_c.r},{ink_c.g},{ink_c.b},0.12)"
-    rule_solid_c = Color(191, 192, 192)
+    rule_solid_c = Color(
+        int(ink_c.r * 0.3 + paper_c.r * 0.7),
+        int(ink_c.g * 0.3 + paper_c.g * 0.7),
+        int(ink_c.b * 0.3 + paper_c.b * 0.7)
+    )
     accent_tint_str = f"rgba({accent_c.r},{accent_c.g},{accent_c.b},0.08)"
     link_c = Color(46, 90, 168)
 
@@ -315,7 +367,11 @@ def compute_derived_roles(tokens: dict[str, str]) -> tuple[dict[str, dict[str, s
         contrast_notes.append(f"[Dark Mode] {note_muted_dark}")
 
     rule_dark_str = f"rgba({ink_dark.r},{ink_dark.g},{ink_dark.b},0.12)"
-    rule_solid_dark_str = f"rgba({ink_dark.r},{ink_dark.g},{ink_dark.b},0.25)"
+    rule_solid_dark_c = Color(
+        int(ink_dark.r * 0.3 + paper_dark.r * 0.7),
+        int(ink_dark.g * 0.3 + paper_dark.g * 0.7),
+        int(ink_dark.b * 0.3 + paper_dark.b * 0.7)
+    )
     accent_tint_dark_str = f"rgba({accent_dark.r},{accent_dark.g},{accent_dark.b},0.10)"
     link_dark = Color(min(255, link_c.r + 60), min(255, link_c.g + 60), min(255, link_c.b + 60))
 
@@ -326,7 +382,7 @@ def compute_derived_roles(tokens: dict[str, str]) -> tuple[dict[str, dict[str, s
         "muted":       {"light": muted_c.to_hex(), "dark": muted_dark.to_hex()},
         "soft":        {"light": soft_c.to_hex(), "dark": soft_dark.to_hex()},
         "rule":        {"light": rule_str, "dark": rule_dark_str},
-        "rule-solid":  {"light": rule_solid_c.to_hex(), "dark": rule_solid_dark_str},
+        "rule-solid":  {"light": rule_solid_c.to_hex(), "dark": rule_solid_dark_c.to_hex()},
         "accent":      {"light": accent_c.to_hex(), "dark": accent_dark.to_hex()},
         "accent-tint": {"light": accent_tint_str, "dark": accent_tint_dark_str},
         "link":        {"light": link_c.to_hex(), "dark": link_dark.to_hex()},
@@ -334,8 +390,21 @@ def compute_derived_roles(tokens: dict[str, str]) -> tuple[dict[str, dict[str, s
     return roles, contrast_notes
 
 
+def validate_output_target(style_guide_path: pathlib.Path) -> None:
+    """Validate that target style guide file exists and contains expected semantic roles table header."""
+    if not style_guide_path.parent.exists():
+        raise FileNotFoundError(f"Target directory does not exist: {style_guide_path.parent}")
+
+    if not style_guide_path.exists():
+        raise FileNotFoundError(f"Target style guide file does not exist: {style_guide_path}")
+
+    content = style_guide_path.read_text(encoding="utf-8")
+    if not TABLE_HEADER_PATTERN.search(content):
+        raise ValueError(f"Target file {style_guide_path} does not contain expected semantic roles table header.")
+
+
 def update_style_guide(roles: dict[str, dict[str, str]], style_guide_path: pathlib.Path, apply_changes: bool = False) -> str:
-    """Generate Markdown tokens table and perform atomic write with recoverable backup if apply_changes is True."""
+    """Generate Markdown tokens table and perform crash-safe atomic write while retaining a recoverable backup."""
     lines = [
         "| Role | Purpose | Default (light) | Default (dark) |",
         "|---|---|---|---|",
@@ -353,35 +422,34 @@ def update_style_guide(roles: dict[str, dict[str, str]], style_guide_path: pathl
     table_text = "\n".join(lines)
 
     if apply_changes:
-        if not style_guide_path.parent.exists():
-            raise FileNotFoundError(f"Target directory does not exist: {style_guide_path.parent}")
-
-        if not style_guide_path.exists():
-            raise FileNotFoundError(f"Target style guide file does not exist: {style_guide_path}")
-
+        validate_output_target(style_guide_path)
         content = style_guide_path.read_text(encoding="utf-8")
+
         table_pattern = re.compile(r"\| Role \| Purpose \| Default \(light\) \| Default \(dark\) \|.*?\n(?:\|.*?\|\n)+", re.DOTALL)
         if not table_pattern.search(content):
             raise ValueError(f"Could not locate semantic roles table pattern in {style_guide_path}")
 
         updated_content = table_pattern.sub(table_text + "\n", content, count=1)
 
-        # Atomic write using backup file (.bak) and temp file
+        # Crash-safe atomic write flow while retaining a recoverable backup (.bak)
         backup_path = style_guide_path.with_name(style_guide_path.name + ".bak")
-        style_guide_path.replace(backup_path)
+        # Step 1: Copy original to backup first (retained backup, original target stays untouched until atomic swap)
+        shutil.copy2(style_guide_path, backup_path)
 
+        # Step 2: Write replacement to temporary file in same directory
+        temp_fd, temp_path_str = tempfile.mkstemp(dir=style_guide_path.parent, prefix="style-guide-", suffix=".tmp")
+        temp_path = pathlib.Path(temp_path_str)
         try:
-            temp_file = style_guide_path.with_name(style_guide_path.name + ".tmp")
-            temp_file.write_text(updated_content, encoding="utf-8")
-            temp_file.replace(style_guide_path)
-            # Remove temporary backup upon successful write
-            if backup_path.exists():
-                backup_path.unlink()
+            with open(temp_fd, "w", encoding="utf-8") as f:
+                f.write(updated_content)
+
+            # Step 3: Atomic replace target file
+            os.replace(temp_path, style_guide_path)
+            # Backup path style_guide_path.bak is deliberately retained as a recoverable backup
         except Exception as e:
-            # Restore from backup in case of write failure
-            if backup_path.exists():
-                backup_path.replace(style_guide_path)
-            raise IOError(f"Atomic write to style guide failed: {e}") from e
+            if temp_path.exists():
+                temp_path.unlink()
+            raise IOError(f"Crash-safe atomic write to style guide failed: {e}") from e
 
     return table_text
 
@@ -397,6 +465,14 @@ def main() -> int:
 
     args = parser.parse_args()
     style_guide_path = pathlib.Path(args.out) if args.out else DEFAULT_STYLE_GUIDE
+
+    # Validate output target prior to extraction if apply mode is requested
+    if args.apply:
+        try:
+            validate_output_target(style_guide_path)
+        except Exception as e:
+            print(f"Error validating output target: {e}", file=sys.stderr)
+            return 1
 
     print("Onboarding diagram-design skin...")
     try:
@@ -434,7 +510,7 @@ def main() -> int:
     print(table_output)
 
     if args.apply:
-        print(f"\n[Apply mode] Successfully updated {style_guide_path}")
+        print(f"\n[Apply mode] Successfully updated {style_guide_path} (backup retained at {style_guide_path}.bak)")
     else:
         print("\n[Preview mode] No changes were written to style-guide.md. Use --apply to commit changes.")
 

--- a/scripts/onboard.py
+++ b/scripts/onboard.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Automated Brand Onboarding CLI Tool for diagram-design.
+
+Extracts brand colors and typography from a website URL, local CSS folder, or design tokens,
+validates WCAG AA contrast compliance, computes light/dark semantic role mappings,
+and updates skills/diagram-design/references/style-guide.md.
+
+Usage:
+    python scripts/onboard.py --url https://example.com
+    python scripts/onboard.py --folder ./my-design-tokens
+    python scripts/onboard.py --url https://example.com --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import pathlib
+import re
+import sys
+import urllib.error
+import urllib.request
+from typing import NamedTuple
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+DEFAULT_STYLE_GUIDE = REPO / "skills" / "diagram-design" / "references" / "style-guide.md"
+
+HEX_RE = re.compile(r"#(?:[0-9a-fA-F]{3}){1,2}\b")
+VAR_RE = re.compile(r"--([\w-]+)\s*:\s*([^;]+);")
+FONT_RE = re.compile(r"font-family\s*:\s*([^;]+);", re.IGNORECASE)
+
+
+class Color(NamedTuple):
+    r: int
+    g: int
+    b: int
+
+    @classmethod
+    def from_hex(cls, hex_str: str) -> Color:
+        hex_clean = hex_str.lstrip("#")
+        if len(hex_clean) == 3:
+            hex_clean = "".join(c * 2 for c in hex_clean)
+        val = int(hex_clean, 16)
+        return cls((val >> 16) & 0xFF, (val >> 8) & 0xFF, val & 0xFF)
+
+    def to_hex(self) -> str:
+        return f"#{self.r:02x}{self.g:02x}{self.b:02x}"
+
+    def luminance(self) -> float:
+        """Calculate relative luminance for WCAG contrast calculation."""
+        def channel_lum(c: int) -> float:
+            s = c / 255.0
+            return s / 12.92 if s <= 0.03928 else ((s + 0.055) / 1.055) ** 2.4
+
+        return 0.2126 * channel_lum(self.r) + 0.7152 * channel_lum(self.g) + 0.0722 * channel_lum(self.b)
+
+
+def contrast_ratio(c1: Color, c2: Color) -> float:
+    """Calculate WCAG contrast ratio between two colors."""
+    l1 = c1.luminance()
+    l2 = c2.luminance()
+    bright = max(l1, l2)
+    dark = min(l1, l2)
+    return (bright + 0.05) / (dark + 0.05)
+
+
+def ensure_contrast(foreground: Color, background: Color, min_ratio: float = 4.5) -> Color:
+    """Adjust foreground color lightness to guarantee minimum WCAG contrast against background."""
+    if contrast_ratio(foreground, background) >= min_ratio:
+        return foreground
+
+    bg_lum = background.luminance()
+    # Darken foreground if background is light, lighten if background is dark
+    make_darker = bg_lum > 0.5
+    factor = 0.9 if make_darker else 1.1
+
+    curr_r, curr_g, curr_b = foreground.r, foreground.g, foreground.b
+    for _ in range(30):
+        if make_darker:
+            curr_r = max(0, int(curr_r * factor))
+            curr_g = max(0, int(curr_g * factor))
+            curr_b = max(0, int(curr_b * factor))
+        else:
+            curr_r = min(255, max(1, int(curr_r * factor)))
+            curr_g = min(255, max(1, int(curr_g * factor)))
+            curr_b = min(255, max(1, int(curr_b * factor)))
+
+        adjusted = Color(curr_r, curr_g, curr_b)
+        if contrast_ratio(adjusted, background) >= min_ratio:
+            return adjusted
+
+    return Color(0, 0, 0) if make_darker else Color(255, 255, 255)
+
+
+def fetch_url_content(url: str) -> str:
+    """Fetch website HTML/CSS content with browser User-Agent."""
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return resp.read().decode("utf-8", errors="ignore")
+
+
+def extract_css_from_folder(folder_path: pathlib.Path) -> str:
+    """Read and concatenate CSS, JSON, and HTML files from a local folder."""
+    chunks = []
+    exts = {".css", ".json", ".html", ".md"}
+    for root, _, files in os.walk(folder_path):
+        for file in files:
+            p = pathlib.Path(root) / file
+            if p.suffix.lower() in exts:
+                try:
+                    chunks.append(p.read_text(encoding="utf-8", errors="ignore"))
+                except Exception:
+                    pass
+    return "\n".join(chunks)
+
+
+def extract_tokens(text: str) -> dict[str, str]:
+    """Extract colors and variables from text content."""
+    vars_found: dict[str, str] = {}
+    for match in VAR_RE.finditer(text):
+        name, val = match.group(1).lower(), match.group(2).strip()
+        hex_match = HEX_RE.search(val)
+        if hex_match:
+            vars_found[name] = hex_match.group(0).lower()
+
+    hexes = [m.lower() for m in HEX_RE.findall(text)]
+
+    # Map semantic roles using name heuristics or frequency
+    paper_hex = "#f5f5f5"
+    ink_hex = "#2d3142"
+    accent_hex = "#eb6c36"
+    muted_hex = "#4f5d75"
+
+    for name, val in vars_found.items():
+        if any(k in name for k in ("bg", "background", "paper", "surface")):
+            paper_hex = val
+        elif any(k in name for k in ("text", "ink", "foreground", "body")):
+            ink_hex = val
+        elif any(k in name for k in ("accent", "brand", "primary", "cta")):
+            accent_hex = val
+        elif any(k in name for k in ("muted", "secondary", "caption")):
+            muted_hex = val
+
+    # Fallback to frequency if custom properties were missing
+    if not vars_found and hexes:
+        counts = {}
+        for h in hexes:
+            counts[h] = counts.get(h, 0) + 1
+        sorted_colors = sorted(counts.items(), key=lambda x: x[1], reverse=True)
+        if sorted_colors:
+            paper_hex = sorted_colors[0][0]
+        if len(sorted_colors) > 1:
+            ink_hex = sorted_colors[1][0]
+        if len(sorted_colors) > 2:
+            accent_hex = sorted_colors[2][0]
+
+    return {
+        "paper": paper_hex,
+        "ink": ink_hex,
+        "accent": accent_hex,
+        "muted": muted_hex,
+    }
+
+
+def compute_derived_roles(tokens: dict[str, str]) -> dict[str, dict[str, str]]:
+    """Compute light and dark variants for all 9 semantic roles with contrast enforcement."""
+    paper_c = Color.from_hex(tokens["paper"])
+    ink_c = Color.from_hex(tokens["ink"])
+    accent_c = Color.from_hex(tokens["accent"])
+    muted_c = Color.from_hex(tokens["muted"])
+
+    # Enforce WCAG AA contrast on ink and muted against paper
+    ink_c = ensure_contrast(ink_c, paper_c, 4.5)
+    muted_c = ensure_contrast(muted_c, paper_c, 4.5)
+
+    # Derived light values
+    paper_2_c = Color(
+        max(0, paper_c.r - 9),
+        max(0, paper_c.g - 9),
+        max(0, paper_c.b - 9)
+    )
+    soft_c = Color(
+        int(ink_c.r * 0.4 + muted_c.r * 0.6),
+        int(ink_c.g * 0.4 + muted_c.g * 0.6),
+        int(ink_c.b * 0.4 + muted_c.b * 0.6)
+    )
+    rule_str = f"rgba({ink_c.r},{ink_c.g},{ink_c.b},0.12)"
+    rule_solid_c = Color(191, 192, 192)
+    accent_tint_str = f"rgba({accent_c.r},{accent_c.g},{accent_c.b},0.08)"
+    link_c = Color(46, 90, 168)
+
+    # Dark mode inversion
+    paper_dark = Color(
+        max(0, 255 - paper_c.r),
+        max(0, 255 - paper_c.g),
+        max(0, 255 - paper_c.b)
+    )
+    ink_dark = Color(
+        min(255, 255 - ink_c.r),
+        min(255, 255 - ink_c.g),
+        min(255, 255 - ink_c.b)
+    )
+    accent_dark = Color(
+        min(255, accent_c.r + 15),
+        min(255, accent_c.g + 18),
+        min(255, accent_c.b + 20)
+    )
+    paper_2_dark = Color(
+        min(255, paper_dark.r + 12),
+        min(255, paper_dark.g + 12),
+        min(255, paper_dark.b + 12)
+    )
+    muted_dark = Color(191, 192, 192)
+    soft_dark = Color(142, 152, 172)
+    rule_dark_str = f"rgba({ink_dark.r},{ink_dark.g},{ink_dark.b},0.12)"
+    rule_solid_dark_str = "rgba(191,192,192,0.25)"
+    accent_tint_dark_str = f"rgba({accent_dark.r},{accent_dark.g},{accent_dark.b},0.10)"
+    link_dark = Color(106, 149, 216)
+
+    return {
+        "paper":       {"light": paper_c.to_hex(), "dark": paper_dark.to_hex()},
+        "paper-2":     {"light": paper_2_c.to_hex(), "dark": paper_2_dark.to_hex()},
+        "ink":         {"light": ink_c.to_hex(), "dark": ink_dark.to_hex()},
+        "muted":       {"light": muted_c.to_hex(), "dark": muted_dark.to_hex()},
+        "soft":        {"light": soft_c.to_hex(), "dark": soft_dark.to_hex()},
+        "rule":        {"light": rule_str, "dark": rule_dark_str},
+        "rule-solid":  {"light": rule_solid_c.to_hex(), "dark": rule_solid_dark_str},
+        "accent":      {"light": accent_c.to_hex(), "dark": accent_dark.to_hex()},
+        "accent-tint": {"light": accent_tint_str, "dark": accent_tint_dark_str},
+        "link":        {"light": link_c.to_hex(), "dark": link_dark.to_hex()},
+    }
+
+
+def update_style_guide(roles: dict[str, dict[str, str]], style_guide_path: pathlib.Path, dry_run: bool = False) -> str:
+    """Generate Markdown tokens table and update style-guide.md."""
+    lines = [
+        "| Role | Purpose | Default (light) | Default (dark) |",
+        "|---|---|---|---|",
+        f"| `paper` | Page background, default node fill | `{roles['paper']['light']}` | `{roles['paper']['dark']}` |",
+        f"| `paper-2` | Diagram container bg, secondary fill | `{roles['paper-2']['light']}` | `{roles['paper-2']['dark']}` |",
+        f"| `ink` | Primary text, primary stroke | `{roles['ink']['light']}` | `{roles['ink']['dark']}` |",
+        f"| `muted` | Secondary text, default arrow stroke | `{roles['muted']['light']}` | `{roles['muted']['dark']}` |",
+        f"| `soft` | Sublabels, boundary labels | `{roles['soft']['light']}` | `{roles['soft']['dark']}` |",
+        f"| `rule` | Hairline borders | `{roles['rule']['light']}` | `{roles['rule']['dark']}` |",
+        f"| `rule-solid` | Stronger borders, baselines | `{roles['rule-solid']['light']}` | `{roles['rule-solid']['dark']}` |",
+        f"| `accent` | Focal / 1–2 max per diagram | `{roles['accent']['light']}` | `{roles['accent']['dark']}` |",
+        f"| `accent-tint` | Fill for accent-bordered boxes | `{roles['accent-tint']['light']}` | `{roles['accent-tint']['dark']}` |",
+        f"| `link` | HTTP/API calls, external arrows | `{roles['link']['light']}` | `{roles['link']['dark']}` |",
+    ]
+    table_text = "\n".join(lines)
+
+    if not dry_run and style_guide_path.exists():
+        content = style_guide_path.read_text(encoding="utf-8")
+        table_pattern = re.compile(r"\| Role \| Purpose \|.*?\n(?:\|.*?\|\n)+", re.DOTALL)
+        if table_pattern.search(content):
+            updated_content = table_pattern.sub(table_text + "\n", content, count=1)
+            style_guide_path.write_text(updated_content, encoding="utf-8")
+
+    return table_text
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Automated Brand Onboarding CLI Tool for diagram-design.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--url", help="Website URL to extract brand tokens from")
+    group.add_argument("--folder", help="Local directory path containing CSS/JSON design tokens")
+    parser.add_argument("--dry-run", action="store_true", help="Preview proposed diff without writing to style-guide.md")
+    parser.add_argument("--out", help="Path to style-guide.md (default: skills/diagram-design/references/style-guide.md)")
+
+    args = parser.parse_args()
+    style_guide_path = pathlib.Path(args.out) if args.out else DEFAULT_STYLE_GUIDE
+
+    print("Onboarding diagram-design skin...")
+    if args.url:
+        print(f"Fetching website: {args.url}")
+        content = fetch_url_content(args.url)
+    else:
+        folder_path = pathlib.Path(args.folder)
+        if not folder_path.exists():
+            print(f"Error: folder path does not exist: {folder_path}", file=sys.stderr)
+            return 1
+        print(f"Reading local folder: {folder_path}")
+        content = extract_css_from_folder(folder_path)
+
+    raw_tokens = extract_tokens(content)
+    print(f"Extracted Raw Tokens: {raw_tokens}")
+
+    roles = compute_derived_roles(raw_tokens)
+    table_output = update_style_guide(roles, style_guide_path, dry_run=args.dry_run)
+
+    print("\n--- Proposed Tokens Table ---")
+    print(table_output)
+
+    if args.dry_run:
+        print("\n[Dry-run mode] No changes were written to style-guide.md.")
+    else:
+        print(f"\nSuccessfully updated {style_guide_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/onboard.py
+++ b/scripts/onboard.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Automated Brand Onboarding CLI Tool for diagram-design.
 
-Extracts brand colors and typography from a website URL, local CSS folder, or design tokens,
+Extracts brand colors from a website URL, local CSS folder, or design tokens,
 validates WCAG AA contrast compliance, computes light/dark semantic role mappings,
 and updates skills/diagram-design/references/style-guide.md.
 
@@ -14,7 +14,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import math
 import os
 import pathlib
 import re
@@ -22,13 +21,13 @@ import sys
 import urllib.error
 import urllib.request
 from typing import NamedTuple
+from urllib.parse import urlparse
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 DEFAULT_STYLE_GUIDE = REPO / "skills" / "diagram-design" / "references" / "style-guide.md"
 
 HEX_RE = re.compile(r"#(?:[0-9a-fA-F]{3}){1,2}\b")
 VAR_RE = re.compile(r"--([\w-]+)\s*:\s*([^;]+);")
-FONT_RE = re.compile(r"font-family\s*:\s*([^;]+);", re.IGNORECASE)
 
 
 class Color(NamedTuple):
@@ -65,13 +64,14 @@ def contrast_ratio(c1: Color, c2: Color) -> float:
     return (bright + 0.05) / (dark + 0.05)
 
 
-def ensure_contrast(foreground: Color, background: Color, min_ratio: float = 4.5) -> Color:
+def ensure_contrast(foreground: Color, background: Color, min_ratio: float = 4.5) -> tuple[Color, str | None]:
     """Adjust foreground color lightness to guarantee minimum WCAG contrast against background."""
-    if contrast_ratio(foreground, background) >= min_ratio:
-        return foreground
+    ratio = contrast_ratio(foreground, background)
+    if ratio >= min_ratio:
+        return foreground, None
 
+    orig_hex = foreground.to_hex()
     bg_lum = background.luminance()
-    # Darken foreground if background is light, lighten if background is dark
     make_darker = bg_lum > 0.5
     factor = 0.9 if make_darker else 1.1
 
@@ -87,20 +87,32 @@ def ensure_contrast(foreground: Color, background: Color, min_ratio: float = 4.5
             curr_b = min(255, max(1, int(curr_b * factor)))
 
         adjusted = Color(curr_r, curr_g, curr_b)
-        if contrast_ratio(adjusted, background) >= min_ratio:
-            return adjusted
+        new_ratio = contrast_ratio(adjusted, background)
+        if new_ratio >= min_ratio:
+            note = f"Adjusted {orig_hex} -> {adjusted.to_hex()} (WCAG AA contrast {new_ratio:.1f}:1 on {background.to_hex()})"
+            return adjusted, note
 
-    return Color(0, 0, 0) if make_darker else Color(255, 255, 255)
+    final_c = Color(0, 0, 0) if make_darker else Color(255, 255, 255)
+    final_ratio = contrast_ratio(final_c, background)
+    note = f"Adjusted {orig_hex} -> {final_c.to_hex()} (WCAG AA contrast {final_ratio:.1f}:1 on {background.to_hex()})"
+    return final_c, note
 
 
-def fetch_url_content(url: str) -> str:
-    """Fetch website HTML/CSS content with browser User-Agent."""
+def fetch_url_content(url: str, max_bytes: int = 5 * 1024 * 1024) -> str:
+    """Fetch website content enforcing http/https schemes and response size cap."""
+    parsed = urlparse(url)
+    if parsed.scheme.lower() not in ("http", "https"):
+        raise ValueError(f"Invalid URL scheme '{parsed.scheme}': only http and https are permitted.")
+
     req = urllib.request.Request(
         url,
         headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
     )
     with urllib.request.urlopen(req, timeout=15) as resp:
-        return resp.read().decode("utf-8", errors="ignore")
+        content_bytes = resp.read(max_bytes + 1)
+        if len(content_bytes) > max_bytes:
+            raise ValueError(f"Response size exceeds maximum permitted cap of {max_bytes // (1024*1024)}MB.")
+        return content_bytes.decode("utf-8", errors="ignore")
 
 
 def extract_css_from_folder(folder_path: pathlib.Path) -> str:
@@ -118,8 +130,9 @@ def extract_css_from_folder(folder_path: pathlib.Path) -> str:
     return "\n".join(chunks)
 
 
-def extract_tokens(text: str) -> dict[str, str]:
+def extract_tokens(text: str) -> tuple[dict[str, str], list[str]]:
     """Extract colors and variables from text content."""
+    warnings: list[str] = []
     vars_found: dict[str, str] = {}
     for match in VAR_RE.finditer(text):
         name, val = match.group(1).lower(), match.group(2).strip()
@@ -147,6 +160,7 @@ def extract_tokens(text: str) -> dict[str, str]:
 
     # Fallback to frequency if custom properties were missing
     if not vars_found and hexes:
+        warnings.append("Warning: No CSS custom properties found; falling back to hex frequency ranking.")
         counts = {}
         for h in hexes:
             counts[h] = counts.get(h, 0) + 1
@@ -158,24 +172,31 @@ def extract_tokens(text: str) -> dict[str, str]:
         if len(sorted_colors) > 2:
             accent_hex = sorted_colors[2][0]
 
-    return {
+    tokens = {
         "paper": paper_hex,
         "ink": ink_hex,
         "accent": accent_hex,
         "muted": muted_hex,
     }
+    return tokens, warnings
 
 
-def compute_derived_roles(tokens: dict[str, str]) -> dict[str, dict[str, str]]:
+def compute_derived_roles(tokens: dict[str, str]) -> tuple[dict[str, dict[str, str]], list[str]]:
     """Compute light and dark variants for all 9 semantic roles with contrast enforcement."""
+    contrast_notes: list[str] = []
     paper_c = Color.from_hex(tokens["paper"])
     ink_c = Color.from_hex(tokens["ink"])
     accent_c = Color.from_hex(tokens["accent"])
     muted_c = Color.from_hex(tokens["muted"])
 
     # Enforce WCAG AA contrast on ink and muted against paper
-    ink_c = ensure_contrast(ink_c, paper_c, 4.5)
-    muted_c = ensure_contrast(muted_c, paper_c, 4.5)
+    ink_c, note_ink = ensure_contrast(ink_c, paper_c, 4.5)
+    if note_ink:
+        contrast_notes.append(note_ink)
+
+    muted_c, note_muted = ensure_contrast(muted_c, paper_c, 4.5)
+    if note_muted:
+        contrast_notes.append(note_muted)
 
     # Derived light values
     paper_2_c = Color(
@@ -193,7 +214,7 @@ def compute_derived_roles(tokens: dict[str, str]) -> dict[str, dict[str, str]]:
     accent_tint_str = f"rgba({accent_c.r},{accent_c.g},{accent_c.b},0.08)"
     link_c = Color(46, 90, 168)
 
-    # Dark mode inversion
+    # Dark mode dynamic brand inversion
     paper_dark = Color(
         max(0, 255 - paper_c.r),
         max(0, 255 - paper_c.g),
@@ -214,14 +235,26 @@ def compute_derived_roles(tokens: dict[str, str]) -> dict[str, dict[str, str]]:
         min(255, paper_dark.g + 12),
         min(255, paper_dark.b + 12)
     )
-    muted_dark = Color(191, 192, 192)
-    soft_dark = Color(142, 152, 172)
+    muted_dark = Color(
+        min(255, 255 - muted_c.r),
+        min(255, 255 - muted_c.g),
+        min(255, 255 - muted_c.b)
+    )
+    soft_dark = Color(
+        min(255, 255 - soft_c.r),
+        min(255, 255 - soft_c.g),
+        min(255, 255 - soft_c.b)
+    )
     rule_dark_str = f"rgba({ink_dark.r},{ink_dark.g},{ink_dark.b},0.12)"
-    rule_solid_dark_str = "rgba(191,192,192,0.25)"
+    rule_solid_dark_str = f"rgba({ink_dark.r},{ink_dark.g},{ink_dark.b},0.25)"
     accent_tint_dark_str = f"rgba({accent_dark.r},{accent_dark.g},{accent_dark.b},0.10)"
-    link_dark = Color(106, 149, 216)
+    link_dark = Color(
+        min(255, link_c.r + 60),
+        min(255, link_c.g + 60),
+        min(255, link_c.b + 60)
+    )
 
-    return {
+    roles = {
         "paper":       {"light": paper_c.to_hex(), "dark": paper_dark.to_hex()},
         "paper-2":     {"light": paper_2_c.to_hex(), "dark": paper_2_dark.to_hex()},
         "ink":         {"light": ink_c.to_hex(), "dark": ink_dark.to_hex()},
@@ -233,6 +266,7 @@ def compute_derived_roles(tokens: dict[str, str]) -> dict[str, dict[str, str]]:
         "accent-tint": {"light": accent_tint_str, "dark": accent_tint_dark_str},
         "link":        {"light": link_c.to_hex(), "dark": link_dark.to_hex()},
     }
+    return roles, contrast_notes
 
 
 def update_style_guide(roles: dict[str, dict[str, str]], style_guide_path: pathlib.Path, dry_run: bool = False) -> str:
@@ -255,7 +289,7 @@ def update_style_guide(roles: dict[str, dict[str, str]], style_guide_path: pathl
 
     if not dry_run and style_guide_path.exists():
         content = style_guide_path.read_text(encoding="utf-8")
-        table_pattern = re.compile(r"\| Role \| Purpose \|.*?\n(?:\|.*?\|\n)+", re.DOTALL)
+        table_pattern = re.compile(r"\| Role \| Purpose \| Default \(light\) \| Default \(dark\) \|.*?\n(?:\|.*?\|\n)+", re.DOTALL)
         if table_pattern.search(content):
             updated_content = table_pattern.sub(table_text + "\n", content, count=1)
             style_guide_path.write_text(updated_content, encoding="utf-8")
@@ -275,21 +309,30 @@ def main() -> int:
     style_guide_path = pathlib.Path(args.out) if args.out else DEFAULT_STYLE_GUIDE
 
     print("Onboarding diagram-design skin...")
-    if args.url:
-        print(f"Fetching website: {args.url}")
-        content = fetch_url_content(args.url)
-    else:
-        folder_path = pathlib.Path(args.folder)
-        if not folder_path.exists():
-            print(f"Error: folder path does not exist: {folder_path}", file=sys.stderr)
-            return 1
-        print(f"Reading local folder: {folder_path}")
-        content = extract_css_from_folder(folder_path)
+    try:
+        if args.url:
+            print(f"Fetching website: {args.url}")
+            content = fetch_url_content(args.url)
+        else:
+            folder_path = pathlib.Path(args.folder)
+            if not folder_path.exists():
+                print(f"Error: folder path does not exist: {folder_path}", file=sys.stderr)
+                return 1
+            print(f"Reading local folder: {folder_path}")
+            content = extract_css_from_folder(folder_path)
+    except Exception as e:
+        print(f"Error reading source content: {e}", file=sys.stderr)
+        return 1
 
-    raw_tokens = extract_tokens(content)
+    raw_tokens, warnings = extract_tokens(content)
+    for warn in warnings:
+        print(warn, file=sys.stderr)
     print(f"Extracted Raw Tokens: {raw_tokens}")
 
-    roles = compute_derived_roles(raw_tokens)
+    roles, contrast_notes = compute_derived_roles(raw_tokens)
+    for note in contrast_notes:
+        print(f"[WCAG AA] {note}")
+
     table_output = update_style_guide(roles, style_guide_path, dry_run=args.dry_run)
 
     print("\n--- Proposed Tokens Table ---")

--- a/scripts/onboard.py
+++ b/scripts/onboard.py
@@ -1,23 +1,25 @@
 #!/usr/bin/env python3
 """Automated Brand Onboarding CLI Tool for diagram-design.
 
-Extracts brand colors from a website URL, local CSS folder, or design tokens,
-validates WCAG AA contrast compliance, computes light/dark semantic role mappings,
-and updates skills/diagram-design/references/style-guide.md.
+Extracts brand colors from website URLs, local folders, CSS/SCSS files, JSON design tokens, or Markdown docs,
+validates WCAG AA contrast compliance for light and dark modes, computes semantic role mappings,
+and safely updates skills/diagram-design/references/style-guide.md with atomic backups.
 
 Usage:
     python scripts/onboard.py --url https://example.com
     python scripts/onboard.py --folder ./my-design-tokens
-    python scripts/onboard.py --url https://example.com --dry-run
+    python scripts/onboard.py --url https://example.com --apply
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import pathlib
 import re
 import sys
+import tempfile
 import urllib.error
 import urllib.request
 from typing import NamedTuple
@@ -28,6 +30,7 @@ DEFAULT_STYLE_GUIDE = REPO / "skills" / "diagram-design" / "references" / "style
 
 HEX_RE = re.compile(r"#(?:[0-9a-fA-F]{3}){1,2}\b")
 VAR_RE = re.compile(r"--([\w-]+)\s*:\s*([^;]+);")
+SCSS_VAR_RE = re.compile(r"\$([\w-]+)\s*:\s*([^;]+);")
 
 
 class Color(NamedTuple):
@@ -65,37 +68,66 @@ def contrast_ratio(c1: Color, c2: Color) -> float:
 
 
 def ensure_contrast(foreground: Color, background: Color, min_ratio: float = 4.5) -> tuple[Color, str | None]:
-    """Adjust foreground color lightness to guarantee minimum WCAG contrast against background."""
+    """Adjust foreground color lightness to guarantee minimum WCAG contrast against background for light and medium backgrounds."""
     ratio = contrast_ratio(foreground, background)
     if ratio >= min_ratio:
         return foreground, None
 
     orig_hex = foreground.to_hex()
-    bg_lum = background.luminance()
-    make_darker = bg_lum > 0.5
-    factor = 0.9 if make_darker else 1.1
 
+    # Try both darkening and lightening candidates to choose the optimal direction for medium backgrounds
+    darker_c = foreground
+    r_dark = ratio
     curr_r, curr_g, curr_b = foreground.r, foreground.g, foreground.b
-    for _ in range(30):
-        if make_darker:
-            curr_r = max(0, int(curr_r * factor))
-            curr_g = max(0, int(curr_g * factor))
-            curr_b = max(0, int(curr_b * factor))
+    for _ in range(40):
+        curr_r = max(0, int(curr_r * 0.88))
+        curr_g = max(0, int(curr_g * 0.88))
+        curr_b = max(0, int(curr_b * 0.88))
+        cand = Color(curr_r, curr_g, curr_b)
+        r_cand = contrast_ratio(cand, background)
+        if r_cand >= min_ratio:
+            darker_c = cand
+            r_dark = r_cand
+            break
+
+    lighter_c = foreground
+    r_light = ratio
+    curr_r, curr_g, curr_b = foreground.r, foreground.g, foreground.b
+    for _ in range(40):
+        curr_r = min(255, max(1, int(curr_r * 1.12)))
+        curr_g = min(255, max(1, int(curr_g * 1.12)))
+        curr_b = min(255, max(1, int(curr_b * 1.12)))
+        cand = Color(curr_r, curr_g, curr_b)
+        r_cand = contrast_ratio(cand, background)
+        if r_cand >= min_ratio:
+            lighter_c = cand
+            r_light = r_cand
+            break
+
+    best_c = foreground
+    best_ratio = ratio
+    if r_dark >= min_ratio and r_light >= min_ratio:
+        best_c = darker_c if background.luminance() > 0.4 else lighter_c
+        best_ratio = max(r_dark, r_light)
+    elif r_dark >= min_ratio:
+        best_c = darker_c
+        best_ratio = r_dark
+    elif r_light >= min_ratio:
+        best_c = lighter_c
+        best_ratio = r_light
+    else:
+        # Pure black or white fallback
+        black_c = Color(0, 0, 0)
+        white_c = Color(255, 255, 255)
+        if contrast_ratio(black_c, background) >= contrast_ratio(white_c, background):
+            best_c = black_c
+            best_ratio = contrast_ratio(black_c, background)
         else:
-            curr_r = min(255, max(1, int(curr_r * factor)))
-            curr_g = min(255, max(1, int(curr_g * factor)))
-            curr_b = min(255, max(1, int(curr_b * factor)))
+            best_c = white_c
+            best_ratio = contrast_ratio(white_c, background)
 
-        adjusted = Color(curr_r, curr_g, curr_b)
-        new_ratio = contrast_ratio(adjusted, background)
-        if new_ratio >= min_ratio:
-            note = f"Adjusted {orig_hex} -> {adjusted.to_hex()} (WCAG AA contrast {new_ratio:.1f}:1 on {background.to_hex()})"
-            return adjusted, note
-
-    final_c = Color(0, 0, 0) if make_darker else Color(255, 255, 255)
-    final_ratio = contrast_ratio(final_c, background)
-    note = f"Adjusted {orig_hex} -> {final_c.to_hex()} (WCAG AA contrast {final_ratio:.1f}:1 on {background.to_hex()})"
-    return final_c, note
+    note = f"Adjusted {orig_hex} -> {best_c.to_hex()} (WCAG AA contrast {best_ratio:.1f}:1 on {background.to_hex()})"
+    return best_c, note
 
 
 def fetch_url_content(url: str, max_bytes: int = 5 * 1024 * 1024) -> str:
@@ -116,9 +148,9 @@ def fetch_url_content(url: str, max_bytes: int = 5 * 1024 * 1024) -> str:
 
 
 def extract_css_from_folder(folder_path: pathlib.Path) -> str:
-    """Read and concatenate CSS, JSON, and HTML files from a local folder."""
+    """Read and concatenate CSS, SCSS, JSON, and HTML files from a local folder."""
     chunks = []
-    exts = {".css", ".json", ".html", ".md"}
+    exts = {".css", ".scss", ".json", ".html", ".md"}
     for root, _, files in os.walk(folder_path):
         for file in files:
             p = pathlib.Path(root) / file
@@ -130,80 +162,131 @@ def extract_css_from_folder(folder_path: pathlib.Path) -> str:
     return "\n".join(chunks)
 
 
+def extract_json_tokens(text: str) -> dict[str, str]:
+    """Format-aware JSON design token parser for nested token objects."""
+    found: dict[str, str] = {}
+
+    def walk_json(obj: object, path: str = "") -> None:
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                new_path = f"{path}.{k}" if path else str(k)
+                if isinstance(v, str):
+                    m = HEX_RE.search(v)
+                    if m:
+                        found[new_path.lower()] = m.group(0).lower()
+                else:
+                    walk_json(v, new_path)
+        elif isinstance(obj, list):
+            for i, item in enumerate(obj):
+                walk_json(item, f"{path}[{i}]")
+
+    # Try parsing text blocks as JSON
+    for block in re.findall(r"\{[^{}]+\}", text):
+        try:
+            data = json.loads(block)
+            walk_json(data)
+        except Exception:
+            pass
+
+    return found
+
+
 def extract_tokens(text: str) -> tuple[dict[str, str], list[str]]:
-    """Extract colors and variables from text content."""
+    """Format-aware token parser for CSS, SCSS, JSON, and raw hexes with zero-confidence guard."""
     warnings: list[str] = []
     vars_found: dict[str, str] = {}
+
+    # 1. CSS Custom Properties (--variable: #hex;)
     for match in VAR_RE.finditer(text):
         name, val = match.group(1).lower(), match.group(2).strip()
         hex_match = HEX_RE.search(val)
         if hex_match:
             vars_found[name] = hex_match.group(0).lower()
 
+    # 2. SCSS Variables ($variable: #hex;)
+    for match in SCSS_VAR_RE.finditer(text):
+        name, val = match.group(1).lower(), match.group(2).strip()
+        hex_match = HEX_RE.search(val)
+        if hex_match:
+            vars_found[name] = hex_match.group(0).lower()
+
+    # 3. JSON Design Tokens
+    json_vars = extract_json_tokens(text)
+    vars_found.update(json_vars)
+
     hexes = [m.lower() for m in HEX_RE.findall(text)]
 
-    # Map semantic roles using name heuristics or frequency
-    paper_hex = "#f5f5f5"
-    ink_hex = "#2d3142"
-    accent_hex = "#eb6c36"
-    muted_hex = "#4f5d75"
+    # Zero-Confidence Guard: if no hexes or variables found, fail without modifying style guide
+    if not vars_found and not hexes:
+        raise ValueError("Zero-confidence extraction: no valid hex colors or design tokens found in source.")
+
+    paper_hex: str | None = None
+    ink_hex: str | None = None
+    accent_hex: str | None = None
+    muted_hex: str | None = None
 
     for name, val in vars_found.items():
-        if any(k in name for k in ("bg", "background", "paper", "surface")):
+        if not paper_hex and any(k in name for k in ("bg", "background", "paper", "surface")):
             paper_hex = val
-        elif any(k in name for k in ("text", "ink", "foreground", "body")):
+        elif not ink_hex and any(k in name for k in ("text", "ink", "foreground", "body")):
             ink_hex = val
-        elif any(k in name for k in ("accent", "brand", "primary", "cta")):
+        elif not accent_hex and any(k in name for k in ("accent", "brand", "primary", "cta")):
             accent_hex = val
-        elif any(k in name for k in ("muted", "secondary", "caption")):
+        elif not muted_hex and any(k in name for k in ("muted", "secondary", "caption")):
             muted_hex = val
 
-    # Fallback to frequency if custom properties were missing
-    if not vars_found and hexes:
-        warnings.append("Warning: No CSS custom properties found; falling back to hex frequency ranking.")
-        counts = {}
+    # Fallback to frequency ranking if variables were incomplete
+    if (not paper_hex or not ink_hex or not accent_hex) and hexes:
+        if vars_found:
+            warnings.append("Warning: Partially missing semantic CSS/JSON properties; using frequency ranking for unmapped roles.")
+        else:
+            warnings.append("Warning: No CSS/JSON custom properties found; falling back to hex frequency ranking.")
+
+        counts: dict[str, int] = {}
         for h in hexes:
             counts[h] = counts.get(h, 0) + 1
         sorted_colors = sorted(counts.items(), key=lambda x: x[1], reverse=True)
-        if sorted_colors:
+
+        if not paper_hex and sorted_colors:
             paper_hex = sorted_colors[0][0]
-        if len(sorted_colors) > 1:
+        if not ink_hex and len(sorted_colors) > 1:
             ink_hex = sorted_colors[1][0]
-        if len(sorted_colors) > 2:
+        if not accent_hex and len(sorted_colors) > 2:
             accent_hex = sorted_colors[2][0]
 
+    paper_final = paper_hex or "#f5f5f5"
+    ink_final = ink_hex or "#2d3142"
+    accent_final = accent_hex or "#eb6c36"
+    muted_final = muted_hex or "#4f5d75"
+
     tokens = {
-        "paper": paper_hex,
-        "ink": ink_hex,
-        "accent": accent_hex,
-        "muted": muted_hex,
+        "paper": paper_final,
+        "ink": ink_final,
+        "accent": accent_final,
+        "muted": muted_final,
     }
     return tokens, warnings
 
 
 def compute_derived_roles(tokens: dict[str, str]) -> tuple[dict[str, dict[str, str]], list[str]]:
-    """Compute light and dark variants for all 9 semantic roles with contrast enforcement."""
+    """Compute light and dark variants for all 9 semantic roles with double-ended WCAG contrast enforcement."""
     contrast_notes: list[str] = []
     paper_c = Color.from_hex(tokens["paper"])
     ink_c = Color.from_hex(tokens["ink"])
     accent_c = Color.from_hex(tokens["accent"])
     muted_c = Color.from_hex(tokens["muted"])
 
-    # Enforce WCAG AA contrast on ink and muted against paper
+    # Enforce WCAG AA contrast for Light Mode pairs
     ink_c, note_ink = ensure_contrast(ink_c, paper_c, 4.5)
     if note_ink:
-        contrast_notes.append(note_ink)
+        contrast_notes.append(f"[Light Mode] {note_ink}")
 
     muted_c, note_muted = ensure_contrast(muted_c, paper_c, 4.5)
     if note_muted:
-        contrast_notes.append(note_muted)
+        contrast_notes.append(f"[Light Mode] {note_muted}")
 
     # Derived light values
-    paper_2_c = Color(
-        max(0, paper_c.r - 9),
-        max(0, paper_c.g - 9),
-        max(0, paper_c.b - 9)
-    )
+    paper_2_c = Color(max(0, paper_c.r - 9), max(0, paper_c.g - 9), max(0, paper_c.b - 9))
     soft_c = Color(
         int(ink_c.r * 0.4 + muted_c.r * 0.6),
         int(ink_c.g * 0.4 + muted_c.g * 0.6),
@@ -214,45 +297,27 @@ def compute_derived_roles(tokens: dict[str, str]) -> tuple[dict[str, dict[str, s
     accent_tint_str = f"rgba({accent_c.r},{accent_c.g},{accent_c.b},0.08)"
     link_c = Color(46, 90, 168)
 
-    # Dark mode dynamic brand inversion
-    paper_dark = Color(
-        max(0, 255 - paper_c.r),
-        max(0, 255 - paper_c.g),
-        max(0, 255 - paper_c.b)
-    )
-    ink_dark = Color(
-        min(255, 255 - ink_c.r),
-        min(255, 255 - ink_c.g),
-        min(255, 255 - ink_c.b)
-    )
-    accent_dark = Color(
-        min(255, accent_c.r + 15),
-        min(255, accent_c.g + 18),
-        min(255, accent_c.b + 20)
-    )
-    paper_2_dark = Color(
-        min(255, paper_dark.r + 12),
-        min(255, paper_dark.g + 12),
-        min(255, paper_dark.b + 12)
-    )
-    muted_dark = Color(
-        min(255, 255 - muted_c.r),
-        min(255, 255 - muted_c.g),
-        min(255, 255 - muted_c.b)
-    )
-    soft_dark = Color(
-        min(255, 255 - soft_c.r),
-        min(255, 255 - soft_c.g),
-        min(255, 255 - soft_c.b)
-    )
+    # Dark mode dynamic brand inversion with independent numerical validation
+    paper_dark = Color(max(0, 255 - paper_c.r), max(0, 255 - paper_c.g), max(0, 255 - paper_c.b))
+    ink_dark_cand = Color(min(255, 255 - ink_c.r), min(255, 255 - ink_c.g), min(255, 255 - ink_c.b))
+    accent_dark = Color(min(255, accent_c.r + 15), min(255, accent_c.g + 18), min(255, accent_c.b + 20))
+    paper_2_dark = Color(min(255, paper_dark.r + 12), min(255, paper_dark.g + 12), min(255, paper_dark.b + 12))
+    muted_dark_cand = Color(min(255, 255 - muted_c.r), min(255, 255 - muted_c.g), min(255, 255 - muted_c.b))
+    soft_dark = Color(min(255, 255 - soft_c.r), min(255, 255 - soft_c.g), min(255, 255 - soft_c.b))
+
+    # Numerical WCAG AA validation on Dark Mode pairs
+    ink_dark, note_ink_dark = ensure_contrast(ink_dark_cand, paper_dark, 4.5)
+    if note_ink_dark:
+        contrast_notes.append(f"[Dark Mode] {note_ink_dark}")
+
+    muted_dark, note_muted_dark = ensure_contrast(muted_dark_cand, paper_dark, 4.5)
+    if note_muted_dark:
+        contrast_notes.append(f"[Dark Mode] {note_muted_dark}")
+
     rule_dark_str = f"rgba({ink_dark.r},{ink_dark.g},{ink_dark.b},0.12)"
     rule_solid_dark_str = f"rgba({ink_dark.r},{ink_dark.g},{ink_dark.b},0.25)"
     accent_tint_dark_str = f"rgba({accent_dark.r},{accent_dark.g},{accent_dark.b},0.10)"
-    link_dark = Color(
-        min(255, link_c.r + 60),
-        min(255, link_c.g + 60),
-        min(255, link_c.b + 60)
-    )
+    link_dark = Color(min(255, link_c.r + 60), min(255, link_c.g + 60), min(255, link_c.b + 60))
 
     roles = {
         "paper":       {"light": paper_c.to_hex(), "dark": paper_dark.to_hex()},
@@ -269,8 +334,8 @@ def compute_derived_roles(tokens: dict[str, str]) -> tuple[dict[str, dict[str, s
     return roles, contrast_notes
 
 
-def update_style_guide(roles: dict[str, dict[str, str]], style_guide_path: pathlib.Path, dry_run: bool = False) -> str:
-    """Generate Markdown tokens table and update style-guide.md."""
+def update_style_guide(roles: dict[str, dict[str, str]], style_guide_path: pathlib.Path, apply_changes: bool = False) -> str:
+    """Generate Markdown tokens table and perform atomic write with recoverable backup if apply_changes is True."""
     lines = [
         "| Role | Purpose | Default (light) | Default (dark) |",
         "|---|---|---|---|",
@@ -287,12 +352,36 @@ def update_style_guide(roles: dict[str, dict[str, str]], style_guide_path: pathl
     ]
     table_text = "\n".join(lines)
 
-    if not dry_run and style_guide_path.exists():
+    if apply_changes:
+        if not style_guide_path.parent.exists():
+            raise FileNotFoundError(f"Target directory does not exist: {style_guide_path.parent}")
+
+        if not style_guide_path.exists():
+            raise FileNotFoundError(f"Target style guide file does not exist: {style_guide_path}")
+
         content = style_guide_path.read_text(encoding="utf-8")
         table_pattern = re.compile(r"\| Role \| Purpose \| Default \(light\) \| Default \(dark\) \|.*?\n(?:\|.*?\|\n)+", re.DOTALL)
-        if table_pattern.search(content):
-            updated_content = table_pattern.sub(table_text + "\n", content, count=1)
-            style_guide_path.write_text(updated_content, encoding="utf-8")
+        if not table_pattern.search(content):
+            raise ValueError(f"Could not locate semantic roles table pattern in {style_guide_path}")
+
+        updated_content = table_pattern.sub(table_text + "\n", content, count=1)
+
+        # Atomic write using backup file (.bak) and temp file
+        backup_path = style_guide_path.with_name(style_guide_path.name + ".bak")
+        style_guide_path.replace(backup_path)
+
+        try:
+            temp_file = style_guide_path.with_name(style_guide_path.name + ".tmp")
+            temp_file.write_text(updated_content, encoding="utf-8")
+            temp_file.replace(style_guide_path)
+            # Remove temporary backup upon successful write
+            if backup_path.exists():
+                backup_path.unlink()
+        except Exception as e:
+            # Restore from backup in case of write failure
+            if backup_path.exists():
+                backup_path.replace(style_guide_path)
+            raise IOError(f"Atomic write to style guide failed: {e}") from e
 
     return table_text
 
@@ -301,8 +390,9 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Automated Brand Onboarding CLI Tool for diagram-design.")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--url", help="Website URL to extract brand tokens from")
-    group.add_argument("--folder", help="Local directory path containing CSS/JSON design tokens")
-    parser.add_argument("--dry-run", action="store_true", help="Preview proposed diff without writing to style-guide.md")
+    group.add_argument("--folder", help="Local directory path containing CSS/SCSS/JSON design tokens")
+    parser.add_argument("--apply", action="store_true", help="Explicitly write updated tokens table to style-guide.md (default is preview mode)")
+    parser.add_argument("--dry-run", action="store_true", help="Explicit preview mode (default behavior)")
     parser.add_argument("--out", help="Path to style-guide.md (default: skills/diagram-design/references/style-guide.md)")
 
     args = parser.parse_args()
@@ -320,11 +410,12 @@ def main() -> int:
                 return 1
             print(f"Reading local folder: {folder_path}")
             content = extract_css_from_folder(folder_path)
+
+        raw_tokens, warnings = extract_tokens(content)
     except Exception as e:
-        print(f"Error reading source content: {e}", file=sys.stderr)
+        print(f"Error: {e}", file=sys.stderr)
         return 1
 
-    raw_tokens, warnings = extract_tokens(content)
     for warn in warnings:
         print(warn, file=sys.stderr)
     print(f"Extracted Raw Tokens: {raw_tokens}")
@@ -333,15 +424,19 @@ def main() -> int:
     for note in contrast_notes:
         print(f"[WCAG AA] {note}")
 
-    table_output = update_style_guide(roles, style_guide_path, dry_run=args.dry_run)
+    try:
+        table_output = update_style_guide(roles, style_guide_path, apply_changes=args.apply)
+    except Exception as e:
+        print(f"Error updating style guide: {e}", file=sys.stderr)
+        return 1
 
     print("\n--- Proposed Tokens Table ---")
     print(table_output)
 
-    if args.dry_run:
-        print("\n[Dry-run mode] No changes were written to style-guide.md.")
+    if args.apply:
+        print(f"\n[Apply mode] Successfully updated {style_guide_path}")
     else:
-        print(f"\nSuccessfully updated {style_guide_path}")
+        print("\n[Preview mode] No changes were written to style-guide.md. Use --apply to commit changes.")
 
     return 0
 

--- a/scripts/verify-onboarding.py
+++ b/scripts/verify-onboarding.py
@@ -2,7 +2,7 @@
 """Verification script for the automated brand onboarding CLI tool (scripts/onboard.py).
 
 Verifies zero-confidence extraction guards, format-aware JSON/SCSS parsing, WCAG AA contrast enforcement
-for medium backgrounds and dark mode, atomic backup writes, and URL scheme rejection.
+for medium backgrounds and dark mode, crash-safe atomic write with retained backup, and URL scheme rejection.
 
 Usage:
     python scripts/verify-onboarding.py
@@ -85,7 +85,12 @@ $brand-primary: #0088ff;
         json_file.write_text("""
 {
   "color": {
-    "muted": "#888888"
+    "primary": {
+      "$value": "#ff5500"
+    },
+    "muted": {
+      "value": "#888888"
+    }
   }
 }
 """, encoding="utf-8")
@@ -97,8 +102,8 @@ $brand-primary: #0088ff;
             print(f"FAIL: format-aware SCSS/JSON parsing failed: {res.stderr}", file=sys.stderr)
             sys.exit(1)
 
-        if "`#101010`" not in res.stdout or "`#0088ff`" not in res.stdout:
-            print("FAIL: SCSS/JSON design tokens were not extracted correctly", file=sys.stderr)
+        if "`#101010`" not in res.stdout or "`#ff5500`" not in res.stdout:
+            print("FAIL: SCSS/JSON nested design tokens were not extracted correctly", file=sys.stderr)
             sys.exit(1)
 
         print("OK: onboard.py format-aware SCSS/JSON parsing test passed")
@@ -130,7 +135,7 @@ def test_medium_bg_contrast_and_dark_mode_validation() -> None:
         print("OK: onboard.py medium background & dark mode contrast validation test passed")
 
 
-def test_atomic_write_and_invalid_path() -> None:
+def test_atomic_write_and_retained_backup() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_path = pathlib.Path(tmpdir)
         css_file = tmp_path / "tokens.css"
@@ -143,9 +148,10 @@ def test_atomic_write_and_invalid_path() -> None:
 }
 """, encoding="utf-8")
         out_guide = tmp_path / "style-guide.md"
-        out_guide.write_text(STYLE_GUIDE.read_text(encoding="utf-8"), encoding="utf-8")
+        orig_content = STYLE_GUIDE.read_text(encoding="utf-8")
+        out_guide.write_text(orig_content, encoding="utf-8")
 
-        # 1. Test atomic write with --apply
+        # 1. Test atomic write with --apply and retained backup
         cmd = [sys.executable, str(ONBOARD_SCRIPT), "--folder", str(tmp_path), "--out", str(out_guide), "--apply"]
         res = subprocess.run(cmd, capture_output=True, text=True)
 
@@ -158,6 +164,15 @@ def test_atomic_write_and_invalid_path() -> None:
             print("FAIL: style-guide.md table was not updated atomically", file=sys.stderr)
             sys.exit(1)
 
+        backup_file = out_guide.with_name(out_guide.name + ".bak")
+        if not backup_file.exists():
+            print("FAIL: retained backup file (.bak) was not preserved", file=sys.stderr)
+            sys.exit(1)
+
+        if backup_file.read_text(encoding="utf-8") != orig_content:
+            print("FAIL: retained backup file content does not match original style guide", file=sys.stderr)
+            sys.exit(1)
+
         # 2. Test invalid --out path failure
         bad_out = tmp_path / "non-existent-dir" / "style-guide.md"
         cmd_bad = [sys.executable, str(ONBOARD_SCRIPT), "--folder", str(tmp_path), "--out", str(bad_out), "--apply"]
@@ -167,7 +182,7 @@ def test_atomic_write_and_invalid_path() -> None:
             print("FAIL: onboard.py did not fail on invalid --out directory path", file=sys.stderr)
             sys.exit(1)
 
-        print("OK: onboard.py atomic write & output path validation test passed")
+        print("OK: onboard.py crash-safe atomic write & retained backup test passed")
 
 
 def test_url_scheme_rejection() -> None:
@@ -187,7 +202,7 @@ def main() -> int:
     test_zero_confidence_extraction_guard()
     test_format_aware_json_scss_parsing()
     test_medium_bg_contrast_and_dark_mode_validation()
-    test_atomic_write_and_invalid_path()
+    test_atomic_write_and_retained_backup()
     test_url_scheme_rejection()
     print("ALL ADVERSARIAL ONBOARDING GATES PASSED")
     return 0

--- a/scripts/verify-onboarding.py
+++ b/scripts/verify-onboarding.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Verification script for the automated brand onboarding CLI tool (scripts/onboard.py).
+
+Verifies that onboard.py correctly parses CSS custom properties, calculates derived light/dark
+semantic roles, enforces WCAG AA contrast ratios, and formats the style-guide.md tokens table.
+
+Usage:
+    python scripts/verify-onboarding.py
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+ONBOARD_SCRIPT = REPO / "scripts" / "onboard.py"
+
+
+def test_onboard_folder_dry_run() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = pathlib.Path(tmpdir)
+        css_file = tmp_path / "tokens.css"
+        css_file.write_text("""
+:root {
+    --color-bg: #fafafa;
+    --color-text: #1a1a1a;
+    --color-brand: #ff4500;
+    --color-muted: #666666;
+}
+""", encoding="utf-8")
+
+        cmd = [sys.executable, str(ONBOARD_SCRIPT), "--folder", str(tmp_path), "--dry-run"]
+        res = subprocess.run(cmd, capture_output=True, text=True)
+
+        if res.returncode != 0:
+            print(f"FAIL: onboard.py exited with code {res.returncode}", file=sys.stderr)
+            print(res.stderr, file=sys.stderr)
+            sys.exit(1)
+
+        output = res.stdout
+        required_roles = ["paper", "paper-2", "ink", "muted", "soft", "rule", "rule-solid", "accent", "accent-tint", "link"]
+        for role in required_roles:
+            if f"`{role}`" not in output:
+                print(f"FAIL: role `{role}` missing from onboard.py output", file=sys.stderr)
+                sys.exit(1)
+
+        print("OK: onboard.py folder dry-run test passed")
+
+
+def main() -> int:
+    print("Running verification suite for onboard.py...")
+    test_onboard_folder_dry_run()
+    print("ALL ONBOARDING GATES PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify-onboarding.py
+++ b/scripts/verify-onboarding.py
@@ -2,7 +2,7 @@
 """Verification script for the automated brand onboarding CLI tool (scripts/onboard.py).
 
 Verifies that onboard.py correctly parses CSS custom properties, calculates derived light/dark
-semantic roles, enforces WCAG AA contrast ratios, and formats the style-guide.md tokens table.
+semantic roles, enforces WCAG AA contrast ratios, rejects invalid URL schemes, and updates style-guide.md.
 
 Usage:
     python scripts/verify-onboarding.py
@@ -17,6 +17,7 @@ import tempfile
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 ONBOARD_SCRIPT = REPO / "scripts" / "onboard.py"
+STYLE_GUIDE = REPO / "skills" / "diagram-design" / "references" / "style-guide.md"
 
 
 def test_onboard_folder_dry_run() -> None:
@@ -50,9 +51,75 @@ def test_onboard_folder_dry_run() -> None:
         print("OK: onboard.py folder dry-run test passed")
 
 
+def test_onboard_non_dry_run_table_update() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = pathlib.Path(tmpdir)
+        css_file = tmp_path / "tokens.css"
+        css_file.write_text("""
+:root {
+    --color-bg: #ffffff;
+    --color-text: #111111;
+    --color-brand: #0066cc;
+    --color-muted: #555555;
+}
+""", encoding="utf-8")
+        out_guide = tmp_path / "style-guide.md"
+        out_guide.write_text(STYLE_GUIDE.read_text(encoding="utf-8"), encoding="utf-8")
+
+        cmd = [sys.executable, str(ONBOARD_SCRIPT), "--folder", str(tmp_path), "--out", str(out_guide)]
+        res = subprocess.run(cmd, capture_output=True, text=True)
+
+        if res.returncode != 0:
+            print(f"FAIL: non-dry-run onboard.py failed with code {res.returncode}", file=sys.stderr)
+            sys.exit(1)
+
+        updated_text = out_guide.read_text(encoding="utf-8")
+        if "`#ffffff`" not in updated_text or "`#0066cc`" not in updated_text:
+            print("FAIL: style-guide.md table was not updated with extracted colors", file=sys.stderr)
+            sys.exit(1)
+
+        print("OK: onboard.py non-dry-run table replacement test passed")
+
+
+def test_contrast_adjustment() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = pathlib.Path(tmpdir)
+        css_file = tmp_path / "tokens.css"
+        # #e0e0e0 text on #fafafa paper fails WCAG AA (contrast ~1.2:1) and requires adjustment
+        css_file.write_text("""
+:root {
+    --color-bg: #fafafa;
+    --color-text: #e0e0e0;
+}
+""", encoding="utf-8")
+
+        cmd = [sys.executable, str(ONBOARD_SCRIPT), "--folder", str(tmp_path), "--dry-run"]
+        res = subprocess.run(cmd, capture_output=True, text=True)
+
+        if "[WCAG AA] Adjusted" not in res.stdout:
+            print("FAIL: contrast adjustment note missing for low-contrast text color", file=sys.stderr)
+            sys.exit(1)
+
+        print("OK: onboard.py WCAG AA contrast adjustment test passed")
+
+
+def test_url_scheme_rejection() -> None:
+    cmd = [sys.executable, str(ONBOARD_SCRIPT), "--url", "file:///etc/passwd", "--dry-run"]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+
+    if res.returncode == 0 or "only http and https are permitted" not in res.stderr:
+        print("FAIL: onboard.py did not reject non-http/https URL scheme", file=sys.stderr)
+        sys.exit(1)
+
+    print("OK: onboard.py URL scheme rejection test passed")
+
+
 def main() -> int:
     print("Running verification suite for onboard.py...")
     test_onboard_folder_dry_run()
+    test_onboard_non_dry_run_table_update()
+    test_contrast_adjustment()
+    test_url_scheme_rejection()
     print("ALL ONBOARDING GATES PASSED")
     return 0
 

--- a/scripts/verify-onboarding.py
+++ b/scripts/verify-onboarding.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Verification script for the automated brand onboarding CLI tool (scripts/onboard.py).
 
-Verifies that onboard.py correctly parses CSS custom properties, calculates derived light/dark
-semantic roles, enforces WCAG AA contrast ratios, rejects invalid URL schemes, and updates style-guide.md.
+Verifies zero-confidence extraction guards, format-aware JSON/SCSS parsing, WCAG AA contrast enforcement
+for medium backgrounds and dark mode, atomic backup writes, and URL scheme rejection.
 
 Usage:
     python scripts/verify-onboarding.py
@@ -20,7 +20,7 @@ ONBOARD_SCRIPT = REPO / "scripts" / "onboard.py"
 STYLE_GUIDE = REPO / "skills" / "diagram-design" / "references" / "style-guide.md"
 
 
-def test_onboard_folder_dry_run() -> None:
+def test_onboard_folder_preview() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_path = pathlib.Path(tmpdir)
         css_file = tmp_path / "tokens.css"
@@ -33,7 +33,7 @@ def test_onboard_folder_dry_run() -> None:
 }
 """, encoding="utf-8")
 
-        cmd = [sys.executable, str(ONBOARD_SCRIPT), "--folder", str(tmp_path), "--dry-run"]
+        cmd = [sys.executable, str(ONBOARD_SCRIPT), "--folder", str(tmp_path)]
         res = subprocess.run(cmd, capture_output=True, text=True)
 
         if res.returncode != 0:
@@ -42,16 +42,95 @@ def test_onboard_folder_dry_run() -> None:
             sys.exit(1)
 
         output = res.stdout
+        if "[Preview mode]" not in output:
+            print("FAIL: default mode must be preview mode", file=sys.stderr)
+            sys.exit(1)
+
         required_roles = ["paper", "paper-2", "ink", "muted", "soft", "rule", "rule-solid", "accent", "accent-tint", "link"]
         for role in required_roles:
             if f"`{role}`" not in output:
                 print(f"FAIL: role `{role}` missing from onboard.py output", file=sys.stderr)
                 sys.exit(1)
 
-        print("OK: onboard.py folder dry-run test passed")
+        print("OK: onboard.py folder preview mode test passed")
 
 
-def test_onboard_non_dry_run_table_update() -> None:
+def test_zero_confidence_extraction_guard() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = pathlib.Path(tmpdir)
+        empty_css = tmp_path / "empty.css"
+        empty_css.write_text("/* No hex colors or design tokens */ body { margin: 0; }", encoding="utf-8")
+
+        cmd = [sys.executable, str(ONBOARD_SCRIPT), "--folder", str(tmp_path), "--apply"]
+        res = subprocess.run(cmd, capture_output=True, text=True)
+
+        if res.returncode == 0 or "Zero-confidence extraction" not in res.stderr:
+            print("FAIL: zero-confidence extraction did not halt execution", file=sys.stderr)
+            sys.exit(1)
+
+        print("OK: onboard.py zero-confidence extraction guard test passed")
+
+
+def test_format_aware_json_scss_parsing() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = pathlib.Path(tmpdir)
+        scss_file = tmp_path / "vars.scss"
+        scss_file.write_text("""
+$brand-bg: #101010;
+$brand-text: #f0f0f0;
+$brand-primary: #0088ff;
+""", encoding="utf-8")
+
+        json_file = tmp_path / "tokens.json"
+        json_file.write_text("""
+{
+  "color": {
+    "muted": "#888888"
+  }
+}
+""", encoding="utf-8")
+
+        cmd = [sys.executable, str(ONBOARD_SCRIPT), "--folder", str(tmp_path)]
+        res = subprocess.run(cmd, capture_output=True, text=True)
+
+        if res.returncode != 0:
+            print(f"FAIL: format-aware SCSS/JSON parsing failed: {res.stderr}", file=sys.stderr)
+            sys.exit(1)
+
+        if "`#101010`" not in res.stdout or "`#0088ff`" not in res.stdout:
+            print("FAIL: SCSS/JSON design tokens were not extracted correctly", file=sys.stderr)
+            sys.exit(1)
+
+        print("OK: onboard.py format-aware SCSS/JSON parsing test passed")
+
+
+def test_medium_bg_contrast_and_dark_mode_validation() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = pathlib.Path(tmpdir)
+        css_file = tmp_path / "medium.css"
+        # Medium background #888888 requires intelligent direction contrast adjustment
+        css_file.write_text("""
+:root {
+    --color-bg: #888888;
+    --color-text: #777777;
+}
+""", encoding="utf-8")
+
+        cmd = [sys.executable, str(ONBOARD_SCRIPT), "--folder", str(tmp_path)]
+        res = subprocess.run(cmd, capture_output=True, text=True)
+
+        if res.returncode != 0:
+            print(f"FAIL: medium background contrast calculation failed: {res.stderr}", file=sys.stderr)
+            sys.exit(1)
+
+        if "[WCAG AA] [Light Mode] Adjusted" not in res.stdout:
+            print("FAIL: WCAG AA contrast adjustment missing for medium background", file=sys.stderr)
+            sys.exit(1)
+
+        print("OK: onboard.py medium background & dark mode contrast validation test passed")
+
+
+def test_atomic_write_and_invalid_path() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_path = pathlib.Path(tmpdir)
         css_file = tmp_path / "tokens.css"
@@ -66,45 +145,33 @@ def test_onboard_non_dry_run_table_update() -> None:
         out_guide = tmp_path / "style-guide.md"
         out_guide.write_text(STYLE_GUIDE.read_text(encoding="utf-8"), encoding="utf-8")
 
-        cmd = [sys.executable, str(ONBOARD_SCRIPT), "--folder", str(tmp_path), "--out", str(out_guide)]
+        # 1. Test atomic write with --apply
+        cmd = [sys.executable, str(ONBOARD_SCRIPT), "--folder", str(tmp_path), "--out", str(out_guide), "--apply"]
         res = subprocess.run(cmd, capture_output=True, text=True)
 
         if res.returncode != 0:
-            print(f"FAIL: non-dry-run onboard.py failed with code {res.returncode}", file=sys.stderr)
+            print(f"FAIL: atomic --apply write failed: {res.stderr}", file=sys.stderr)
             sys.exit(1)
 
         updated_text = out_guide.read_text(encoding="utf-8")
         if "`#ffffff`" not in updated_text or "`#0066cc`" not in updated_text:
-            print("FAIL: style-guide.md table was not updated with extracted colors", file=sys.stderr)
+            print("FAIL: style-guide.md table was not updated atomically", file=sys.stderr)
             sys.exit(1)
 
-        print("OK: onboard.py non-dry-run table replacement test passed")
+        # 2. Test invalid --out path failure
+        bad_out = tmp_path / "non-existent-dir" / "style-guide.md"
+        cmd_bad = [sys.executable, str(ONBOARD_SCRIPT), "--folder", str(tmp_path), "--out", str(bad_out), "--apply"]
+        res_bad = subprocess.run(cmd_bad, capture_output=True, text=True)
 
-
-def test_contrast_adjustment() -> None:
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = pathlib.Path(tmpdir)
-        css_file = tmp_path / "tokens.css"
-        # #e0e0e0 text on #fafafa paper fails WCAG AA (contrast ~1.2:1) and requires adjustment
-        css_file.write_text("""
-:root {
-    --color-bg: #fafafa;
-    --color-text: #e0e0e0;
-}
-""", encoding="utf-8")
-
-        cmd = [sys.executable, str(ONBOARD_SCRIPT), "--folder", str(tmp_path), "--dry-run"]
-        res = subprocess.run(cmd, capture_output=True, text=True)
-
-        if "[WCAG AA] Adjusted" not in res.stdout:
-            print("FAIL: contrast adjustment note missing for low-contrast text color", file=sys.stderr)
+        if res_bad.returncode == 0:
+            print("FAIL: onboard.py did not fail on invalid --out directory path", file=sys.stderr)
             sys.exit(1)
 
-        print("OK: onboard.py WCAG AA contrast adjustment test passed")
+        print("OK: onboard.py atomic write & output path validation test passed")
 
 
 def test_url_scheme_rejection() -> None:
-    cmd = [sys.executable, str(ONBOARD_SCRIPT), "--url", "file:///etc/passwd", "--dry-run"]
+    cmd = [sys.executable, str(ONBOARD_SCRIPT), "--url", "file:///etc/passwd"]
     res = subprocess.run(cmd, capture_output=True, text=True)
 
     if res.returncode == 0 or "only http and https are permitted" not in res.stderr:
@@ -115,12 +182,14 @@ def test_url_scheme_rejection() -> None:
 
 
 def main() -> int:
-    print("Running verification suite for onboard.py...")
-    test_onboard_folder_dry_run()
-    test_onboard_non_dry_run_table_update()
-    test_contrast_adjustment()
+    print("Running adversarial verification suite for onboard.py...")
+    test_onboard_folder_preview()
+    test_zero_confidence_extraction_guard()
+    test_format_aware_json_scss_parsing()
+    test_medium_bg_contrast_and_dark_mode_validation()
+    test_atomic_write_and_invalid_path()
     test_url_scheme_rejection()
-    print("ALL ONBOARDING GATES PASSED")
+    print("ALL ADVERSARIAL ONBOARDING GATES PASSED")
     return 0
 
 

--- a/skills/diagram-design/references/onboarding.md
+++ b/skills/diagram-design/references/onboarding.md
@@ -4,9 +4,9 @@
 
 Automated CLI tool:
 ```bash
-python scripts/onboard.py --url https://example.com
-python scripts/onboard.py --folder ./my-design-tokens
-python scripts/onboard.py --url https://example.com --dry-run
+python scripts/onboard.py --url https://example.com          # Preview mode (default)
+python scripts/onboard.py --url https://example.com --apply  # Atomic write mode with backup
+python scripts/onboard.py --folder ./my-design-tokens --apply
 ```
 
 Takes about 60 seconds.

--- a/skills/diagram-design/references/onboarding.md
+++ b/skills/diagram-design/references/onboarding.md
@@ -2,6 +2,13 @@
 
 **Goal:** point the skill at a design source — a website, an installed skill, or a local folder — and have it extract the palette + typography, then rewrite `style-guide.md` so every future diagram inherits that skin.
 
+Automated CLI tool:
+```bash
+python scripts/onboard.py --url https://example.com
+python scripts/onboard.py --folder ./my-design-tokens
+python scripts/onboard.py --url https://example.com --dry-run
+```
+
 Takes about 60 seconds.
 
 Three source methods are supported. Jump to the relevant section:


### PR DESCRIPTION
Hi and Namaste @cathrynlavery 👋

Adds an automated CLI tool `scripts/onboard.py` implementing the brand extraction, WCAG AA contrast check, and `style-guide.md` token update specification detailed in `references/onboarding.md`.

### Summary & Motivation
While `references/onboarding.md` describes the 60-second URL/Folder onboarding procedure, having a dedicated CLI script allows developers, agents, and CI workflows to programmatically extract brand design tokens and update `style-guide.md`.

### What's Included
- `scripts/onboard.py`: CLI tool supporting `--url`, `--folder`, `--dry-run`, and `--out` options.
- Extracts CSS custom properties (`--bg`, `--text`, `--accent`, `--muted`) and hex colors from websites or local CSS folders.
- Maps extracted palette to all 9 semantic diagram roles (`paper`, `paper-2`, `ink`, `muted`, `soft`, `rule`, `rule-solid`, `accent`, `accent-tint`, `link`).
- Enforces WCAG AA contrast ratio compliance (>= 4.5:1 for `ink` and `muted` against `paper`).
- Calculates dark mode inversion variants automatically.
- `scripts/verify-onboarding.py`: Verification test suite for the onboarding tool.
- Updated `.github/workflows/ci.yml` and `references/onboarding.md` documenting CLI usage.

### Verification
- Executed `python scripts/verify-onboarding.py` -> All onboarding gates pass.
- Executed `python scripts/lint-skin.py --all --baseline` -> All linter gates green.