### PR TITLE
fix: repair mojibake arrow directions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Verify accessible SVG contract
         run: python3 scripts/test-lint-a11y.py
 
+      - name: Verify mojibake repair utility
+        run: python3 scripts/test-fix-mojibake.py
+
       - name: Run skin linter
         run: python3 scripts/lint-skin.py --all --baseline
 

--- a/scripts/fix-mojibake.py
+++ b/scripts/fix-mojibake.py
@@ -17,8 +17,10 @@ PAIRS = [
     ('â€¦', '…'),  # horizontal ellipsis
     ('â€¢', '•'),  # bullet
     ('â†’', '→'),  # right arrow
-    ('â†‘', '←'),  # left arrow
-    ('â†‘', '↑'),  # up arrow (same prefix collision - rare)
+    # CP1252 leaves byte 0x90 undefined, so spell the left-arrow corruption
+    # with a Unicode escape instead of embedding an invisible control character.
+    ('\u00e2\u2020\u0090', '←'),  # left arrow
+    ('â†‘', '↑'),  # up arrow
     ('â†“', '↓'),  # down arrow
     ('â‰¤', '≤'),  # less-than-or-equal
     ('â‰¥', '≥'),  # greater-than-or-equal

--- a/scripts/test-fix-mojibake.py
+++ b/scripts/test-fix-mojibake.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Regression tests for the mojibake repair utility."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "fix-mojibake.py"
+
+
+def main() -> int:
+    # These are the strings produced when UTF-8 arrow bytes are decoded as
+    # Windows-1252. Byte 0x90 is undefined in CP1252, hence the explicit escape.
+    source = "right â†’, left \u00e2\u2020\u0090, up â†‘, down â†“\n"
+    expected = "right →, left ←, up ↑, down ↓\n"
+    with tempfile.TemporaryDirectory(prefix="diagram-design-mojibake-") as directory:
+        path = Path(directory) / "fixture.md"
+        path.write_text(source, encoding="utf-8")
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), str(path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise AssertionError(f"repair failed: {result.stdout}{result.stderr}")
+        actual = path.read_text(encoding="utf-8")
+        if actual != expected:
+            raise AssertionError(f"expected {expected!r}, got {actual!r}")
+    print("PASS: mojibake arrow sequences repair to the intended directions")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

`scripts/fix-mojibake.py` had the same corrupted up-arrow key twice. The first entry rewrote up arrows to left arrows, and the actual left-arrow corruption sequence was absent, so both directions were repaired incorrectly.

This change uses the correct CP1252 undefined-byte sequence for left arrows, keeps the up-arrow mapping distinct, and adds a focused regression test to CI.

## Verification

- `python3 scripts/test-fix-mojibake.py`
- `python3 -m py_compile scripts/fix-mojibake.py scripts/test-fix-mojibake.py`
- `git diff --check`
- Repository preflight, secret, burst, and title gates pass.

The repository CI continues to run the full Python 3.11 validation matrix.