### PR TITLE
feat: shared SVG extraction tooling for Figma export (branch-independent slice)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,10 @@ jobs:
         id: mermaid
         run: python scripts/verify-mermaid-import.py
 
+      - name: Verify Figma export tooling
+        id: figma
+        run: python scripts/verify-figma-export.py
+
       - name: Verify generated icon assets
         id: icons
         shell: bash
@@ -95,4 +99,5 @@ jobs:
           echo "| Sequence Diagram Grammar | ${{ steps.oauth.outcome == 'success' && '✅ Passed' || (steps.oauth.outcome == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Draw.io Import Extractor | ${{ steps.drawio.outcome == 'success' && '✅ Passed' || (steps.drawio.outcome == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Mermaid Import Extractor | ${{ steps.mermaid.outcome == 'success' && '✅ Passed' || (steps.mermaid.outcome == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Figma Export Tooling | ${{ steps.figma.outcome == 'success' && '✅ Passed' || (steps.figma.outcome == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Primitive Icons & Documentation | ${{ steps.icons.outcome == 'success' && '✅ Passed' || (steps.icons.outcome == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY

--- a/docs/plan-figma-export.md
+++ b/docs/plan-figma-export.md
@@ -1,0 +1,271 @@
+# Plan: Send a diagram to Figma (Code to Canvas)
+**Status:** draft for review · **Target version:** 2.3.0 · **Date:** 2026-08-12
+
+Add a first-class "send this diagram to Figma" path to the diagram-design plugin:
+
+- "Send this diagram to Figma." / "Send this diagram to `<Figma file URL>`."
+  
+- `/diagram-design:figma path/to/diagram.html`
+  
+- Targets: new Figma draft (default), existing Figma Design file, clipboard.
+  
+- SVG export fallback (existing `references/export.md`) whenever Figma MCP is unavailable, unauthenticated, or under-permissioned.
+  
+
+* * *
+## 1. What the research changed
+I researched Figma's official MCP docs, the launch/help-center material, and hands-on engineering reports. Four findings materially change the original sketch:
+### 1.1 Code to Canvas is a live-page DOM capture, not an HTML upload
+`generate_figma_design` (the Code to Canvas tool, confirmed current name) does **not** accept HTML as a parameter. The documented mechanics:
+
+1. The agent calls `generate_figma_design` on the **remote** Figma MCP server (`https://mcp.figma.com/mcp` — the tool does not exist on the desktop MCP server) and receives a capture ID.
+  
+2. A **real browser** must load the page from a **running local HTTP server** (`file://` URLs are not supported), with Figma-supplied hash params (`#figmacapture=<id>&figmaendpoint=<url>`).
+  
+3. A capture script runs in the page, serializes the rendered DOM, and POSTs it to Figma; the agent polls until the layers land.
+  
+
+Consequences for us:
+
+- We must **serve** the capture page over `127.0.0.1`, not just write a temp file.
+  
+- The flow is **browser-in-the-loop** — there is no headless path. The agent opens the capture URL in the user's browser (`open <url>` on macOS) as part of the flow.
+  
+- **Capture is viewport-only.** Off-screen content is silently dropped. Our capture page must size the viewport/body exactly to the diagram's `viewBox` so nothing scrolls out of frame. (This is documented as a real failure mode: mid-scroll sections of a page simply vanish.)
+  
+### 1.2 Inline-SVG fidelity is undocumented — this needs a spike before we build
+No source states how Code to Canvas handles inline SVG paths, markers, dash arrays, opacity stops, `<title>`/`<desc>`, or web fonts. Known adjacent signals are worrying:
+
+- CSS effects with no Figma-primitive equivalent degrade (confirmed: `background-clip: text` gradients flatten to plain colored text).
+  
+- A confirmed SVG bounding-box bug exists in the adjacent `get_design_context` tool.
+  
+- For the separate Write to Canvas tool, custom fonts are explicitly unsupported; for Code to Canvas, fonts are undocumented either way.
+  
+
+Meanwhile our deliverable is _pure inline SVG_ — and Figma's plain **SVG paste** has been a high-fidelity vector import path for years. It is genuinely possible that our existing SVG export pasted into Figma beats Code to Canvas on fidelity for this content, with Code to Canvas winning only on ergonomics (agent-drivable, returns a link, auto variable binding).
+
+**So Phase 0 is a decision gate, not a formality** (§3).
+### 1.3 Permissions and targets (confirmed)
+| Target | Requirement |
+| --- | --- |
+| New file in **drafts** | Any seat |
+| **Existing file outside drafts** | Full seat **and** edit permission |
+| **Clipboard** | Any seat |
+
+`generate_figma_design` is exempt from the MCP read-tool rate limits (the ~6-calls/month Starter-seat cap applies to `get_design_context` etc., not to this tool). Auth is OAuth only — no PAT support.
+### 1.4 Setup differs per agent
+- **Claude Code:** `claude mcp add --transport http figma https://mcp.figma.com/mcp` (or the official plugin), restart, OAuth in browser.
+  
+- **Codex CLI:** `codex mcp add figma --url https://mcp.figma.com/mcp`; older builds need a `~/.codex/config.toml` entry plus the `rmcp_client` feature flag.
+  
+- **Pi:** no Figma MCP → SVG fallback path, as originally proposed.
+  
+- Desktop app is **not** required (remote server), but a browser is.
+  
+### 1.5 Explicitly out of scope (confirmed by research)
+- **Write to Canvas (**`use_figma`**)** — explicitly beta ("output may need manual review"), 20KB per-call output limit, no image/asset support, no custom fonts. Matches the original scope boundary; a later version could revisit.
+  
+- **Code Layers** (Config 2026) — different feature (live code components on canvas), early-access only, Full seat. Do not conflate.
+  
+- **html.to.design** — third-party MCP alternative with a longer HTML→Figma track record. We won't depend on it, but it's a useful comparator in the Phase 0 bake-off if Code to Canvas underperforms.
+  
+
+* * *
+## 2. The contract
+Documented at the top of `references/figma.md` (source of truth), mirrored briefly in README.
+
+- **Accepted sources:** a single diagram-design HTML file (any variant: light, dark, full, terminal, sketchy, imported). Same edge-case rules as `export.md`: gallery (`assets/index.html` or any multi-diagram page) → refuse and ask which diagram; no `<svg>` → refuse; the **source HTML is never modified**.
+  
+- **Targets:** `draft` (default) · `file <Figma URL>` · `clipboard`. A pasted Figma URL implies `file`.
+  
+- **Permissions:** surfaced before attempting — existing-file target warns it needs a Full seat + edit access, and on failure offers `draft` or `clipboard` instead.
+  
+- **Fallback:** if Figma MCP is missing / unauthenticated / denied / capture fails → run the existing `export.md` SVG procedure, hand the user the `.svg`, and explain the trade-off in one sentence (editable vectors either way; Code to Canvas adds structured layers + variable binding; SVG paste is manual but dependable).
+  
+- **Trigger:** manual only, like export — never send to Figma unprompted.
+  
+- **Security:** temp server binds `127.0.0.1` on an ephemeral port, serves only the capture temp dir, and is shut down and deleted afterward. Source content is never fetched or executed; no OAuth tokens or Figma state ever land in generated artifacts.
+  
+
+* * *
+## 3. Phase 0 — fidelity spike (decision gate)
+Timeboxed, before any real implementation. In a Claude Code session with Figma MCP connected:
+
+1. Hand-build a minimal capture page from `assets/example-architecture.html` (head + fonts + the one `<svg>`, body sized to `viewBox`), serve it with `python3 -m http.server --bind 127.0.0.1`, run `generate_figma_design` → new draft.
+  
+2. In the same Figma file, paste the existing `export.md` SVG output of the same diagram.
+  
+3. Compare side by side: path geometry, arrow markers, dashed strokes, label masks, fonts (Instrument Serif / Geist / Geist Mono), text editability, layer structure, `<title>`/`<desc>` survival.
+  
+4. Repeat once with a dark variant (CSS-variable-heavy) and once with the terminal variant.
+  
+
+Also resolve the one open mechanical question: **does a zero-JS static page served by** `http.server` **capture at all**, or does the capture script injection assume a dev server? If static serving fails, the capture page embeds Figma's capture snippet itself (the temp page is ephemeral tooling, so the "no JS in deliverables" rule is untouched).
+
+**Decision:**
+
+- **Code to Canvas ≥ SVG paste on fidelity** → build as planned; SVG stays the fallback.
+  
+- **Code to Canvas < SVG paste** → invert the design: `/figma` becomes a _Figma handoff_ command whose primary path is the SVG export plus guided paste (and optionally still offers Code to Canvas with a fidelity warning). Same files, same verification, different default — so the spike outcome changes wording, not architecture.
+  
+
+Record spike results (screenshots + a short fidelity ledger) in the PR description.
+
+* * *
+## 4. File map
+New files follow the existing pattern exactly (reference = source of truth; commands/prompts are thin wrappers; one verify script per feature wired into CI):
+
+| File | Role |
+|---|---|
+| `skills/diagram-design/scripts/figma_capture.py` | Deterministic capture-page builder + local server (§5) |
+| `skills/diagram-design/references/figma.md` | Source-of-truth procedure: contract, MCP detection, serve → capture → target → link → cleanup, permission/error UX, fallback rules, Claude/Codex/Pi setup notes |
+| `commands/figma.md` | Claude Code / Codex slash command `/diagram-design:figma <html-file> [--target=draft\|clipboard\|<url>]` — delegates to the reference |
+| `prompts/figma.md` | Pi prompt — routes to the SVG fallback until Pi supports the MCP flow |
+| `scripts/verify-figma-export.py` | CI verification gate (§7) |
+
+Edits: `SKILL.md` (§12 gains a "Sending to Figma" routing paragraph next to the export one, plus natural-language triggers), `README.md`, `CONTRIBUTING.md` (validation-gates list), `.github/workflows/ci.yml` (new step + summary row), both plugin manifests → `2.3.0`.
+
+* * *
+## 5. `figma_capture.py` design
+One script, three modes, stdlib only (matches `drawio_extract.py` / `mermaid_extract.py` conventions: no third-party deps, JSON-ish digest output, treats all source content as untrusted data).
+
+```
+figma_capture.py check  <src.html>            # validate only, exit 0/1 + reasons
+figma_capture.py build  <src.html> [--out DIR] # write capture page, print manifest JSON
+figma_capture.py serve  <capture-dir>          # 127.0.0.1, port 0 (ephemeral), prints URL, serves until killed
+```
+
+`build` **steps:**
+
+1. Validate: file exists, parses, contains ≥1 `<svg>`; refuse the gallery (`assets/index.html` or multiple sibling diagram SVGs); never fetch or execute anything from the source.
+  
+2. Isolate the **first** `<svg>` block (same regex-anchored extraction as `export.md`).
+  
+3. Emit a capture page into a fresh `mktemp -d`:
+  
+  - Source `<head>` styles and Google Fonts `<link>` carried over so CSS variables, classes, and typography resolve identically.
+    
+  - `<body>` contains **only** the diagram SVG; `margin: 0`; body and page sized exactly to the `viewBox` (viewport-only capture, §1.1).
+    
+  - `<title>`, `<desc>`, `role="img"`, `aria-labelledby` preserved verbatim.
+    
+  - No scripts (unless the Phase 0 spike proves the Figma capture snippet must be embedded — then it's added here, in the temp page only).
+    
+4. Print a manifest: temp dir, capture file path, width × height, source SHA-256 (so verification can prove the source is untouched).
+  
+
+`serve` wraps `http.server` bound to `127.0.0.1`, port 0, rooted at the capture dir only. The agent runs it in the background, opens the Figma-provided capture URL, and kills it (and removes the temp dir) after the capture completes or fails.
+
+**The agent workflow in** `references/figma.md`**:**
+
+1. Detect Figma MCP (is `generate_figma_design` callable?). Missing → print per-agent setup instructions + offer SVG fallback.
+  
+2. `check` → `build` → `serve`.
+  
+3. Call `generate_figma_design` with the local URL and the chosen target; open the capture URL in the browser; poll.
+  
+4. Report the resulting Figma link (or "pasteable from clipboard").
+  
+5. Always: kill server, delete temp dir — including on error paths.
+  
+6. Any failure after step 1 → offer the SVG fallback rather than dead-ending.
+  
+
+* * *
+## 6. Error and permission UX
+| Situation | Behavior |
+| --- | --- |
+| Figma MCP not configured | Show the one-line setup command for the current agent; offer SVG fallback now |
+| OAuth expired / unauthenticated | Say so plainly; offer re-auth or SVG fallback |
+| Existing-file target, no Full seat / no edit access | Explain the seat rule; offer draft or clipboard |
+| Capture times out / errors | One retry, then SVG fallback with the error surfaced |
+| Gallery / no-SVG / malformed source | Refuse with the same wording family as export.md; write nothing |
+| MCP response exceeds client token cap | Surface the `MAX_MCP_OUTPUT_TOKENS` remedy from Figma's known-issues doc |
+
+* * *
+## 7. `scripts/verify-figma-export.py` (CI gate)
+Same shape as `verify-drawio-import.py`: drives the real shipped artifacts, exits non-zero on any failure, added to `ci.yml` (all-OS × Python 3.11/3.12 matrix) and the summary table. No live Figma in CI — everything below is structural:
+
+- **Capture correctness:** CSS-variable diagram, inline-style diagram, light / dark / full / terminal variants each produce a capture page whose SVG is byte-identical to the source's first SVG, with styles + fonts present and body sized to the `viewBox`.
+  
+- **Rejections:** missing SVG, gallery file, malformed HTML → non-zero exit, nothing written.
+  
+- **Path robustness:** spaces (and unicode) in source paths.
+  
+- **Source integrity:** source SHA-256 identical before/after every mode.
+  
+- **Accessibility:** `<title>`, `<desc>`, `role`, `aria-labelledby` survive into the capture page.
+  
+- **Hygiene:** no credentials/token patterns, no user-absolute paths in any generated artifact; `serve` binds only `127.0.0.1` (assert on the bound socket) and refuses to serve outside the capture dir.
+  
+- **Doc sync:** `commands/figma.md`, `prompts/figma.md`, `references/figma.md`, and `SKILL.md` cross-reference each other consistently (flag names, target names, fallback wording) — same technique the draw.io verifier uses.
+  
+
+* * *
+## 8. Docs and packaging
+- **README:** new "Send to Figma" section after "Export to PNG / SVG" — the three invocations, target table with seat requirements, fallback sentence.
+  
+- **SKILL.md:** routing paragraph in §12 + version bump to 2.3.
+  
+- **CONTRIBUTING:** add the new gate to the validation list.
+  
+- **Manifests:** `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` → `2.3.0`; description gains "send to Figma"; keyword `figma`.
+  
+
+* * *
+## 9. Live acceptance matrix (pre-release)
+Fresh Claude Code and Codex sessions, real Figma account:
+
+| #   | Scenario | Pass criterion |
+| --- | --- | --- |
+| 1   | New draft, architecture example | Editable layers in a new draft; link returned; temp server gone |
+| 2   | Existing editable file via URL | Layers land in that file |
+| 3   | Clipboard target | Paste into any file works |
+| 4   | MCP missing | Setup instructions + working SVG fallback |
+| 5   | Unauthenticated MCP | Clean message + fallback offer |
+| 6   | Existing file without Full seat | Seat explanation + draft/clipboard offer |
+| 7   | Fonts unavailable in Figma | Substitution reported honestly |
+| 8   | Process diagram (second representative type) | Same as #1 |
+| 9   | Source hash check after every run | Unchanged |
+
+Codex runs at least #1 and #4. Pi runs the SVG-fallback path once.
+
+* * *
+## 10. Release and fleet install
+After review, green CI, and Greptile 5/5 with resolved comments:
+
+1. Merge, tag, release 2.3.0.
+  
+2. Install on this machine plus studio, ronan, and knox — **preserving each machine's customized** `style-guide.md` (the install must not clobber onboarded skins; verify the accent token survives on each machine).
+  
+3. Final live check per machine: generate one diagram, send to a Figma draft, open it, edit a node. Anything short of that is reported as "unverified", not done.
+  
+
+* * *
+## 11. Risks and open questions
+| Risk | Mitigation |
+| --- | --- |
+| Code to Canvas mangles inline SVG (undocumented) | Phase 0 spike is a hard gate; SVG-first inversion is pre-designed (§3) |
+| Static zero-JS page may not trigger capture | Spike tests it; embedding the capture snippet in the temp page is the pre-approved plan B |
+| Fonts (Instrument Serif / Geist) unsupported in capture | Spike measures it; if fonts flatten, the reference documents it and recommends matching fonts installed in Figma |
+| Browser-in-the-loop step surprises users | The reference scripts the exact wording: "your browser will open briefly so Figma can capture the page" |
+| Figma renames/re-scopes the tool (product moving fast in 2026) | Detection is by tool availability at runtime, not hardcoded assumptions; failure path always lands on the SVG fallback |
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Codex Review | `/codex review` | Independent 2nd opinion | 1 | ABSORBED | 14 findings, 7 substantive tensions, all resolved |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR | 15 issues, 0 critical gaps |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | — |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+**CODEX:** Outside voice found 14 problems; 2 verified against shipped files (nested-SVG truncation in 9 examples; Codex plugin ships no commands). All 7 substantive tensions accepted: parser-based extraction + active-content rejection (T1), owned-dir-only cleanup, `--out` dropped (T2), reconcile-before-retry + destination postcondition (T3), Codex = NL routing + dual-client spike (T4), user-done completion boundary + font preloads (T5), SVG-first losing branch ships extract-only (T6), editorial batch (T7).
+
+**CROSS-MODEL:** Claude review hardened lifecycle/coverage (1A–8A); Codex caught extraction correctness, cleanup data-loss, capture idempotency, packaging honesty. No unresolved disagreements — Codex sharpened five Claude decisions rather than reversing any.
+
+**VERDICT:** ENG CLEARED (15/15 findings folded) — ready for plan formalization and spike.
+
+NO UNRESOLVED DECISIONS

--- a/docs/plans/2026-08-12-001-feat-figma-code-to-canvas-export-plan.md
+++ b/docs/plans/2026-08-12-001-feat-figma-code-to-canvas-export-plan.md
@@ -1,0 +1,357 @@
+---
+title: "feat: Send diagrams to Figma via Code to Canvas"
+type: feat
+status: active
+date: 2026-08-12
+---
+
+# feat: Send diagrams to Figma via Code to Canvas
+
+## Summary
+
+Add a manual "send this diagram to Figma" capability to the diagram-design plugin: a spike-gated Figma MCP Code to Canvas flow (capture page + loopback server + `generate_figma_design`), a shared SVG-extraction subcommand that also becomes the export path's single implementation, and the existing SVG export as the universal fallback. Every design decision below was locked in an engineering review plus a cross-model outside-voice pass on 2026-08-12 (15 findings, all resolved — see the review report at the end).
+
+---
+
+## Problem Frame
+
+Diagrams ship as standalone HTML with inline SVG. Getting one into Figma today means manually exporting an SVG and pasting it — no agent-drivable path, no returned link, no targeting of a specific file. Figma's Code to Canvas (Feb 2026) promises editable layers from a live page, but its fidelity on pure inline SVG is undocumented, so the feature must be built behind a decision gate rather than on faith.
+
+---
+
+## Requirements
+
+- R1. "Send this diagram to Figma" works as natural language, with a Figma file URL, and as `/diagram-design:figma <html-file>` (slash command: Claude Code; Codex via natural-language routing).
+- R2. *(Conditional on the Code to Canvas branch winning U1 — see T6 for the extract-only contract.)* Targets: new Figma draft (default), existing Figma Design file by URL, clipboard — with seat/permission rules surfaced before attempting.
+- R3. The source HTML is never modified; a byte-hash proves it after every operation.
+- R4. Every failure (MCP missing, unauthenticated, under-permissioned, capture failure, headless session) lands on the existing `references/export.md` SVG fallback with an honest one-line explanation — never a dead end.
+- R5. Manual trigger only — never send to Figma unprompted.
+- R6. A CI verification gate pins all shipped behaviors on the existing 3-OS × 2-Python matrix; no live Figma in CI.
+- R7. The Phase 0 spike is a hard decision gate: mechanics first, then fidelity vs plain SVG paste; the losing branch for Code to Canvas ships extract-only.
+- R8. Documentation surfaces (reference, command, prompt, SKILL.md, README) stay synchronized and claim only verified behavior.
+
+---
+
+## Scope Boundaries
+
+- No Write to Canvas (`use_figma`): beta quality, 20KB/call, no assets or custom fonts.
+- No Code Layers (early-access, different capability).
+- No html.to.design dependency (spike comparator only).
+- No custom Figma plugin or native SVG→Figma translator in v1.
+- No headless capture — doesn't exist in Figma's architecture; headless sessions pre-flight to the SVG fallback.
+- No Pi MCP flow — Pi ships the SVG-fallback prompt until it supports Figma MCP.
+
+### Deferred to Follow-Up Work
+
+- **Codex slash-command packaging** — `.codex-plugin/plugin.json` ships only `skills`; commands can't reach Codex installs today. Revisit when the Codex plugin format supports commands. Until then Codex uses natural-language routing (review decision T4).
+- **Automated post-capture font verification** — inspect the resulting Figma file (REST API) for font substitution instead of visual checks. Contingent on Code to Canvas winning the spike (review decision T5).
+- **Write to Canvas semantic frames / components / bound variables** — future version, once that API leaves beta.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `skills/diagram-design/references/export.md` — existing SVG/PNG export procedure; the fallback path, and (per decision 4A) the consumer of the new shared `extract` subcommand.
+- `skills/diagram-design/scripts/drawio_extract.py`, `mermaid_extract.py` — stdlib-only script conventions: untrusted-input posture, structured digest output.
+- `scripts/verify-drawio-import.py` — the verify-gate shape to mirror (drives real artifacts, doc-sync checks, exit 0 only when all gates pass).
+- `commands/export-diagram.md`, `prompts/export-diagram.md` — thin-wrapper convention: reference file is the source of truth.
+- `.github/workflows/ci.yml` — one step per verify gate + summary-table row.
+- Nested-SVG examples: `skills/diagram-design/assets/example-datalake*.html`, `example-high-level*.html` (9 files) embed icon `<svg>` elements inside the diagram SVG — the fixture class that kills naive regex extraction.
+
+### External References
+
+- Figma Code to Canvas docs: https://developers.figma.com/docs/figma-mcp-server/code-to-canvas/ — tool `generate_figma_design` (remote MCP only), destinations, seat rules, variable binding, URL-fallback-to-new-file behavior.
+- Remote server setup: https://developers.figma.com/docs/figma-mcp-server/remote-server-installation/ — Claude Code / Codex setup, OAuth-only auth.
+- Write to Canvas limitations: https://developers.figma.com/docs/figma-mcp-server/write-to-canvas/ — grounds the scope boundary.
+- Codeminer42 hands-on postmortem — capture-ID/injected-script/DOM-capture mechanics, viewport-only capture, CSS degradation.
+
+### Key facts that shaped the design
+
+1. Code to Canvas is a **live-page DOM capture**: real browser + local HTTP server (no `file://`), capture script POSTs the rendered DOM to Figma; browser-in-the-loop, no headless path.
+2. Capture is **viewport-only** — off-screen content silently drops.
+3. Inline-SVG fidelity is **undocumented**; plain SVG paste is a proven high-fidelity path. Hence the spike gate (R7).
+4. Seats: any seat for drafts/clipboard; Full seat + edit access for existing files outside drafts. OAuth only.
+5. A target URL that isn't a Design file **silently creates a new file** — a postcondition check is mandatory.
+6. The Figma session is **interactive** (team prompt, additional toolbar captures) — cleanup needs a user-done boundary, not poll-and-kill.
+
+---
+
+## Key Technical Decisions
+
+All confirmed interactively in the 2026-08-12 engineering review (issue/tension IDs preserved):
+
+- **1A — Scale-to-fit capture page.** The capture page renders the SVG at `width:100%; max-height:100vh` so any viewport contains the whole diagram; the spike asserts Figma reconstructs from viewBox coordinates, not display pixels. Prevents silent cropping on small screens.
+- **2A/8A — Self-terminating server, injectable timeouts.** `serve` exits at `--max-lifetime` (generous default sized for the interactive Figma session), deleting its own capture dir on exit; both timeout flags accept any positive value so CI expiry proofs run in ~2s. **Idle-timeout is not armed in the interactive flow** — after the initial capture Figma sends no further loopback traffic, so an armed idle timer would kill the server mid-session while the user is still working in Figma. `--idle-timeout` exists for CI expiry proofs and abandoned-session cleanup only (when armed, it must be ≥ max-lifetime in interactive use). If the max-lifetime backstop fires while the user still needs toolbar captures, the reference scripts the recovery plainly: re-run `/figma` — the source file is untouched, so re-capture is cheap.
+- **3A/T4 — Mechanics-first, dual-client spike.** Stage 1 (go/no-go, run in Claude Code AND Codex): static zero-JS page captures at all; scale-to-fit geometry lands at viewBox coordinates; programmatic URL-targeting works; retry/destination behavior is observable; capture-vs-font-loading timing. Stage 2 (only if Stage 1 passes): fidelity bake-off vs plain SVG paste on light, dark (CSS-variable-heavy), and terminal variants.
+- **4A/T1 — One extraction implementation, parser-based.** `figma_capture.py extract` uses balanced-tag (stdlib `html.parser`) SVG isolation — never first-`</svg>` regex, which truncates the 9 shipped nested-SVG examples. `build` calls it; `export.md` points agents at it (prose kept as no-script fallback). `check` rejects or flags active/external constructs (`<script>`, event handlers, `foreignObject`, external `url()`/`@import`/`href`) — the security posture states what's true instead of claiming "nothing executes."
+- **5A — Fix the stale pointer** in `export.md` (`commands/export.md` → `commands/export-diagram.md`); doc-sync gate asserts every reference→command pointer resolves.
+- **6A — Explicit error paths.** Missing/unusable `viewBox` → hard fail with a clear message; GUI-browser pre-flight (headless/SSH detection) routes straight to the SVG fallback before any doomed capture poll.
+- **7A — Full verify-gate adoption.** All nine review-identified test additions ship in the CI gate, including the extract-parity case (CRITICAL regression guard for the export path), server self-expiry/self-cleanup proofs, the nested-SVG fixture, and the `role="img"` diagram-not-glyph assertion. Enumerated in U3.
+- **T2 — Ownership-tracked cleanup.** No `--out` flag; `build` always creates its own temp directory; deletion is restricted to directories this run created. A verify case proves a pre-existing directory is never removed.
+- **T3 — Trust-but-verify results.** On timeout, reconcile the same capture ID before any re-submit (retry only proven-pre-submission failures); after success, compare returned destination to the requested target and treat an unexpected new draft as a failure.
+- **T5 — User-done completion boundary.** The server stays up until the user confirms they're finished in Figma (max-lifetime as backstop); capture page preloads the three font families; acceptance criterion for fonts is "visually verified," stated honestly.
+- **T6 — Losing branch ships extract-only.** If SVG paste wins the spike, v1 ships `/figma` as `extract` + guided handoff: no `serve`, no capture page, verify gate shrinks to extract/doc-sync/hygiene. The Code to Canvas machinery stays designed-on-paper here.
+  **Extract-only branch contract:** `/figma <html-file>` produces a standalone SVG next to the source plus step-by-step paste instructions; `--target` is dropped; seat rules, destination validation, and the capture lifecycle do not apply; R2 is void in this branch (R1's three invocation styles survive, all routing to the extract+handoff flow). U6's acceptance matrix reduces to: extract correctness on both representative diagrams, guided paste verified once in Figma, MCP-missing/headless messaging, source-hash integrity. The README section describes the SVG handoff and frames Code to Canvas as a future option.
+- **T7 — Claim only what sources support.** Variable binding worded as "may bind in configured target files"; no `MAX_MCP_OUTPUT_TOKENS` error row unless the spike reproduces it; §Acceptance is a release gate (pre-tag), fleet installs are post-release smoke.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Primary mechanism: Code to Canvas vs SVG-first — resolved into a spike-gated branch structure (R7, T6).
+- Extraction strategy: parser-based balanced isolation, shared with export (4A/T1).
+- Cleanup ownership, retry semantics, destination validation, session lifecycle — all resolved (T2/T3/T5).
+
+### Deferred to Implementation (the spike answers these)
+
+- Does a zero-JS static page served by `http.server` trigger capture, or must the capture snippet be embedded in the temp page? (Plan B pre-approved: embed it — the temp page is ephemeral tooling, not a deliverable.)
+- Does scaled-down display degrade Figma's reconstruction? (1A assertion.)
+- Can `generate_figma_design` be pointed at a file URL programmatically, and is the returned destination observable? (3A/T3.)
+- Does the initial capture beat font loading? (T5.)
+- Actual inline-SVG fidelity vs SVG paste. (Stage 2.)
+
+---
+
+## Output Structure
+
+    skills/diagram-design/
+      scripts/figma_capture.py          # extract | check | build | serve
+      references/figma.md               # source-of-truth procedure
+    commands/figma.md                   # Claude Code slash command
+    prompts/figma.md                    # Pi prompt (SVG fallback path)
+    scripts/verify-figma-export.py      # CI verification gate
+    scripts/fixtures/                   # nested-SVG fixture (from example-datalake)
+
+---
+
+## High-Level Technical Design
+
+> *Directional guidance for review, not implementation specification.*
+
+```
+diagram.html
+   │  figma_capture.py
+   ├─ check   ── gallery? no <svg>? no viewBox? active content? ──✗ refuse w/ message
+   ├─ extract ── balanced-tag SVG isolation (shared with export.md)
+   ├─ build   ── capture page: source <head> styles + font preloads,
+   │             body = diagram only, scale-to-fit (1A), owned temp dir,
+   │             manifest {path, w×h, source sha256}
+   └─ serve   ── 127.0.0.1:ephemeral/<token>/, owned-dir root, self-expiring (2A/8A)
+                       │
+        agent: Figma MCP present? ──no──> per-agent setup + SVG fallback
+                       │ yes                         ▲
+        GUI browser?  ──no──────────────────────────┤ (6A pre-flight)
+                       │ yes                         │
+        generate_figma_design(local URL, target) ────┤ error/timeout:
+                       │                             │ reconcile capture ID (T3)
+        browser opens; user completes in Figma       │ then ONE retry, else fallback
+                       │ user-done boundary (T5)     │
+        validate destination == requested target (T3)┘
+                       │
+        report Figma link ──> kill server, delete owned dirs (T2)
+```
+
+---
+
+## Implementation Units
+
+- U1. **Phase 0 spike — mechanics gate, then fidelity bake-off (decision gate)**
+
+**Goal:** Prove or kill the Code to Canvas path before building it; select the winning branch for U2–U6.
+
+**Requirements:** R7
+
+**Dependencies:** Environment prerequisites — (1) Figma account with a Full seat and edit access to a scratch Design file (required for the URL-targeting check); (2) Figma remote MCP server connected and OAuth-authenticated in **both** Claude Code and Codex (per the remote-server-installation doc, including the Codex `rmcp_client` note); (3) a GUI browser session (not SSH/headless); (4) a throwaway drafts space for generated files.
+
+**Files:**
+- Create: `docs/plans/2026-08-12-001-feat-figma-code-to-canvas-export-plan.md` (spike ledger appended as a dated section) — no product code
+
+**Approach:**
+- Stage 1 (mechanics, run in Claude Code and Codex): hand-built capture page from `skills/diagram-design/assets/example-architecture.html`, served via `python3 -m http.server --bind 127.0.0.1`. Checks: static-page capture fires; scale-to-fit geometry lands at viewBox coordinates; URL-targeting is programmatic; destination is observable in the result; retry/reconcile behavior; capture-vs-`document.fonts.ready` timing; whether a toolbar re-capture re-fetches the local URL or reuses the already-captured DOM (determines how long `serve` must outlive the initial capture).
+- Stage 2 (fidelity, only if Stage 1 passes): same diagram via Code to Canvas vs pasted `export.md` SVG, side by side in one Figma file; repeat for a dark variant and the terminal variant. Compare path geometry, markers, dashes, masks, fonts, text editability, layer structure, `<title>`/`<desc>` survival.
+- **Pre-committed branch-decision rule (recorded in the ledger before Stage 2 begins):** Code to Canvas wins only if it matches plain SVG paste on path geometry and font rendering across all three variants AND delivers a concrete workflow advantage (editable text/layers or fewer user interactions than extract-plus-paste). Any geometry or font regression means SVG paste wins. The rule is written down first so mixed results can't be argued into shipping the machinery.
+- Record a fidelity ledger with screenshots; the branch decision (full flow vs extract-only per T6) is written into this plan before U2 begins.
+
+**Test scenarios:** Test expectation: none — throwaway spike; its output is the recorded ledger and branch decision.
+
+**Verification:** Ledger records pass/fail for every Stage 1 check in both clients; branch decision committed to this plan file.
+
+- U2. **`figma_capture.py` — extract / check / build / serve**
+
+**Goal:** The deterministic tooling: shared SVG extraction, validation, capture-page builder, self-expiring loopback server.
+
+**Requirements:** R2, R3, R6; decisions 1A, 2A, 4A, 6A, 8A, T1, T2
+
+**Dependencies:** U1 (losing branch: only `extract` + `check` ship)
+
+**Files:**
+- Create: `skills/diagram-design/scripts/figma_capture.py`
+- Test: `scripts/verify-figma-export.py` (written in U3; scenarios enumerated there)
+
+**Approach:**
+- Stdlib only, mirroring `drawio_extract.py` conventions. Subcommands: `extract <src> [--stdout]`, `check <src>`, `build <src>` (owned temp dir + JSON manifest), `serve <capture-dir> --max-lifetime N --idle-timeout N`.
+- Balanced-tag extraction via `html.parser`; refuse gallery (`assets/index.html` / multiple sibling diagram SVGs), missing `<svg>`, missing/unusable `viewBox`, active/external constructs. External-reference policy (committed): `check` allowlists exactly the known Google Fonts hosts (`fonts.googleapis.com`, `fonts.gstatic.com`) by default with no flag — every shipped diagram legitimately loads them — and rejects every other external `url()`/`@import`/`href`; no override flag in v1.
+- Capture page: source `<head>` styles + `<link rel="preload">` for Instrument Serif/Geist/Geist Mono, body = SVG only, `margin:0`, scale-to-fit CSS.
+- `serve`: `http.server` bound to `127.0.0.1`, port 0, rooted at the owned capture dir; the capture page lives under a random per-session path token (e.g. `/<uuid>/index.html`) and any request missing the token gets a 404, so knowing the loopback port alone is not enough for another local process to read the diagram; exits on max-lifetime (idle-timeout only when explicitly armed — see 2A/8A); deletes only directories recorded as created by this run.
+
+**Patterns to follow:** `drawio_extract.py` (arg handling, untrusted input, digest output), `export.md` §SVG procedure (standalone-SVG spec the `extract` output must match).
+
+**Test scenarios:** enumerated in U3 (single verify gate drives this script).
+
+**Verification:** All U3 verify cases pass locally on macOS; script runs on Python 3.11/3.12 with no third-party imports.
+
+- U3. **`verify-figma-export.py` + CI wiring**
+
+**Goal:** Pin every shipped behavior in CI; extend doc-sync coverage.
+
+**Requirements:** R3, R6, R8; decisions 5A, 7A, T1, T2, 8A
+
+**Dependencies:** U2
+
+**Files:**
+- Create: `scripts/verify-figma-export.py`, `scripts/fixtures/` nested-SVG fixture (derived from `example-datalake.html`)
+- Modify: `.github/workflows/ci.yml` (new step + summary-table row)
+
+**Approach:** Same shape as `verify-drawio-import.py`: drive the real artifacts, exit non-zero on any failure.
+
+**Test scenarios:**
+- Happy path: light / dark / full / terminal variants → capture page whose SVG is byte-identical to the source's first diagram SVG, styles+fonts present, scale-to-fit CSS present, body sized from viewBox.
+- Happy path: `extract` output == `export.md` standalone-SVG spec (xmlns, viewBox, fonts `@import`, XML declaration) — **CRITICAL regression guard** for the export path.
+- Edge: nested-SVG fixture (datalake) → extraction returns the complete outer SVG including all nested icon SVGs.
+- Edge: extracted SVG carries `role="img"` (proves diagram, not decorative glyph); `<title>`/`<desc>`/`aria-labelledby` survive verbatim.
+- Edge: spaces and unicode in source paths.
+- Error: missing `<svg>`, gallery file, malformed HTML, missing `viewBox`, embedded `<script>`/event-handler content → non-zero exit, nothing written, message names the cause.
+- Edge: external-reference policy pinned from both sides — the Google Fonts link passes `check`; any other external `url()`/`@import`/`href` fails it.
+- Error: `serve` request outside the capture dir → refused; asserted bind address is `127.0.0.1`.
+- Integration: `serve --max-lifetime 2` exits ≈2s and removes its owned dir; `--idle-timeout 2` likewise; a pre-existing user directory passed as cwd context is never deleted.
+- Integration: source SHA-256 identical before/after every subcommand.
+- Hygiene: no credential/token patterns, no user-absolute paths in any generated artifact.
+- Doc-sync: `commands/figma.md`, `prompts/figma.md`, `references/figma.md`, `SKILL.md` consistent (flags, target names, fallback wording); every reference→command pointer in `references/` resolves to an existing file (catches the 5A class repo-wide).
+
+**Verification:** Gate green on all 6 matrix jobs; deliberate mutations (break a pointer, re-introduce regex extraction) fail it.
+
+- U4. **Agent workflow surfaces — reference, command, prompt, routing**
+
+**Goal:** The procedure agents follow, in the repo's reference-as-source-of-truth pattern.
+
+**Requirements:** R1, R2, R4, R5; decisions 3A, 6A, T3, T4, T5, T7
+
+**Dependencies:** U1 (wording depends on branch), U2
+
+**Files:**
+- Create: `skills/diagram-design/references/figma.md`, `commands/figma.md`, `prompts/figma.md`
+- Modify: `skills/diagram-design/SKILL.md` (§12 routing paragraph + version 2.3)
+
+**Approach:**
+- `references/figma.md` carries: the contract; MCP detection with per-agent setup lines (Claude Code and Codex, including the `rmcp_client` note); GUI-browser pre-flight; check → build → serve → `generate_figma_design` → user-done boundary → destination validation → report link → cleanup; the error table (no token-cap row); fallback rules; honest variable-binding wording; Codex = natural-language routing (no slash command until packaging supports it).
+- `commands/figma.md`: thin wrapper, `<html-file> [--target=draft|clipboard|<figma-url>]`, delegates to the reference.
+- `prompts/figma.md` (Pi): routes to the SVG fallback procedure.
+
+**Patterns to follow:** `references/export.md` trigger/edge-case structure; `commands/export-diagram.md` wrapper shape.
+
+**Test scenarios:** covered by U3's doc-sync cases (behavioral testing of the live flow is U6's acceptance matrix). Test expectation for prose files beyond doc-sync: none — no executable behavior.
+
+**Verification:** Doc-sync gate passes; a dry read-through of the reference reproduces the U1 spike flow without improvisation.
+
+- U5. **Export path updates**
+
+**Goal:** Make `extract` the single extraction implementation and fix the stale pointer.
+
+**Requirements:** R8; decisions 4A, 5A
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `skills/diagram-design/references/export.md`
+
+**Approach:** SVG procedure points agents at `figma_capture.py extract` (prose retained as no-script fallback); fix `commands/export.md` → `commands/export-diagram.md` at line 9.
+
+**Test scenarios:** the U3 extract-parity CRITICAL case and pointer-resolution case are this unit's regression guards.
+
+**Verification:** Export of `example-datalake.html` via `extract` yields the complete nested-SVG diagram (previously truncated by the prose regex).
+
+- U6. **Docs, packaging, release gate, fleet install**
+
+**Goal:** Ship 2.3.0 honestly: README, CONTRIBUTING, manifests, pre-tag acceptance, post-release smoke.
+
+**Requirements:** R1, R2, R8; decision T7
+
+**Dependencies:** U3, U4, U5
+
+**Files:**
+- Modify: `README.md` (Send-to-Figma section after Export), `CONTRIBUTING.md` (validation-gates list), `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json` (2.3.0, description + `figma` keyword)
+
+**Approach & release sequencing (T7):**
+1. **Release gate (pre-tag):** live acceptance matrix in fresh Claude Code and Codex sessions — new draft; existing editable file (destination validated); clipboard; MCP missing; unauthenticated; seat-denied; headless/SSH session → clean SVG fallback; fonts visually verified; source-hash unchanged after every run; kill-agent-mid-capture → server self-expires, no orphan. Pi runs the SVG-fallback path once.
+2. Merge and release only after the gate + green CI + Greptile 5/5 with resolved comments.
+3. **Post-release smoke:** install on local, studio, ronan, knox — verifying each machine's customized `style-guide.md` survives (accent token spot-check) — then one generate→send→edit-in-Figma round-trip per machine. Anything unexercised is reported "unverified."
+
+**Test scenarios:** Test expectation: none — packaging/docs; the acceptance matrix above is the live verification.
+
+**Verification:** Release tagged only after step 1 passes; per-machine smoke results recorded.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** New entry points (`/diagram-design:figma`, SKILL.md routing) plus one modified existing surface: `export.md`'s SVG procedure now delegates to `extract` — the parity case guards existing export behavior.
+- **Error propagation:** Every Figma-path failure terminates in the SVG fallback with an honest message; no path dead-ends (R4).
+- **State lifecycle risks:** Temp dirs and server lifetime are process-guaranteed (2A/T2); source files are read-only by contract with hash proof (R3).
+- **API surface parity:** Slash command Claude-Code-only until Codex packaging exists (T4); Pi = SVG fallback; all three documented explicitly.
+- **Integration coverage:** Live acceptance matrix covers what CI can't (real MCP, real browser, real seats).
+- **Unchanged invariants:** Generated diagram HTML format, the accessible-SVG contract, the no-JS-in-deliverables rule (the capture page is ephemeral tooling, not a deliverable), and all existing verify gates.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Code to Canvas mangles inline SVG (undocumented) | U1 Stage 2 is a hard gate; T6 losing branch ships extract-only |
+| Static zero-JS page doesn't trigger capture | U1 Stage 1 first check; pre-approved plan B embeds the capture snippet in the ephemeral page |
+| Figma changes/renames the tool (fast-moving product) | Runtime tool detection, never hardcoded; all failures land on SVG fallback |
+| Capture races font loading | Preloads + U1 timing measurement; substitution reported honestly; automated inspection deferred |
+| Figma silently creates a new file for a bad target URL | T3 destination postcondition treats it as failure |
+| Timeout after successful submit → duplicate drafts | T3 reconcile-same-capture-ID before any retry |
+| Browser-in-the-loop surprises users | Reference scripts the exact wording: "your browser will open briefly so Figma can capture the page" |
+
+---
+
+## Documentation / Operational Notes
+
+- README section mirrors the reference's contract table (targets × seat requirements) and the fallback sentence, plus two additions the plan commits to: (1) the intro tagline is reframed so the headline and this feature tell one story — Figma-independence with optional export ("No Figma required — but when you want editable layers there, one command sends any diagram over"), with the doc-sync review confirming intro and Send-to-Figma section agree; (2) the section carries the browser disclosure up front ("your browser will open briefly so Figma can capture the page", plus the finish-in-Figma/user-done step) and a three-row invocation table: Claude Code = slash command, Codex = natural language only (slash command deferred, T4), Pi = SVG fallback.
+- The reviewed draft with full research narrative lives at `docs/plan-figma-export.md`; this plan supersedes it for execution.
+- Fleet installs (studio, ronan, knox) must preserve onboarded style guides — verify the accent token per machine before declaring done.
+
+---
+
+## Sources & References
+
+- Reviewed draft + research narrative: `docs/plan-figma-export.md`
+- Related code: `skills/diagram-design/references/export.md`, `scripts/verify-drawio-import.py`, `skills/diagram-design/scripts/drawio_extract.py`
+- External docs: Figma Code to Canvas / remote-server-installation / write-to-canvas (developers.figma.com)
+- Eng-review task artifact: `~/.gstack/projects/cathrynlavery-diagram-design/tasks-eng-review-20260812-122240.jsonl`
+
+---
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Codex Review | `/codex review` | Independent 2nd opinion | 1 | ABSORBED | 14 findings, 7 substantive tensions, all resolved |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR | 15 issues, 0 critical gaps |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | — |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+**CODEX:** Outside voice found 14 problems; 2 verified against shipped files (nested-SVG truncation in 9 examples; Codex plugin ships no commands). All 7 substantive tensions accepted and folded into the decisions above (T1–T7).
+
+**CROSS-MODEL:** Claude review hardened lifecycle/coverage (1A–8A); Codex caught extraction correctness, cleanup data-loss, capture idempotency, and packaging honesty. No unresolved disagreements.
+
+**VERDICT:** ENG CLEARED (15/15 findings folded) — ready to implement, starting with U1.
+
+NO UNRESOLVED DECISIONS

--- a/scripts/fixtures/sample-nested-svg.html
+++ b/scripts/fixtures/sample-nested-svg.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Open data lake · Nested SVG fixture</title>
+</head>
+<body>
+  <svg viewBox="0 0 480 180" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="nested-datalake-title nested-datalake-desc">
+    <title id="nested-datalake-title">Open data lake · End-to-end stack</title>
+    <desc id="nested-datalake-desc">A trimmed data lake architecture with app server, database, and Apache NiFi icon SVGs nested inside the diagram SVG.</desc>
+    <defs>
+      <pattern id="fixture-dots" width="16" height="16" patternUnits="userSpaceOnUse">
+        <circle cx="1" cy="1" r="0.8" fill="#d5d7de"/>
+      </pattern>
+    </defs>
+    <rect width="480" height="180" rx="12" fill="url(#fixture-dots)"/>
+
+    <g transform="translate(24 40)">
+      <rect width="120" height="96" rx="8" fill="white" stroke="#2d3142"/>
+      <svg x="48" y="16" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#2d3142" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M3 7a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v2a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3"/>
+        <path d="M3 15a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v2a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3l0 -2"/>
+        <path d="M7 8l0 .01"/><path d="M7 16l0 .01"/>
+      </svg>
+      <text x="60" y="64" text-anchor="middle" font-family="sans-serif" font-size="12">App servers</text>
+    </g>
+
+    <g transform="translate(180 40)">
+      <rect width="120" height="96" rx="8" fill="white" stroke="#2d3142"/>
+      <svg x="48" y="16" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#2d3142" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M4 6a8 3 0 1 0 16 0a8 3 0 1 0 -16 0"/>
+        <path d="M4 6v6a8 3 0 0 0 16 0v-6"/>
+        <path d="M4 12v6a8 3 0 0 0 16 0v-6"/>
+      </svg>
+      <text x="60" y="64" text-anchor="middle" font-family="sans-serif" font-size="12">Databases</text>
+    </g>
+
+    <g transform="translate(336 40)">
+      <rect width="120" height="96" rx="8" fill="white" stroke="#eb6c36"/>
+      <svg x="48" y="16" width="24" height="24" viewBox="0 0 24 24" fill="#eb6c36" aria-hidden="true">
+        <path d="M11.648 0a.093.093 0 0 0-.084.053A30.71 30.71 0 0 1 8.592 4.73c-2.09 2.728-5.145 6.466-5.145 10.364a8.201 8.201 0 0 0 8.201 8.2v-5.003c0-.106.087-.193.194-.193h2.81v-2.813c0-.106.087-.191.194-.191h5.004c0-3.9-3.056-7.636-5.145-10.364A30.712 30.712 0 0 1 11.732.053.094.094 0 0 0 11.648 0z"/>
+      </svg>
+      <text x="60" y="64" text-anchor="middle" font-family="sans-serif" font-size="12">Apache NiFi</text>
+    </g>
+  </svg>
+</body>
+</html>

--- a/scripts/verify-figma-export.py
+++ b/scripts/verify-figma-export.py
@@ -1,0 +1,585 @@
+#!/usr/bin/env python3
+"""Cross-platform verification gate for the shipped Figma SVG tooling."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from html.parser import HTMLParser
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+sys.dont_write_bytecode = True
+
+ROOT = Path(__file__).resolve().parent.parent
+CAPTURE = ROOT / "skills/diagram-design/scripts/figma_capture.py"
+EXPORT_REF = ROOT / "skills/diagram-design/references/export.md"
+REFERENCES = ROOT / "skills/diagram-design/references"
+COMMANDS = ROOT / "commands"
+FIXTURE = ROOT / "scripts/fixtures/sample-nested-svg.html"
+GALLERY = ROOT / "skills/diagram-design/assets/index.html"
+MEDALLION = ROOT / "skills/diagram-design/assets/example-medallion.html"
+SVG_NAMESPACE = "http://www.w3.org/2000/svg"
+XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8"?>\n'
+VARIANTS = (
+    ("light", ROOT / "skills/diagram-design/assets/example-architecture.html"),
+    ("dark", ROOT / "skills/diagram-design/assets/example-architecture-dark.html"),
+    ("full", ROOT / "skills/diagram-design/assets/example-architecture-full.html"),
+    ("terminal", ROOT / "skills/diagram-design/assets/example-loop-terminal.html"),
+)
+SECRET_RE = re.compile(r"(?i)(api[_-]?key|token|secret)\s*[:=]")
+WINDOWS_HOME_RE = re.compile(r"[A-Za-z]:\\Users\\", re.IGNORECASE)
+
+
+class VerificationError(Exception):
+    """A verification assertion failed."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise VerificationError(message)
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class SvgIsolationParser(HTMLParser):
+    """Find top-level SVG spans without confusing nested icon SVGs for siblings."""
+
+    def __init__(self, source: str) -> None:
+        super().__init__(convert_charrefs=True)
+        self.source = source
+        self.line_starts = [0]
+        self.line_starts.extend(match.end() for match in re.finditer("\n", source))
+        self.depth = 0
+        self.start: int | None = None
+        self.spans: list[tuple[int, int]] = []
+
+    def _offset(self) -> int:
+        line, column = self.getpos()
+        return self.line_starts[line - 1] + column
+
+    def _token_end(self, start: int) -> int:
+        end = self.source.find(">", start)
+        if end < 0:
+            raise VerificationError("unterminated SVG tag in verification input")
+        return end + 1
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        del attrs
+        if tag.lower() != "svg":
+            return
+        if self.depth == 0:
+            self.start = self._offset()
+        self.depth += 1
+
+    def handle_startendtag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        del attrs
+        if tag.lower() == "svg" and self.depth == 0:
+            start = self._offset()
+            self.spans.append((start, self._token_end(start)))
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() != "svg" or self.depth == 0:
+            return
+        self.depth -= 1
+        if self.depth == 0:
+            require(self.start is not None, "inconsistent SVG nesting in source")
+            self.spans.append((self.start, self._token_end(self._offset())))
+            self.start = None
+
+
+class RootAttributesParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.attrs: dict[str, str | None] | None = None
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        if self.attrs is None and tag.lower() == "svg":
+            self.attrs = {name.lower(): value for name, value in attrs}
+
+
+def isolate_svg(path: Path) -> str:
+    source = path.read_text(encoding="utf-8")
+    parser = SvgIsolationParser(source)
+    parser.feed(source)
+    parser.close()
+    require(parser.depth == 0, f"{path.name}: unterminated source SVG")
+    require(len(parser.spans) == 1, f"{path.name}: expected one top-level source SVG")
+    start, end = parser.spans[0]
+    return source[start:end]
+
+
+def root_attributes(svg: str) -> dict[str, str | None]:
+    parser = RootAttributesParser()
+    parser.feed(svg)
+    parser.close()
+    require(parser.attrs is not None, "could not read outer SVG attributes")
+    return parser.attrs
+
+
+def audit_generated_svg(svg: str) -> None:
+    for marker in ("/Users/", "/home/"):
+        require(marker not in svg, f"generated SVG leaks absolute home path {marker!r}")
+    require(
+        WINDOWS_HOME_RE.search(svg) is None,
+        "generated SVG leaks an absolute Windows user-home path",
+    )
+    require(
+        SECRET_RE.search(svg) is None,
+        "generated SVG contains an obvious secret-token assignment pattern",
+    )
+
+
+class CaptureRunner:
+    """Drive the real CLI while centrally enforcing source and output invariants."""
+
+    def __init__(self) -> None:
+        self.integrity_checks = 0
+        self.integrity_failures: list[str] = []
+        self.hygiene_checks = 0
+        self.hygiene_failures: list[str] = []
+
+    def run(self, command: str, source: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+        before = sha256(source)
+        proc = subprocess.run(
+            [sys.executable, "-B", str(CAPTURE), command, str(source), *extra],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            shell=False,
+        )
+        after = sha256(source)
+        self.integrity_checks += 1
+        if before != after:
+            message = f"{command} modified source {source}"
+            self.integrity_failures.append(message)
+            raise VerificationError(message)
+
+        if command == "extract" and proc.returncode == 0:
+            if "--stdout" in extra:
+                generated = proc.stdout
+            else:
+                if "--out" in extra:
+                    out_arg = extra[extra.index("--out") + 1]
+                    output = Path(out_arg)
+                    if not output.is_absolute():
+                        output = ROOT / output
+                else:
+                    output = source.with_suffix(".svg")
+                require(output.is_file(), f"extract succeeded without writing {output}")
+                generated = output.read_text(encoding="utf-8")
+            self.hygiene_checks += 1
+            try:
+                audit_generated_svg(generated)
+            except VerificationError as exc:
+                self.hygiene_failures.append(str(exc))
+                raise
+        return proc
+
+
+def require_success(proc: subprocess.CompletedProcess[str], context: str) -> None:
+    require(
+        proc.returncode == 0,
+        f"{context} exited {proc.returncode}: {proc.stderr.strip()}",
+    )
+
+
+def case_happy_paths(runner: CaptureRunner, tmp: Path) -> None:
+    del tmp
+    for variant, source in VARIANTS:
+        checked = runner.run("check", source)
+        require_success(checked, f"{variant} check")
+        digest = re.fullmatch(
+            r'ok source=(.+) viewBox="([^"]+)" dimensions=([^\s]+) '
+            r"sha256=([0-9a-f]{64})\n?",
+            checked.stdout,
+        )
+        require(digest is not None, f"{variant} check digest has the wrong shape")
+
+        extracted = runner.run("extract", source, "--stdout")
+        require_success(extracted, f"{variant} extract")
+        svg = extracted.stdout
+        require(svg.startswith(XML_DECLARATION), f"{variant} XML declaration is wrong")
+        try:
+            root = ET.fromstring(svg)
+        except ET.ParseError as exc:
+            raise VerificationError(f"{variant} extract is not well-formed XML: {exc}") from exc
+        source_viewbox = root_attributes(isolate_svg(source)).get("viewbox")
+        require(digest.group(1) == str(source), f"{variant} check reported wrong source")
+        require(digest.group(2) == source_viewbox, f"{variant} check reported wrong viewBox")
+        viewbox_numbers = [float(part) for part in str(source_viewbox).replace(",", " ").split()]
+        expected_dimensions = f"{viewbox_numbers[2]:g}x{viewbox_numbers[3]:g}"
+        require(
+            digest.group(3) == expected_dimensions,
+            f"{variant} check reported wrong dimensions",
+        )
+        require(digest.group(4) == sha256(source), f"{variant} check reported wrong SHA-256")
+        require(root.tag == f"{{{SVG_NAMESPACE}}}svg", f"{variant} root lacks SVG xmlns")
+        require(
+            root.attrib.get("viewBox") == source_viewbox,
+            f"{variant} extract changed viewBox",
+        )
+
+
+def case_verbatim_source(runner: CaptureRunner, tmp: Path) -> None:
+    del tmp
+    source = VARIANTS[0][1]
+    source_svg = isolate_svg(source)
+    text_match = re.search(r"<text\b[^>]*>[^<]{4,}</text>", source_svg, re.IGNORECASE)
+    path_match = re.search(r'<path\b[^>]*\bd="([^"]{24,})"', source_svg, re.IGNORECASE)
+    require(text_match is not None, "could not select a source text label")
+    require(path_match is not None, "could not select a source path fragment")
+    snippets = (text_match.group(0), f'd="{path_match.group(1)[:80]}')
+
+    proc = runner.run("extract", source, "--stdout")
+    require_success(proc, "verbatim-source extract")
+    for snippet in snippets:
+        require(snippet in proc.stdout, f"source SVG content was rewritten: {snippet!r}")
+
+
+def export_font_import() -> str:
+    spec = EXPORT_REF.read_text(encoding="utf-8")
+    require("## SVG export procedure" in spec, "export.md lacks SVG export procedure")
+    section = spec.split("## SVG export procedure", 1)[1].split("## PNG export procedure", 1)[0]
+    block = re.search(r"```svg\s*(.*?)\s*```", section, re.DOTALL)
+    require(block is not None, "export.md SVG procedure lacks its SVG snippet")
+    font_import = re.search(
+        r"(@import url\('https://fonts\.googleapis\.com/[^'\n]+'\);)",
+        block.group(1),
+    )
+    require(font_import is not None, "export.md SVG snippet lacks Google Fonts @import")
+    return font_import.group(1)
+
+
+def case_export_spec_parity(runner: CaptureRunner, tmp: Path) -> None:
+    source = VARIANTS[0][1]
+    source_svg = isolate_svg(source)
+    require(
+        len(re.findall(r"<defs(?=[\s>])", source_svg, re.IGNORECASE)) == 1,
+        "parity source must begin with exactly one existing defs block",
+    )
+    proc = runner.run("extract", source, "--stdout")
+    require_success(proc, "export-spec parity extract")
+    output = proc.stdout
+    font_import = export_font_import()
+    require(font_import in output, "extract output drifted from export.md font import")
+    require(
+        output.count(f"<style>{font_import}</style>") == 1,
+        "font import was not merged exactly once",
+    )
+    require(
+        len(re.findall(r"<defs(?=[\s>])", output, re.IGNORECASE)) == 1,
+        "extract added a duplicate defs block",
+    )
+    require(output.startswith(XML_DECLARATION), "export.md XML declaration is not honored")
+    opening = re.match(r"<svg\b[^>]*>", output[len(XML_DECLARATION) :], re.DOTALL)
+    require(opening is not None, "standalone output lacks an SVG opening tag")
+    require(
+        f'xmlns="{SVG_NAMESPACE}"' in opening.group(0),
+        "export.md xmlns requirement is not honored",
+    )
+
+    bare = tmp / "no-defs-or-xmlns.html"
+    bare.write_text(
+        '<svg viewBox="0 0 20 10" role="img" aria-labelledby="bare-title bare-desc">'
+        '<title id="bare-title">Bare diagram</title>'
+        '<desc id="bare-desc">No namespace or definitions block.</desc>'
+        '<rect width="20" height="10"/></svg>',
+        encoding="utf-8",
+    )
+    bare_proc = runner.run("extract", bare, "--stdout")
+    require_success(bare_proc, "missing-defs/missing-xmlns extract")
+    bare_output = bare_proc.stdout
+    bare_opening = re.match(
+        r"<svg\b[^>]*>", bare_output[len(XML_DECLARATION) :], re.DOTALL
+    )
+    require(bare_opening is not None, "normalized SVG lacks an opening tag")
+    require(
+        f'xmlns="{SVG_NAMESPACE}"' in bare_opening.group(0),
+        "extract did not add a missing SVG namespace",
+    )
+    require(bare_output.count(f"<style>{font_import}</style>") == 1, "new defs lost font style")
+    require(
+        bare_output.index("</desc>") < bare_output.index("<defs>") < bare_output.index("<rect"),
+        "new defs block was not inserted after title/desc",
+    )
+
+
+def case_nested_svg(runner: CaptureRunner, tmp: Path) -> None:
+    del tmp
+    source_svg = isolate_svg(FIXTURE)
+    proc = runner.run("extract", FIXTURE, "--stdout")
+    require_success(proc, "nested-SVG extract")
+    pattern = re.compile(r"<svg(?=[\s>/])", re.IGNORECASE)
+    require(
+        len(pattern.findall(source_svg)) == len(pattern.findall(proc.stdout)),
+        "nested SVG count changed during extraction",
+    )
+    require(len(pattern.findall(source_svg)) >= 4, "fixture lacks three nested icon SVGs")
+    try:
+        ET.fromstring(proc.stdout)
+    except ET.ParseError as exc:
+        raise VerificationError(f"nested-SVG extract is not well-formed XML: {exc}") from exc
+
+
+def raw_element(svg: str, tag: str) -> bytes:
+    match = re.search(
+        rf"<{tag}\b[^>]*>.*?</{tag}\s*>", svg, re.IGNORECASE | re.DOTALL
+    )
+    require(match is not None, f"SVG lacks <{tag}> element")
+    return match.group(0).encode("utf-8")
+
+
+def case_accessibility(runner: CaptureRunner, tmp: Path) -> None:
+    del tmp
+    for source in (FIXTURE, VARIANTS[0][1]):
+        source_svg = isolate_svg(source)
+        proc = runner.run("extract", source, "--stdout")
+        require_success(proc, f"{source.name} accessibility extract")
+        source_attrs = root_attributes(source_svg)
+        output_attrs = root_attributes(proc.stdout[len(XML_DECLARATION) :])
+        require(source_attrs.get("role") == "img", f"{source.name} lacks role=img")
+        require(
+            output_attrs.get("role") == source_attrs.get("role"),
+            f"{source.name} role changed during extract",
+        )
+        require(
+            output_attrs.get("aria-labelledby") == source_attrs.get("aria-labelledby"),
+            f"{source.name} aria-labelledby changed during extract",
+        )
+        for tag in ("title", "desc"):
+            require(
+                raw_element(proc.stdout, tag) == raw_element(source_svg, tag),
+                f"{source.name} {tag} element was not byte-identical",
+            )
+
+
+def case_path_edge(runner: CaptureRunner, tmp: Path) -> None:
+    folder = tmp / "über diagramm"
+    folder.mkdir()
+    source = folder / "mein plan.html"
+    shutil.copyfile(VARIANTS[0][1], source)
+    expected_output = source.with_suffix(".svg")
+    proc = runner.run("extract", source)
+    require_success(proc, "spaces/non-ASCII default extract")
+    require(expected_output.is_file(), "default extract did not write next to source")
+    require(f"source: {source}" in proc.stdout, "file digest omitted source")
+    require(f"output: {expected_output}" in proc.stdout, "file digest omitted output")
+    require("viewBox: " in proc.stdout, "file digest omitted viewBox")
+    require(f"source_sha256: {sha256(source)}" in proc.stdout, "file digest omitted SHA-256")
+
+    explicit_output = folder / "maßgeschneidert.svg"
+    explicit = runner.run("extract", source, "--out", str(explicit_output))
+    require_success(explicit, "explicit --out extract")
+    require(explicit_output.is_file(), "explicit --out path was not written")
+    require(f"output: {explicit_output}" in explicit.stdout, "explicit output digest is wrong")
+
+
+def write_svg_case(path: Path, body: str, viewbox: str | None = "0 0 20 10") -> None:
+    viewbox_attr = "" if viewbox is None else f' viewBox="{viewbox}"'
+    path.write_text(
+        f'<svg{viewbox_attr} xmlns="{SVG_NAMESPACE}">{body}</svg>',
+        encoding="utf-8",
+    )
+
+
+def case_errors(runner: CaptureRunner, tmp: Path) -> None:
+    errors = tmp / "errors"
+    errors.mkdir()
+    missing_svg = errors / "missing-svg.html"
+    missing_svg.write_text("<!doctype html><p>not a diagram</p>", encoding="utf-8")
+    siblings = errors / "two-siblings.html"
+    siblings.write_text(
+        '<svg viewBox="0 0 10 10"></svg><svg viewBox="0 0 10 10"></svg>',
+        encoding="utf-8",
+    )
+    missing_viewbox = errors / "missing-viewbox.html"
+    write_svg_case(missing_viewbox, "<rect width=\"10\" height=\"10\"/>", None)
+    malformed_viewbox = errors / "malformed-viewbox.html"
+    write_svg_case(malformed_viewbox, "<rect/>", "0 0 x 10")
+    nonpositive_viewbox = errors / "nonpositive-viewbox.html"
+    write_svg_case(nonpositive_viewbox, "<rect/>", "0 0 0 10")
+    script = errors / "script.html"
+    write_svg_case(script, "<script>alert(1)</script>")
+    handler = errors / "handler.html"
+    write_svg_case(handler, '<rect onclick="alert(1)"/>')
+    javascript_url = errors / "javascript-url.html"
+    write_svg_case(javascript_url, '<a href="javascript:alert(1)"><rect/></a>')
+    xml_unclean = errors / "xml-unclean.html"
+    write_svg_case(xml_unclean, "<text>A & B</text>")
+
+    cases = (
+        ("missing-svg", missing_svg, "no <svg>"),
+        ("gallery", GALLERY, "gallery source"),
+        ("siblings", siblings, "2 top-level <svg>"),
+        ("missing-viewbox", missing_viewbox, "missing a viewBox"),
+        ("malformed-viewbox", malformed_viewbox, "malformed viewBox"),
+        ("nonpositive-viewbox", nonpositive_viewbox, "positive width and height"),
+        ("script", script, "<script>"),
+        ("handler", handler, "event-handler"),
+        ("javascript-url", javascript_url, "javascript:"),
+        ("xml-unclean", xml_unclean, "not XML-clean"),
+    )
+    for name, source, cause in cases:
+        output = errors / f"{name}-must-not-exist.svg"
+        proc = runner.run("extract", source, "--out", str(output))
+        require(proc.returncode == 2, f"{name} exited {proc.returncode}, expected 2")
+        require(proc.stderr.startswith("figma_capture: "), f"{name} lacks error prefix")
+        require(cause.lower() in proc.stderr.lower(), f"{name} stderr does not name {cause}")
+        require(not output.exists(), f"{name} wrote an output file on failure")
+
+
+def case_external_references(runner: CaptureRunner, tmp: Path) -> None:
+    refs = tmp / "external-references"
+    refs.mkdir()
+    google = refs / "google-fonts.html"
+    write_svg_case(
+        google,
+        "<style>@import url('https://fonts.googleapis.com/css2?family=Geist');</style>"
+        '<rect width="20" height="10"/>',
+    )
+    other_font = refs / "other-font.html"
+    write_svg_case(
+        other_font,
+        "<style>@import url('https://other.example/css2?family=Geist');</style>",
+    )
+    other_image = refs / "other-image.html"
+    write_svg_case(other_image, '<image href="https://other.example/x.png"/>')
+    other_css_url = refs / "other-css-url.html"
+    write_svg_case(
+        other_css_url,
+        "<style>.remote { fill: url('https://other.example/fill.svg'); }</style>",
+    )
+    local_refs = refs / "local-refs.html"
+    write_svg_case(
+        local_refs,
+        '<defs><linearGradient id="grad"><stop offset="1"/></linearGradient>'
+        '<path id="shape" d="M0 0h1v1z"/></defs>'
+        '<use href="#shape"/><rect width="20" height="10" fill="url(#grad)"/>'
+        '<image href="data:image/png;base64,iVBORw0KGgo="/>',
+    )
+
+    for name, source in (("Google Fonts", google), ("fragment references", local_refs)):
+        proc = runner.run("check", source)
+        require_success(proc, f"{name} policy check")
+    for name, source, cause in (
+        ("other font host", other_font, "external @import host"),
+        ("other image host", other_image, "external href host"),
+        ("other CSS URL host", other_css_url, "external url() host"),
+    ):
+        proc = runner.run("check", source)
+        require(proc.returncode == 2, f"{name} unexpectedly passed")
+        require(cause in proc.stderr, f"{name} failure did not identify {cause}")
+
+
+def case_foreign_object(runner: CaptureRunner, tmp: Path) -> None:
+    proc = runner.run("check", MEDALLION)
+    require_success(proc, "medallion foreignObject check")
+    require("warning:" in proc.stderr, "medallion check omitted warning")
+    require("foreignObject" in proc.stderr, "medallion warning omitted foreignObject")
+
+    unsafe = tmp / "foreign-object-script.html"
+    write_svg_case(unsafe, "<foreignObject><script>alert(1)</script></foreignObject>")
+    proc = runner.run("check", unsafe)
+    require(proc.returncode == 2, "foreignObject with script unexpectedly passed")
+    require("<script>" in proc.stderr, "foreignObject script failure omitted cause")
+
+
+def case_source_integrity(runner: CaptureRunner, tmp: Path) -> None:
+    del tmp
+    require(runner.integrity_checks > 0, "no subprocess source hashes were checked")
+    require(
+        not runner.integrity_failures,
+        "source integrity failures: " + "; ".join(runner.integrity_failures),
+    )
+
+
+def case_hygiene(runner: CaptureRunner, tmp: Path) -> None:
+    del tmp
+    require(runner.hygiene_checks > 0, "no generated SVG outputs were audited")
+    require(
+        not runner.hygiene_failures,
+        "output hygiene failures: " + "; ".join(runner.hygiene_failures),
+    )
+
+
+def case_doc_pointers(runner: CaptureRunner, tmp: Path) -> None:
+    del runner, tmp
+    references: list[tuple[Path, str]] = []
+    target_re = re.compile(
+        r"^(?:\.\./)*commands/([A-Za-z0-9._-]+\.md)(?:#[^\s]*)?$"
+    )
+    for document in sorted(REFERENCES.glob("*.md")):
+        text = document.read_text(encoding="utf-8")
+        targets = re.findall(r"`([^`\n]+)`", text)
+        targets.extend(re.findall(r"\[[^\]]*\]\(([^)\s]+)\)", text))
+        for target in targets:
+            match = target_re.fullmatch(target.strip("<>"))
+            if match:
+                references.append((document, match.group(1)))
+    require(references, "no commands/<name>.md references were discovered")
+    missing = [
+        f"{document.name}: commands/{name}"
+        for document, name in references
+        if not (COMMANDS / name).is_file()
+    ]
+    require(not missing, "stale command pointers: " + ", ".join(missing))
+
+
+def main() -> int:
+    required = (CAPTURE, EXPORT_REF, FIXTURE, GALLERY, MEDALLION, *(path for _, path in VARIANTS))
+    missing = [str(path.relative_to(ROOT)) for path in required if not path.is_file()]
+    if missing:
+        print("FAIL: missing required artifacts: " + ", ".join(missing), file=sys.stderr)
+        return 1
+
+    cases = (
+        ("happy path across light/dark/full/terminal variants", case_happy_paths),
+        ("extract preserves distinctive source SVG content verbatim", case_verbatim_source),
+        ("extract stays in parity with export.md", case_export_spec_parity),
+        ("nested SVG fixture survives complete and well-formed", case_nested_svg),
+        ("accessibility metadata and title/desc survive byte-identically", case_accessibility),
+        ("spaces and non-ASCII paths support default output", case_path_edge),
+        ("invalid and active-content inputs fail without output", case_errors),
+        ("external-reference allowlist accepts and rejects correctly", case_external_references),
+        ("foreignObject warns while active content still fails", case_foreign_object),
+        ("every subprocess leaves its source byte-identical", case_source_integrity),
+        ("all generated SVGs pass path and secret hygiene", case_hygiene),
+        ("reference command pointers resolve at the repository root", case_doc_pointers),
+    )
+    runner = CaptureRunner()
+    failures = 0
+    with tempfile.TemporaryDirectory(prefix="diagram-design-figma-") as tmp_dir:
+        tmp = Path(tmp_dir)
+        for number, (label, check) in enumerate(cases, start=1):
+            try:
+                check(runner, tmp)
+            except VerificationError as exc:
+                failures += 1
+                print(f"FAIL {number}: {label}: {exc}", file=sys.stderr)
+            else:
+                print(f"PASS {number}: {label}")
+
+    if failures:
+        print(f"\n{failures} of {len(cases)} Figma export tooling cases failed.", file=sys.stderr)
+        return 1
+    print(f"\nAll {len(cases)} Figma export tooling cases passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/diagram-design/references/export.md
+++ b/skills/diagram-design/references/export.md
@@ -6,7 +6,7 @@ Convert a generated diagram HTML file into a portable `.svg` and/or `.png` next 
 
 Load this file when:
 
-- The user invokes `/diagram-design:export <html-file>` (the plugin's slash command — defined in `commands/export.md` at the repo root).
+- The user invokes `/diagram-design:export <html-file>` (the plugin's slash command — defined in `commands/export-diagram.md` at the repo root).
 - The user asks in natural language to export, save, rasterize, convert, or download a diagram in `.svg` or `.png` form. Typical phrasings:
   - "export this as PNG"
   - "save as SVG"
@@ -26,8 +26,18 @@ If the user explicitly asks for "a screenshot of the whole page including the ca
 
 ## SVG export procedure
 
+Run the shared extraction implementation:
+
+```
+python3 skills/diagram-design/scripts/figma_capture.py extract <src> [--stdout | --out PATH]
+```
+
+Without an output option, it validates the source and writes `<basename>.svg` next to it. Use `--out PATH` for an explicit destination or `--stdout` to emit the standalone SVG without writing a file.
+
+When running scripts isn't possible, use this manual fallback:
+
 1. Read the source HTML file.
-2. Extract the **first** `<svg ...>...</svg>` block. Use a multiline regex anchored on `<svg` and `</svg>`. Most generated diagrams have only one SVG; if there are multiple, the first is the diagram (gallery files are an exception — see *Edge cases*).
+2. Isolate the **first** complete `<svg ...>...</svg>` block with balanced, nested-aware tag parsing. Don't stop at the first `</svg>` — that truncates diagrams with nested SVGs, such as `example-datalake.html`. Most generated diagrams have only one SVG; if there are multiple, the first is the diagram (gallery files are an exception — see *Edge cases*).
 3. Make it standalone:
    - Ensure the opening tag has `xmlns="http://www.w3.org/2000/svg"`. Add it if missing.
    - Ensure a `viewBox` is present. The skill's templates always include one; warn the user if absent rather than guessing.
@@ -35,9 +45,10 @@ If the user explicitly asks for "a screenshot of the whole page including the ca
    - Inject Google Fonts `@import` so the SVG renders with correct typography in a browser:
      ```svg
      <defs>
-       <style>@import url('https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap');</style>
+       <style>@import url('https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&amp;family=Geist:wght@400;500;600&amp;family=Geist+Mono:wght@400;500;600&amp;display=swap');</style>
      </defs>
      ```
+     Escaping the ampersands as `&amp;` is required for the standalone file to be well-formed XML.
      If the SVG already contains a `<defs>` block, **merge** the `<style>` into it (don't add a second `<defs>`).
 4. Prepend `<?xml version="1.0" encoding="UTF-8"?>\n` so the file is well-formed XML.
 5. Write to `<basename>.svg` next to the source (e.g. `example-architecture.html` → `example-architecture.svg`). Honour an explicit output path if the user provides one.
@@ -125,6 +136,7 @@ If the target aspect ratio doesn't match the `viewBox` aspect ratio, say so and 
 
 - **Source is `assets/index.html`** (the gallery, multiple SVGs in one file): refuse the export and ask the user which specific diagram file they meant. Don't guess.
 - **No `<svg>` block found**: the source isn't a diagram file. Tell the user; don't write anything.
+- **Diagram contains `<foreignObject>`** (including the medallion examples): SVG export succeeds, but warn that import targets may render it with reduced fidelity.
 - **Surrounding HTML matters to the user**: they want cards/header in the image. Tell them this skill exports diagrams only, and recommend a browser-based full-page screenshot (or a separate PDF print).
 - **Source is missing fonts at runtime**: Playwright will substitute, the screenshot will look off. Check that the source HTML has the `<link href="...fonts.googleapis.com...">` tag in `<head>`. If absent, the file isn't from a current template — fix the source rather than working around it in export.
 

--- a/skills/diagram-design/scripts/figma_capture.py
+++ b/skills/diagram-design/scripts/figma_capture.py
@@ -1,0 +1,693 @@
+#!/usr/bin/env python3
+"""Validate diagram HTML and extract its SVG for Figma-oriented workflows.
+
+This branch-independent core isolates SVG markup with balanced-tag parsing,
+checks that it is safe and self-contained, and can write a standalone SVG
+without modifying the source HTML.  Future capture commands can be added as
+additional subcommands.
+
+Usage:
+    python3 figma_capture.py extract <src> [--stdout | --out PATH]
+    python3 figma_capture.py check <src>
+
+Exit codes: 0 ok, 2 unreadable / invalid input.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import math
+import re
+import sys
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import NoReturn
+from urllib.parse import urlsplit
+from xml.etree import ElementTree as ET
+
+# --------------------------------------------------------------------------
+# constants + errors
+# --------------------------------------------------------------------------
+
+MAX_INPUT_BYTES = 32 * 1024 * 1024
+SVG_NAMESPACE = "http://www.w3.org/2000/svg"
+FONT_IMPORT = (
+    "@import url('https://fonts.googleapis.com/css2?"
+    "family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&"
+    "family=Geist+Mono:wght@400;500;600&display=swap');"
+)
+FONT_IMPORT_XML = html.escape(FONT_IMPORT, quote=False)
+FONT_STYLE = f"<style>{FONT_IMPORT_XML}</style>"
+FONT_DEFS = f"<defs>{FONT_STYLE}</defs>"
+ALLOWED_EXTERNAL_HOSTS = frozenset(
+    {"fonts.googleapis.com", "fonts.gstatic.com"}
+)
+
+CSS_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+CSS_URL_RE = re.compile(
+    r"url\(\s*(?:\"(?P<double>[^\"]*)\"|'(?P<single>[^']*)'|"
+    r"(?P<bare>[^)]*?))\s*\)",
+    re.IGNORECASE | re.DOTALL,
+)
+CSS_IMPORT_RE = re.compile(
+    r"@import\s+(?P<target>"
+    r"url\(\s*(?:\"[^\"]*\"|'[^']*'|[^)]*?)\s*\)"
+    r"|\"[^\"]*\"|'[^']*'|[^\s;]+)",
+    re.IGNORECASE | re.DOTALL,
+)
+CSS_ESCAPE_RE = re.compile(r"\\(?:([0-9a-fA-F]{1,6})[ \t\r\n\f]?|([^\r\n\f]))")
+XMLNS_RE = re.compile(
+    r"(?P<prefix>\sxmlns\s*=\s*)"
+    r"(?P<value>\"[^\"]*\"|'[^']*'|[^\s>]+)"
+)
+
+
+def _fail(msg: str) -> NoReturn:
+    print(f"figma_capture: {msg}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def _warn(msg: str) -> None:
+    print(f"figma_capture: warning: {msg}", file=sys.stderr)
+
+
+@dataclass(frozen=True)
+class ViewBox:
+    raw: str
+    min_x: float
+    min_y: float
+    width: float
+    height: float
+
+
+@dataclass(frozen=True)
+class CheckedDiagram:
+    source: Path
+    source_sha256: str
+    svg: str
+    viewbox: ViewBox
+
+
+# --------------------------------------------------------------------------
+# balanced SVG isolation
+# --------------------------------------------------------------------------
+
+
+class SvgIsolationParser(HTMLParser):
+    """Locate top-level SVG spans while retaining source-text offsets."""
+
+    def __init__(self, source: str) -> None:
+        super().__init__(convert_charrefs=True)
+        self.source = source
+        self.line_starts = [0]
+        self.line_starts.extend(match.end() for match in re.finditer("\n", source))
+        self.svg_depth = 0
+        self.current_start: int | None = None
+        self.spans: list[tuple[int, int]] = []
+
+    def _offset(self) -> int:
+        line, column = self.getpos()
+        return self.line_starts[line - 1] + column
+
+    def _token_end(self, start: int) -> int:
+        end = self.source.find(">", start)
+        if end < 0:
+            raise ValueError("unterminated SVG tag")
+        return end + 1
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        del attrs
+        if tag.lower() != "svg":
+            return
+        if self.svg_depth == 0:
+            self.current_start = self._offset()
+        self.svg_depth += 1
+
+    def handle_startendtag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        del attrs
+        if tag.lower() == "svg" and self.svg_depth == 0:
+            start = self._offset()
+            self.spans.append((start, self._token_end(start)))
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() != "svg" or self.svg_depth == 0:
+            return
+        self.svg_depth -= 1
+        if self.svg_depth == 0:
+            if self.current_start is None:
+                raise ValueError("SVG nesting is inconsistent")
+            self.spans.append(
+                (self.current_start, self._token_end(self._offset()))
+            )
+            self.current_start = None
+
+
+def _is_gallery_path(path: Path) -> bool:
+    return path.name.lower() == "index.html" and path.parent.name.lower() == "assets"
+
+
+def _read_source(path: Path) -> tuple[bytes, str]:
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        _fail(f"{path}: cannot read source: {exc.strerror or exc}")
+    if not path.is_file():
+        _fail(f"{path}: not a regular file")
+    if size > MAX_INPUT_BYTES:
+        _fail(
+            f"{path.name}: input is {size} bytes; maximum is "
+            f"{MAX_INPUT_BYTES // (1024 * 1024)} MiB"
+        )
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        _fail(f"{path}: cannot read source: {exc.strerror or exc}")
+    try:
+        return data, data.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        _fail(f"{path}: source is not valid UTF-8: {exc}")
+
+
+def _isolate_svg(path: Path, source: str) -> str:
+    if _is_gallery_path(path):
+        _fail(f"{path}: gallery source is not a single diagram")
+
+    parser = SvgIsolationParser(source)
+    try:
+        parser.feed(source)
+        parser.close()
+    except (ValueError, AssertionError) as exc:
+        _fail(f"{path}: cannot parse HTML: {exc}")
+
+    if parser.svg_depth:
+        _fail(f"{path}: unterminated <svg> element")
+    if not parser.spans:
+        _fail(f"{path}: no <svg> element found")
+    if len(parser.spans) > 1:
+        _fail(
+            f"{path}: gallery source contains {len(parser.spans)} "
+            "top-level <svg> elements"
+        )
+    start, end = parser.spans[0]
+    return source[start:end]
+
+
+# --------------------------------------------------------------------------
+# SVG validation
+# --------------------------------------------------------------------------
+
+
+def _css_unescape(value: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        if match.group(1) is not None:
+            codepoint = int(match.group(1), 16)
+            if codepoint == 0 or codepoint > 0x10FFFF:
+                return "\ufffd"
+            return chr(codepoint)
+        return match.group(2) or ""
+
+    return CSS_ESCAPE_RE.sub(replace, value)
+
+
+def _compact_for_scheme(value: str) -> str:
+    decoded = html.unescape(_css_unescape(value)).strip()
+    return re.sub(r"[\x00-\x20\x7f]+", "", decoded)
+
+
+def _reference_error(
+    value: str, *, context: str, allow_data_image: bool
+) -> str | None:
+    reference = html.unescape(_css_unescape(value)).strip()
+    compact = _compact_for_scheme(reference)
+    lowered = compact.lower()
+
+    if lowered.startswith("javascript:"):
+        return f"active javascript: URL in {context}"
+    if reference.startswith("#"):
+        return None
+    if lowered.startswith("data:"):
+        if allow_data_image and lowered.startswith("data:image/"):
+            return None
+        return f"non-image data: URI in {context} is not allowed"
+
+    parsed = urlsplit(f"https:{reference}" if reference.startswith("//") else reference)
+    if parsed.scheme.lower() in {"http", "https"} and parsed.hostname:
+        host = parsed.hostname.lower().rstrip(".")
+        if host in ALLOWED_EXTERNAL_HOSTS:
+            return None
+        return f"external {context} host {host!r} is not allowed"
+    if parsed.scheme:
+        return f"external {context} scheme {parsed.scheme!r} is not allowed"
+    return f"external {context} reference {reference!r} is not allowed"
+
+
+def _css_url_value(match: re.Match[str]) -> str:
+    for name in ("double", "single", "bare"):
+        value = match.group(name)
+        if value is not None:
+            return value.strip()
+    return ""
+
+
+def _import_value(target: str) -> str:
+    target = target.strip()
+    if target.lower().startswith("url"):
+        match = CSS_URL_RE.fullmatch(target)
+        return _css_url_value(match) if match else target
+    if len(target) >= 2 and target[0] == target[-1] and target[0] in "\"'":
+        return target[1:-1]
+    return target
+
+
+def _audit_css(css: str, context: str) -> str | None:
+    css = _css_unescape(html.unescape(CSS_COMMENT_RE.sub("", css)))
+    compact = _compact_for_scheme(css).lower()
+    if "javascript:" in compact:
+        return f"active javascript: URL in {context}"
+
+    for match in CSS_IMPORT_RE.finditer(css):
+        error = _reference_error(
+            _import_value(match.group("target")),
+            context="@import",
+            allow_data_image=False,
+        )
+        if error:
+            return error
+    for match in CSS_URL_RE.finditer(css):
+        error = _reference_error(
+            _css_url_value(match), context="url()", allow_data_image=True
+        )
+        if error:
+            return error
+    return None
+
+
+class SvgAuditParser(HTMLParser):
+    """Collect the outer attributes and the first unsafe SVG construct."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.outer_attrs: list[tuple[str, str | None]] | None = None
+        self.error: str | None = None
+        self.has_foreign_object = False
+        self.style_depth = 0
+        self.style_parts: list[str] = []
+
+    def _record(self, message: str) -> None:
+        if self.error is None:
+            self.error = message
+
+    def _audit_tag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        lowered_tag = tag.lower()
+        if self.outer_attrs is None:
+            if lowered_tag != "svg":
+                self._record("extracted markup does not begin with <svg>")
+                return
+            self.outer_attrs = attrs
+
+        if lowered_tag == "script":
+            self._record("active <script> element is not allowed")
+        elif lowered_tag == "foreignobject":
+            self.has_foreign_object = True
+
+        for name, value in attrs:
+            lowered_name = name.lower()
+            if lowered_name.startswith("on"):
+                self._record(f"event-handler attribute {name!r} is not allowed")
+            if value is None:
+                continue
+            decoded_value = _css_unescape(html.unescape(value))
+            if _compact_for_scheme(value).lower().startswith("javascript:"):
+                self._record(f"active javascript: URL in attribute {name!r}")
+            if lowered_name in {"href", "xlink:href"}:
+                error = _reference_error(
+                    value,
+                    context=lowered_name,
+                    allow_data_image=lowered_tag in {"image", "feimage"},
+                )
+                if error:
+                    self._record(error)
+            attribute_css = CSS_COMMENT_RE.sub("", decoded_value)
+            for match in CSS_URL_RE.finditer(attribute_css):
+                error = _reference_error(
+                    _css_url_value(match), context="url()", allow_data_image=True
+                )
+                if error:
+                    self._record(error)
+            if lowered_name == "style":
+                error = _audit_css(value, "style attribute")
+                if error:
+                    self._record(error)
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        self._audit_tag(tag, attrs)
+        if tag.lower() == "style":
+            self.style_depth += 1
+
+    def handle_startendtag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        self._audit_tag(tag, attrs)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() == "style" and self.style_depth:
+            self.style_depth -= 1
+            if self.style_depth == 0:
+                error = _audit_css("".join(self.style_parts), "<style>")
+                if error:
+                    self._record(error)
+                self.style_parts.clear()
+
+    def handle_data(self, data: str) -> None:
+        if self.style_depth:
+            self.style_parts.append(data)
+
+    def finish(self) -> None:
+        if self.style_parts:
+            error = _audit_css("".join(self.style_parts), "<style>")
+            if error:
+                self._record(error)
+            self.style_parts.clear()
+
+
+def _parse_viewbox(attrs: list[tuple[str, str | None]]) -> ViewBox:
+    values = [value for name, value in attrs if name.lower() == "viewbox"]
+    if not values or values[0] is None:
+        _fail("diagram <svg> is missing a viewBox")
+    if len(values) > 1:
+        _fail("diagram <svg> has duplicate viewBox attributes")
+
+    raw = values[0]
+    assert raw is not None
+    parts = re.split(r"\s*,\s*|\s+", raw.strip())
+    if len(parts) != 4:
+        _fail(f"diagram <svg> has malformed viewBox {raw!r}; expected 4 numbers")
+    try:
+        numbers = tuple(float(part) for part in parts)
+    except ValueError:
+        _fail(f"diagram <svg> has malformed viewBox {raw!r}; expected 4 numbers")
+    if not all(math.isfinite(number) for number in numbers):
+        _fail(f"diagram <svg> has non-finite viewBox {raw!r}")
+    min_x, min_y, width, height = numbers
+    if width <= 0 or height <= 0:
+        _fail(
+            f"diagram <svg> viewBox must have positive width and height; got {raw!r}"
+        )
+    return ViewBox(raw, min_x, min_y, width, height)
+
+
+def _check_source(path: Path) -> CheckedDiagram:
+    data, source = _read_source(path)
+    svg = _isolate_svg(path, source)
+    parser = SvgAuditParser()
+    try:
+        parser.feed(svg)
+        parser.close()
+        parser.finish()
+    except (ValueError, AssertionError) as exc:
+        _fail(f"{path}: cannot parse extracted SVG: {exc}")
+    if parser.error:
+        _fail(f"{path}: {parser.error}")
+    if parser.outer_attrs is None:
+        _fail(f"{path}: no usable <svg> element found")
+    viewbox = _parse_viewbox(parser.outer_attrs)
+    if parser.has_foreign_object:
+        _warn(
+            f"{path}: <foreignObject> present — "
+            "Figma/import fidelity is not guaranteed"
+        )
+    return CheckedDiagram(path, hashlib.sha256(data).hexdigest(), svg, viewbox)
+
+
+# --------------------------------------------------------------------------
+# standalone SVG construction
+# --------------------------------------------------------------------------
+
+
+class SvgLayoutParser(HTMLParser):
+    """Find insertion points without re-serializing any source markup."""
+
+    def __init__(self, svg: str) -> None:
+        super().__init__(convert_charrefs=True)
+        self.svg = svg
+        self.line_starts = [0]
+        self.line_starts.extend(match.end() for match in re.finditer("\n", svg))
+        self.stack: list[str] = []
+        self.root_seen = False
+        self.root_self_closing = False
+        self.opening_end: int | None = None
+        self.first_defs: tuple[int, int, bool] | None = None
+        self.preamble_open = True
+        self.preamble_end: int | None = None
+
+    def _offset(self) -> int:
+        line, column = self.getpos()
+        return self.line_starts[line - 1] + column
+
+    def _raw_end(self) -> int:
+        raw = self.get_starttag_text()
+        if raw is None:
+            raise ValueError("cannot locate start tag")
+        return self._offset() + len(raw)
+
+    def _endtag_end(self) -> int:
+        end = self.svg.find(">", self._offset())
+        if end < 0:
+            raise ValueError("unterminated end tag")
+        return end + 1
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        del attrs
+        lowered = tag.lower()
+        start = self._offset()
+        end = self._raw_end()
+        if not self.root_seen:
+            self.root_seen = True
+            self.opening_end = end
+            self.stack.append(lowered)
+            return
+
+        direct_child = len(self.stack) == 1
+        if lowered == "defs" and self.first_defs is None:
+            self.first_defs = (start, end, False)
+        if direct_child and self.preamble_open and lowered not in {"title", "desc"}:
+            self.preamble_open = False
+        self.stack.append(lowered)
+
+    def handle_startendtag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        del attrs
+        lowered = tag.lower()
+        start = self._offset()
+        end = self._raw_end()
+        if not self.root_seen:
+            self.root_seen = True
+            self.root_self_closing = True
+            self.opening_end = end
+            return
+
+        direct_child = len(self.stack) == 1
+        if lowered == "defs" and self.first_defs is None:
+            self.first_defs = (start, end, True)
+        if direct_child and self.preamble_open:
+            if lowered in {"title", "desc"}:
+                self.preamble_end = end
+            else:
+                self.preamble_open = False
+
+    def handle_endtag(self, tag: str) -> None:
+        lowered = tag.lower()
+        if lowered in self.stack:
+            matching_index = len(self.stack) - 1 - self.stack[::-1].index(lowered)
+            direct_child = matching_index == 1
+            self.stack = self.stack[:matching_index]
+            if (
+                direct_child
+                and self.preamble_open
+                and lowered in {"title", "desc"}
+            ):
+                self.preamble_end = self._endtag_end()
+
+    def handle_data(self, data: str) -> None:
+        if self.root_seen and len(self.stack) == 1 and data.strip():
+            self.preamble_open = False
+
+
+def _ensure_xmlns(opening: str) -> str:
+    match = XMLNS_RE.search(opening)
+    if match:
+        value = match.group("value")
+        unquoted = value[1:-1] if value[:1] in {"\"", "'"} else value
+        if unquoted == SVG_NAMESPACE:
+            return opening
+        return opening[: match.start("value")] + f'"{SVG_NAMESPACE}"' + opening[match.end("value") :]
+
+    insert_at = len(opening) - 1
+    cursor = insert_at - 1
+    while cursor >= 0 and opening[cursor].isspace():
+        cursor -= 1
+    if cursor >= 0 and opening[cursor] == "/":
+        insert_at = cursor
+    return opening[:insert_at] + f' xmlns="{SVG_NAMESPACE}"' + opening[insert_at:]
+
+
+def _expand_self_closing(opening: str) -> str:
+    close = re.search(r"/\s*>$", opening)
+    if close is None:
+        return opening
+    return opening[: close.start()] + opening[close.start() + 1 :]
+
+
+def _standalone_svg(svg: str) -> str:
+    layout = SvgLayoutParser(svg)
+    try:
+        layout.feed(svg)
+        layout.close()
+    except (ValueError, AssertionError) as exc:
+        _fail(f"cannot prepare standalone SVG: {exc}")
+    if layout.opening_end is None:
+        _fail("cannot locate the diagram <svg> opening tag")
+
+    opening = _ensure_xmlns(svg[: layout.opening_end])
+    if layout.root_self_closing:
+        body = _expand_self_closing(opening) + FONT_DEFS + "</svg>"
+        return '<?xml version="1.0" encoding="UTF-8"?>\n' + body
+
+    body = opening + svg[layout.opening_end :]
+    opening_delta = len(opening) - layout.opening_end
+    if layout.first_defs is not None:
+        defs_start, defs_end, self_closing = layout.first_defs
+        defs_start += opening_delta
+        defs_end += opening_delta
+        if self_closing:
+            defs_open = _expand_self_closing(body[defs_start:defs_end])
+            body = (
+                body[:defs_start]
+                + defs_open
+                + FONT_STYLE
+                + "</defs>"
+                + body[defs_end:]
+            )
+        else:
+            body = body[:defs_end] + FONT_STYLE + body[defs_end:]
+    else:
+        insert_at = (
+            layout.preamble_end
+            if layout.preamble_end is not None
+            else layout.opening_end
+        )
+        insert_at += opening_delta
+        body = body[:insert_at] + FONT_DEFS + body[insert_at:]
+    return '<?xml version="1.0" encoding="UTF-8"?>\n' + body
+
+
+def _verify_xml_clean(svg: str, source: Path) -> None:
+    try:
+        ET.fromstring(svg)
+    except ET.ParseError as exc:
+        _fail(f"{source}: source SVG is not XML-clean: {exc}")
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def _format_number(number: float) -> str:
+    return f"{number:.15g}"
+
+
+def _run_check(args: argparse.Namespace) -> int:
+    diagram = _check_source(Path(args.src))
+    dimensions = (
+        f"{_format_number(diagram.viewbox.width)}x"
+        f"{_format_number(diagram.viewbox.height)}"
+    )
+    print(
+        f'ok source={diagram.source} viewBox="{diagram.viewbox.raw}" '
+        f"dimensions={dimensions} sha256={diagram.source_sha256}"
+    )
+    return 0
+
+
+def _write_stdout_bytes(data: bytes) -> None:
+    buffer = getattr(sys.stdout, "buffer", None)
+    if buffer is not None:
+        buffer.write(data)
+        buffer.flush()
+    else:  # Useful for callers that replace stdout with io.StringIO.
+        sys.stdout.write(data.decode("utf-8"))
+
+
+def _run_extract(args: argparse.Namespace) -> int:
+    diagram = _check_source(Path(args.src))
+    standalone = _standalone_svg(diagram.svg)
+    _verify_xml_clean(standalone, diagram.source)
+    output = standalone.encode("utf-8")
+    if args.stdout:
+        _write_stdout_bytes(output)
+        return 0
+
+    out_path = Path(args.out) if args.out else diagram.source.with_suffix(".svg")
+    same_file = out_path.resolve() == diagram.source.resolve()
+    try:
+        same_file = same_file or (out_path.exists() and out_path.samefile(diagram.source))
+    except OSError:
+        pass
+    if same_file:
+        _fail(f"output path {out_path} would overwrite the source HTML")
+    try:
+        out_path.write_bytes(output)
+    except OSError as exc:
+        _fail(f"{out_path}: cannot write output: {exc.strerror or exc}")
+    print(f"source: {diagram.source}")
+    print(f"output: {out_path}")
+    print(f"viewBox: {diagram.viewbox.raw}")
+    print(f"source_sha256: {diagram.source_sha256}")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    extract_parser = subparsers.add_parser(
+        "extract", help="validate diagram HTML and emit a standalone SVG"
+    )
+    extract_parser.add_argument("src", help="source diagram HTML file")
+    output_group = extract_parser.add_mutually_exclusive_group()
+    output_group.add_argument(
+        "--stdout", action="store_true", help="write only the SVG to stdout"
+    )
+    output_group.add_argument(
+        "--out", metavar="PATH", help="write SVG to PATH instead of next to source"
+    )
+    extract_parser.set_defaults(handler=_run_extract)
+
+    check_parser = subparsers.add_parser(
+        "check", help="validate diagram HTML without writing output"
+    )
+    check_parser.add_argument("src", help="source diagram HTML file")
+    check_parser.set_defaults(handler=_run_check)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Context

First slice of the [send-to-Figma plan](docs/plans/2026-08-12-001-feat-figma-code-to-canvas-export-plan.md) (eng-review cleared 2026-08-12). The plan's Phase 0 spike (U1) is a hard decision gate that needs live Figma MCP OAuth in both Claude Code and Codex plus a Full-seat account — not yet configured — so this PR ships only the work that is required in **both** spike outcomes. The Code to Canvas machinery (`build`/`serve`, `references/figma.md`, `commands/figma.md`, `prompts/figma.md`, README/manifest packaging) stays deferred until the spike runs and the branch decision is written into the plan.

## What shipped

- **`skills/diagram-design/scripts/figma_capture.py`** — stdlib-only `extract` + `check` subcommands (plan U2 partial, decisions 4A/T1/6A). Balanced-tag `html.parser` isolation preserves the nine shipped nested-SVG examples that first-`</svg>` regex extraction truncates. `check` validates viewBox (4 finite numbers, positive dimensions), refuses galleries, `<script>`, event handlers, `javascript:` URLs, and any external `url()`/`@import`/`href` outside the two Google Fonts hosts; `foreignObject` warns (the medallion examples are legitimate) while active content inside it still rejects. Extract output is standalone, well-formed XML — the fonts `@import` is injected with `&amp;` escaping and verified with `ET.fromstring` before writing. Sources are never modified (R3, hash-proven).
- **`skills/diagram-design/references/export.md`** (plan U5, decision 5A) — the SVG procedure now delegates to `extract` with the prose kept as the no-script fallback; fixes the stale `commands/export.md` pointer; corrects a latent XML bug in the doc's own `@import` snippet (raw `&` is a fatal parse error in a standalone SVG).
- **`scripts/verify-figma-export.py` + `scripts/fixtures/sample-nested-svg.html` + CI step** (plan U3 partial, decision 7A) — 12 case families pinning every shipped behavior, including the CRITICAL extract-vs-export.md parity regression guard and the repo-wide reference→command pointer-resolution check. Wired into the existing 3-OS × 2-Python matrix with a summary-table row.

## Test evidence

- `verify-figma-export.py`: 12/12 green locally; deliberate mutations fail it (stale pointer → case 12; re-introduced first-`</svg>` truncation → case 4).
- Full 94-asset corpus sweep: `check` + `extract` + strict XML parse + source-hash integrity, zero failures; warnings on exactly the three medallion variants.
- All 10 existing CI verification gates green locally after the change.

## Out of scope / follow-ups

- U1 spike (mechanics gate + fidelity bake-off) and the branch decision — blocked on Figma MCP setup.
- `build`/`serve` subcommands, agent workflow surfaces (U4), packaging/release 2.3.0 (U6).
- Live acceptance matrix and fleet installs — post-spike, per the plan's release sequencing.