### PR TITLE
feat(scripts): add robust Playwright rendered diagram layout validator scripts/lint-render.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
       - name: Verify Mermaid import script
         run: python3 scripts/verify-mermaid-import.py
 
+      - name: Verify render layout validator self-test
+        run: python3 scripts/lint-render.py --self-test
       - name: Verify generated icon assets
         run: |
           python3 scripts/build-icons.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,10 @@ jobs:
         run: python3 scripts/verify-mermaid-import.py
 
       - name: Verify render layout validator self-test
-        run: python3 scripts/lint-render.py --self-test
+        run: |
+          python3 -m pip install playwright
+          python3 -m playwright install --with-deps chromium
+          python3 scripts/lint-render.py --self-test
       - name: Verify generated icon assets
         run: |
           python3 scripts/build-icons.py

--- a/README.md
+++ b/README.md
@@ -361,6 +361,8 @@ If you touch the Mermaid import path, `python3 scripts/verify-mermaid-import.py`
 it covers all supported grammars, multi-block Markdown, adversarial labels, trust-boundary
 behavior, resource caps, named failures, and reference/command wiring.
 
+To validate laid-out diagram geometry (clipped shapes, zero-height SVGs, page overflow), run `python3 scripts/lint-render.py --all` or `python3 scripts/lint-render.py --self-test`.
+
 All pull requests and pushes are automatically validated via GitHub Actions CI (`.github/workflows/ci.yml`).
 
 ### What loads when

--- a/scripts/fixtures/sample-broken-layout.html
+++ b/scripts/fixtures/sample-broken-layout.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Sample Broken Layout Fixture for Self-Test</title>
+    <style>
+        body { margin: 0; padding: 0; }
+        .overflow-box { width: 3000px; height: 10px; background: red; }
+    </style>
+</head>
+<body>
+    <!-- Category: page-overflow -->
+    <div class="overflow-box"></div>
+
+    <!-- Category: svg-collapsed -->
+    <svg id="collapsed-svg" width="0" height="0"></svg>
+
+    <!-- Category: clipped -->
+    <svg id="clipped-svg" width="400" height="300" viewBox="0 0 400 300">
+        <circle cx="950" cy="150" r="50" fill="red" />
+    </svg>
+</body>
+</html>

--- a/scripts/lint-render.py
+++ b/scripts/lint-render.py
@@ -111,14 +111,36 @@ JS_MEASURE_LAYOUT = """
 def lint_file(page: Any, html_path: pathlib.Path) -> list[dict[str, str]]:
     """Render a single HTML file in Playwright and measure layout invariants."""
     findings: list[dict[str, str]] = []
+    console_errors: list[str] = []
+
+    def on_console(msg: Any) -> None:
+        if msg.type == "error":
+            text = msg.text
+            # Filter remote Google WebFont network timeouts when running offline/proxied
+            if any(domain in text for domain in ("fonts.googleapis.com", "fonts.gstatic.com")):
+                return
+            console_errors.append(text)
+
+    page.on("console", on_console)
     file_url = html_path.as_uri()
 
     try:
         page.goto(file_url, wait_until="load", timeout=10000)
+
+        # Wait for webfonts to finish loading (resolving TypeError in evaluate calls)
+        try:
+            page.wait_for_function("document.fonts.status === 'loaded'", timeout=3000)
+        except Exception:
+            pass
+
         res = page.evaluate(JS_MEASURE_LAYOUT)
         if isinstance(res, list):
             for item in res:
                 findings.append({"file": str(html_path), "category": item["category"], "message": item["message"]})
+
+        for err in console_errors:
+            findings.append({"file": str(html_path), "category": "console-error", "message": err})
+
     except Exception as e:
         findings.append({"file": str(html_path), "category": "page-error", "message": str(e)})
 

--- a/scripts/lint-render.py
+++ b/scripts/lint-render.py
@@ -108,7 +108,7 @@ JS_MEASURE_LAYOUT = """
 """
 
 
-def lint_file(page: Any, html_path: pathlib.Path) -> list[dict[str, str]]:
+def lint_file(page: Any, html_path: pathlib.Path, screenshot_dir: pathlib.Path | None = None) -> list[dict[str, str]]:
     """Render a single HTML file in Playwright and measure layout invariants."""
     findings: list[dict[str, str]] = []
     console_errors: list[str] = []
@@ -141,6 +141,10 @@ def lint_file(page: Any, html_path: pathlib.Path) -> list[dict[str, str]]:
         for err in console_errors:
             findings.append({"file": str(html_path), "category": "console-error", "message": err})
 
+        if findings and screenshot_dir:
+            screenshot_dir.mkdir(parents=True, exist_ok=True)
+            page.screenshot(path=str(screenshot_dir / f"{html_path.stem}-failure.png"))
+
     except Exception as e:
         findings.append({"file": str(html_path), "category": "page-error", "message": str(e)})
 
@@ -152,10 +156,12 @@ def main() -> int:
     parser.add_argument("file", nargs="?", help="Path to specific HTML diagram file to lint")
     parser.add_argument("--all", action="store_true", help="Lint all HTML files in skills/diagram-design/assets/")
     parser.add_argument("--self-test", action="store_true", help="Run self-test suite against broken diagram fixture")
+    parser.add_argument("--screenshot-dir", help="Directory path to save Playwright layout failure screenshots")
     parser.add_argument("--quiet", action="store_true", help="Suppress progress output")
 
     args = parser.parse_args()
     sync_playwright = check_playwright()
+    screenshot_dir = pathlib.Path(args.screenshot_dir) if args.screenshot_dir else None
 
     if getattr(args, "self_test", False):
         fixture_path = FIXTURES_DIR / "sample-broken-layout.html"
@@ -167,7 +173,7 @@ def main() -> int:
             browser = p.chromium.launch(headless=True)
             context = browser.new_context(viewport={"width": 1600, "height": 1200})
             page = context.new_page()
-            findings = lint_file(page, fixture_path)
+            findings = lint_file(page, fixture_path, screenshot_dir=screenshot_dir)
             browser.close()
 
         categories_found = {f["category"] for f in findings}
@@ -199,7 +205,7 @@ def main() -> int:
         page = context.new_page()
 
         for html_file in files_to_lint:
-            findings = lint_file(page, html_file)
+            findings = lint_file(page, html_file, screenshot_dir=screenshot_dir)
             all_findings.extend(findings)
 
         browser.close()

--- a/scripts/lint-render.py
+++ b/scripts/lint-render.py
@@ -151,10 +151,34 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Rendered diagram layout validator.")
     parser.add_argument("file", nargs="?", help="Path to specific HTML diagram file to lint")
     parser.add_argument("--all", action="store_true", help="Lint all HTML files in skills/diagram-design/assets/")
+    parser.add_argument("--self-test", action="store_true", help="Run self-test suite against broken diagram fixture")
     parser.add_argument("--quiet", action="store_true", help="Suppress progress output")
 
     args = parser.parse_args()
     sync_playwright = check_playwright()
+
+    if getattr(args, "self_test", False):
+        fixture_path = FIXTURES_DIR / "sample-broken-layout.html"
+        if not fixture_path.exists():
+            print(f"FAIL: self-test fixture missing at {fixture_path}", file=sys.stderr)
+            return 1
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            context = browser.new_context(viewport={"width": 1600, "height": 1200})
+            page = context.new_page()
+            findings = lint_file(page, fixture_path)
+            browser.close()
+
+        categories_found = {f["category"] for f in findings}
+        required_categories = {"clipped", "svg-collapsed", "page-overflow"}
+        missing = required_categories - categories_found
+        if missing:
+            print(f"FAIL: self-test failed to detect categories: {missing}", file=sys.stderr)
+            return 1
+
+        print("OK: self-test passed — all broken layout categories correctly detected.")
+        return 0
 
     files_to_lint: list[pathlib.Path] = []
     if args.file:

--- a/scripts/lint-render.py
+++ b/scripts/lint-render.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Rendered diagram layout validator for diagram-design.
+
+Renders HTML diagrams in headless Chromium via Playwright and measures laid-out geometries to catch:
+  - clipped: elements escaping their <svg> viewport boundaries
+  - svg-collapsed: <svg> elements rendering with zero width or height
+  - page-overflow: horizontal document scrolling at export width (1600px)
+  - page-error / console-error: JavaScript runtime exceptions or asset errors
+
+Usage:
+    python scripts/lint-render.py --all
+    python scripts/lint-render.py skills/diagram-design/assets/example-venn.html
+    python scripts/lint-render.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import sys
+from typing import Any
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+ASSETS_DIR = REPO / "skills" / "diagram-design" / "assets"
+FIXTURES_DIR = REPO / "scripts" / "fixtures"
+
+
+def check_playwright() -> Any:
+    """Check if Playwright is installed; exit 2 with install guide if missing."""
+    try:
+        from playwright.sync_api import sync_playwright
+        return sync_playwright
+    except ImportError:
+        print(
+            "Playwright missing. Install required dependencies:\n"
+            "  pip install playwright && playwright install chromium",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
+# JS snippet evaluated in browser to measure rendered geometries & check overflow
+JS_MEASURE_LAYOUT = """
+() => {
+    const findings = [];
+    const SKIP_TAGS = new Set(['defs', 'clippath', 'mask', 'marker', 'pattern', 'symbol', 'style', 'script']);
+
+    function isInsideSkipContainer(el) {
+        let parent = el.parentElement;
+        while (parent && parent.nodeName) {
+            if (SKIP_TAGS.has(parent.nodeName.toLowerCase())) return true;
+            parent = parent.parentElement;
+        }
+        return false;
+    }
+
+    // 1. Check for horizontal page overflow at 1600px
+    if (document.documentElement.scrollWidth > 1600 + 4) {
+        findings.push({
+            category: 'page-overflow',
+            message: `document scrolls horizontally at 1600px: scrollWidth = ${document.documentElement.scrollWidth}px`
+        });
+    }
+
+    // 2. Check each <svg> container
+    const svgs = Array.from(document.querySelectorAll('svg'));
+    svgs.forEach((svg, idx) => {
+        const svgRect = svg.getBoundingClientRect();
+        if (svgRect.width <= 0 || svgRect.height <= 0) {
+            findings.push({
+                category: 'svg-collapsed',
+                message: `<svg #${svg.id || idx}> rendered with zero dimensions: ${svgRect.width}x${svgRect.height}`
+            });
+            return;
+        }
+
+        // Check painted child elements for viewport escape
+        const elements = Array.from(svg.querySelectorAll('*'));
+        elements.forEach(el => {
+            const tag = el.nodeName.toLowerCase();
+            if (SKIP_TAGS.has(tag) || isInsideSkipContainer(el)) return;
+
+            const style = window.getComputedStyle(el);
+            if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') return;
+
+            const rect = el.getBoundingClientRect();
+            if (rect.width <= 0 && rect.height <= 0) return;
+
+            const rightEscape = rect.right - svgRect.right;
+            const bottomEscape = rect.bottom - svgRect.bottom;
+            const leftEscape = svgRect.left - rect.left;
+            const topEscape = svgRect.top - rect.top;
+
+            const maxEscape = Math.max(rightEscape, bottomEscape, leftEscape, topEscape);
+            if (maxEscape > 2.0) {
+                findings.push({
+                    category: 'clipped',
+                    message: `<${tag}> escapes svg viewport boundary by ${maxEscape.toFixed(1)}px`
+                });
+            }
+        });
+    });
+
+    return findings;
+}
+"""
+
+
+def lint_file(page: Any, html_path: pathlib.Path) -> list[dict[str, str]]:
+    """Render a single HTML file in Playwright and measure layout invariants."""
+    findings: list[dict[str, str]] = []
+    file_url = html_path.as_uri()
+
+    try:
+        page.goto(file_url, wait_until="load", timeout=10000)
+        res = page.evaluate(JS_MEASURE_LAYOUT)
+        if isinstance(res, list):
+            for item in res:
+                findings.append({"file": str(html_path), "category": item["category"], "message": item["message"]})
+    except Exception as e:
+        findings.append({"file": str(html_path), "category": "page-error", "message": str(e)})
+
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Rendered diagram layout validator.")
+    parser.add_argument("file", nargs="?", help="Path to specific HTML diagram file to lint")
+    parser.add_argument("--all", action="store_true", help="Lint all HTML files in skills/diagram-design/assets/")
+    parser.add_argument("--quiet", action="store_true", help="Suppress progress output")
+
+    args = parser.parse_args()
+    sync_playwright = check_playwright()
+
+    files_to_lint: list[pathlib.Path] = []
+    if args.file:
+        p = pathlib.Path(args.file)
+        if p.exists():
+            files_to_lint.append(p)
+    elif args.all:
+        files_to_lint = list(ASSETS_DIR.glob("*.html"))
+
+    if not files_to_lint:
+        parser.print_help()
+        return 0
+
+    all_findings: list[dict[str, str]] = []
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(viewport={"width": 1600, "height": 1200})
+        page = context.new_page()
+
+        for html_file in files_to_lint:
+            findings = lint_file(page, html_file)
+            all_findings.extend(findings)
+
+        browser.close()
+
+    if all_findings:
+        for f in all_findings:
+            print(f"{f['category']}: {f['file']}: {f['message']}")
+        return 1
+
+    if not args.quiet:
+        print(f"OK: {len(files_to_lint)} file(s) rendered, 0 finding(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Hi and Namaste Cathryn Lavery 👋

Adds `scripts/lint-render.py` — a Playwright-based rendered diagram layout validator that measures laid-out SVG geometry in headless Chromium to detect clipped nodes, zero-dimension SVG collapse, and horizontal page overflow.

### 🙏 Credit & Acknowledgment
Full credit to @Yuvraj3905 (PR #18) for introducing the original concept of rendered-level diagram layout validation using Playwright. This implementation builds upon that vision and addresses all findings raised in the maintainer review of PR #18.

### 🛠️ Key Improvements & Fixes
1. **Painted Bounds & Element Filtering**: Filters out SVG definition containers (`defs`, `clipPath`, `mask`, `marker`, `symbol`, `pattern`) and ancestor-hidden elements, resolving false positives on valid clipPaths while accurately detecting true viewport overflow.
2. **Proper Font Readiness**: Replaces invalid `page.evaluate()` timeout args with standard `page.wait_for_function("document.fonts.status === 'loaded'", timeout=3000)`, preventing `TypeError` exceptions.
3. **Console & Resource Error Filtering**: Catches JavaScript console runtime exceptions and missing local assets while gracefully filtering remote Google WebFont network timeouts.
4. **Self-Test Suite & Fixture**: Includes `--self-test` mode with `scripts/fixtures/sample-broken-layout.html` asserting that `clipped`, `svg-collapsed`, and `page-overflow` categories are correctly detected.
5. **CI Workflow Integration**: Wires `python3 scripts/lint-render.py --self-test` into `.github/workflows/ci.yml`.

### 🧪 Verification
- `python scripts/lint-render.py --help` -> Exit 0.
- `python3 scripts/lint-render.py --self-test` -> Exit 0 (all broken layout categories verified).
- All linter gates pass green cleanly.