### PR TITLE
ci: deploy live gallery to GitHub Pages and fix README link

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,41 @@
+name: Deploy gallery to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload gallery artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: skills/diagram-design/assets
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ All 27 diagrams ship in three variants: minimal light, minimal dark, and full-ed
 </tr>
 </table>
 
-**Browse the live gallery:** open [`skills/diagram-design/assets/index.html`](skills/diagram-design/assets/index.html) in your browser to flip through all 27 diagrams with light / dark / full-editorial tabs.
+**Browse the live gallery:** [cathrynlavery.github.io/diagram-design](https://cathrynlavery.github.io/diagram-design/) — or open [`skills/diagram-design/assets/index.html`](skills/diagram-design/assets/index.html) locally to flip through all 27 diagrams with light / dark / full-editorial tabs.
 
 ---
 


### PR DESCRIPTION
## What & why

The README's headline **"Browse the live gallery"** link points at `skills/diagram-design/assets/index.html` on GitHub, which renders as **raw HTML source code**, not the gallery — broken UX for every visitor.

This PR (closes #33):
1. Adds `.github/workflows/pages.yml` — a standard GitHub Pages deployment that publishes `skills/diagram-design/assets/` as a static site on push to `main` (and via `workflow_dispatch`).
2. Updates the README link to the hosted gallery, keeping the local-file instructions for cloned checkouts.

## Verified end-to-end on a fork

- Workflow: `build` + `deploy` jobs pass on the fork (deploy in ~11s, no warnings after pinning `checkout@v6`).
- Live site: https://the-ahuja-lab.github.io/diagram-design/ serves the gallery (`<title>Diagram Design · Gallery</title>`), plus `example-*.html` and `icons.html` (all 200).
- Existing CI (`.github/workflows/ci.yml`) still passes on the same commit.

## One-time setup for the maintainer

After merging, enable Pages on this repo: **Settings → Pages → Source → "GitHub Actions"** (no branch needed). The next `main` push (or a manual `workflow_dispatch`) will deploy the gallery to https://cathrynlavery.github.io/diagram-design/ — the URL the README now links to.
