### PR TITLE
Fix first-run style gate: check the tokens actually shipped

### DIFF
--- a/skills/diagram-design/SKILL.md
+++ b/skills/diagram-design/SKILL.md
@@ -20,9 +20,9 @@ Twenty-seven visual types. Semantic patterns describe behavior independently; ty
 
 Don't silently ship default-skinned diagrams into a branded project.
 
-Open [`references/style-guide.md`](references/style-guide.md) and check the default tokens. If they're still the shipped defaults (paper `#faf7f2`, ink `#1c1917`, accent `#b5523a` rust), **pause and ask the user**:
+Open [`references/style-guide.md`](references/style-guide.md) and check the default tokens. If they're still the shipped defaults (paper `#f5f5f5`, ink `#2d3142`, accent `#eb6c36` atomic-tangerine), **pause and ask the user**:
 
-> *"This is your first Schematic in this project. The style guide is still at the default (neutral stone + rust). Do you want to customize it to match your brand first? Options: (a) pull from your website URL, (b) extract from an installed skill, (c) extract from a local folder / design-system directory, (d) paste tokens manually, (e) proceed with the default for now."*
+> *"This is your first Schematic in this project. The style guide is still at the default (neutral white-smoke + atomic-tangerine). Do you want to customize it to match your brand first? Options: (a) pull from your website URL, (b) extract from an installed skill, (c) extract from a local folder / design-system directory, (d) paste tokens manually, (e) proceed with the default for now."*
 
 Then branch:
 
@@ -32,7 +32,7 @@ Then branch:
 - **(d)** → accept the user's tokens and write them into `style-guide.md` under a new "Custom tokens" section.
 - **(e)** → proceed; optionally remind the user they can run onboarding later.
 
-**Once the style guide has been customized** (or the user explicitly opted for default), skip this gate on subsequent runs. A simple way to detect customization: if the `accent` value in `style-guide.md` differs from `#b5523a`, assume custom.
+**Once the style guide has been customized** (or the user explicitly opted for default), skip this gate on subsequent runs. A simple way to detect customization: if the `accent` value in `style-guide.md` differs from `#eb6c36`, assume custom.
 
 ---
 


### PR DESCRIPTION
## The problem

`SKILL.md` §0 gates the first diagram in a project on whether the style guide is still at defaults. It checks for paper `#faf7f2`, ink `#1c1917`, accent `#b5523a` rust.

`references/style-guide.md` currently ships paper `#f5f5f5`, ink `#2d3142`, accent `#eb6c36` atomic-tangerine.

The detection heuristic in the same section reads: *if the `accent` value in `style-guide.md` differs from `#b5523a`, assume custom.*

On a fresh install the accent is `#eb6c36`, which differs from `#b5523a` — so the gate concludes the user already customized, and skips permanently. It never fires.

That leaves the failure mode the section itself names — "Don't silently ship default-skinned diagrams into a branded project" — unguarded on every new install.

## The fix

Three hex values and one prose skin name, updated to match what `style-guide.md` ships today. No other behavior change.

## Verification

Full CI suite run locally (macOS, Python 3.13) against this branch — a11y contract, semantic motion markdown and example, mojibake tests, mermaid import, drawio import, sequence oauth, and `lint-skin.py --all --baseline`. All pass.

Found while auditing v2.3 before installing the skill for client-facing work. The gate not firing was the first thing we hit.

Happy to add a regression check asserting the §0 hexes match the style-guide table, if you'd want that guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
