### PR TITLE
Fix invalid XML in exported standalone SVG (escape & in @import)

### DIFF
--- a/skills/diagram-design/references/export.md
+++ b/skills/diagram-design/references/export.md
@@ -32,10 +32,10 @@ If the user explicitly asks for "a screenshot of the whole page including the ca
    - Ensure the opening tag has `xmlns="http://www.w3.org/2000/svg"`. Add it if missing.
    - Ensure a `viewBox` is present. The skill's templates always include one; warn the user if absent rather than guessing.
    - Preserve `role="img"`, `aria-labelledby`, and the first-child `<title>` / `<desc>` exactly as authored.
-   - Inject Google Fonts `@import` so the SVG renders with correct typography in a browser:
+   - Inject Google Fonts `@import` so the SVG renders with correct typography in a browser. **XML-escape the `&` separators as `&amp;`** — a standalone `.svg` is parsed as strict XML, where a bare `&` starts an entity reference and makes the whole file fail to parse. (Don't copy the raw URL from the HTML `<link href>`; that ampersand form is only valid in HTML.)
      ```svg
      <defs>
-       <style>@import url('https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap');</style>
+       <style>@import url('https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&amp;family=Geist:wght@400;500;600&amp;family=Geist+Mono:wght@400;500;600&amp;display=swap');</style>
      </defs>
      ```
      If the SVG already contains a `<defs>` block, **merge** the `<style>` into it (don't add a second `<defs>`).


### PR DESCRIPTION
Fixes #37.

## Problem

`skills/diagram-design/references/export.md` (SVG export procedure, step 3) injects a Google Fonts `@import` whose URL uses raw `&` separators. That is valid inside HTML, but a standalone `.svg` is parsed as **strict XML**, where a bare `&` starts an entity reference. The exported file therefore fails to parse — browsers/Chromium render an XML error page instead of the diagram:

```
error on line 7 at column 100: EntityRef: expecting ';'
```

Second-order effect: rasterizing several broken SVGs to PNG yields the *same* error-page image for each, so different diagrams can produce byte-for-byte identical PNGs — which hides the failure.

## Fix

Escape the three separators as `&amp;`, which is valid both in standalone SVG (XML) and when the same markup is embedded in HTML. Also added a one-line note in the procedure warning not to copy the raw ampersand form from the HTML `<link href>`.

Doc-only change; no scripts affected. The HTML templates' `<link href="...&...">` is left as-is (valid HTML attribute).

## Verification

Re-exported two diagrams after the fix; both `.svg` files parse cleanly and rasterize to correct, distinct PNGs at the expected `viewBox × scale` dimensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
