### PR TITLE
docs: unify product naming — diagram/diagram-design instead of Schematic

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, or DP security matrix diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, or DP security matrix diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/skills/diagram-design/SKILL.md
+++ b/skills/diagram-design/SKILL.md
@@ -22,7 +22,7 @@ Don't silently ship default-skinned diagrams into a branded project.
 
 Open [`references/style-guide.md`](references/style-guide.md) and check the default tokens. If they're still the shipped defaults (paper `#f5f5f5`, ink `#2d3142`, accent `#eb6c36` atomic-tangerine), **pause and ask the user**:
 
-> *"This is your first Schematic in this project. The style guide is still at the default (neutral white-smoke + atomic-tangerine). Do you want to customize it to match your brand first? Options: (a) pull from your website URL, (b) extract from an installed skill, (c) extract from a local folder / design-system directory, (d) paste tokens manually, (e) proceed with the default for now."*
+> *"This is your first diagram in this project. The style guide is still at the default (neutral white-smoke + atomic-tangerine). Do you want to customize it to match your brand first? Options: (a) pull from your website URL, (b) extract from an installed skill, (c) extract from a local folder / design-system directory, (d) paste tokens manually, (e) proceed with the default for now."*
 
 Then branch:
 

--- a/skills/diagram-design/references/onboarding.md
+++ b/skills/diagram-design/references/onboarding.md
@@ -38,7 +38,7 @@ future diagrams use your tokens
 
 ### Invocation
 
-> *"Onboard Schematic to my site — `https://example.com`"*
+> *"Onboard diagram-design to my site — `https://example.com`"*
 
 ---
 
@@ -111,7 +111,7 @@ Before writing, validate:
 
 - **AA contrast**: `ink` on `paper` ≥ 4.5:1. `muted` on `paper` ≥ 4.5:1 for body text.
 - **Accent is the most saturated color**: not muted-ish, not near-grey.
-- **paper ≠ pure white**: if the site uses `#ffffff`, fall back to `#fafaf7` to preserve Schematic's warm-neutral feel — or ask the user to confirm pure-white is intentional.
+- **paper ≠ pure white**: if the site uses `#ffffff`, fall back to `#fafaf7` to preserve Diagram Design's warm-neutral feel — or ask the user to confirm pure-white is intentional.
 
 If any check fails, propose an adjusted value and explain why.
 
@@ -170,7 +170,7 @@ Extract tokens from an installed Agent Skill that carries its own design system 
 
 ### Invocation
 
-> *"Onboard Schematic from my `acme-design` skill"*
+> *"Onboard diagram-design from my `acme-design` skill"*
 
 Or the gate offers this as option (b) and the user names the skill.
 
@@ -243,7 +243,7 @@ Extract tokens from a local directory — a checked-out design system repo, a Fi
 
 ### Invocation
 
-> *"Onboard Schematic from my design system at `~/projects/brand/design-tokens/`"*
+> *"Onboard diagram-design from my design system at `~/projects/brand/design-tokens/`"*
 
 Or the gate offers this as option (c) and the user provides the path.
 

--- a/skills/diagram-design/references/style-guide.md
+++ b/skills/diagram-design/references/style-guide.md
@@ -1,6 +1,6 @@
 # Style Guide
 
-**The single source of truth for colors, typography, and tokens.** Every diagram draws from this — not from hex values inlined in other reference files. If you want to change the visual skin of Schematic, change this file.
+**The single source of truth for colors, typography, and tokens.** Every diagram draws from this — not from hex values inlined in other reference files. If you want to change the visual skin of Diagram Design, change this file.
 
 Default skin is a cool editorial palette — white-smoke paper, jet-black ink, atomic-tangerine accent, blue-slate muted. It's designed to look good out of the box; swap these values (or run [`onboarding.md`](onboarding.md)) and every new diagram inherits the new skin without touching any type-specific logic.
 


### PR DESCRIPTION
## What does this PR do?

Unifies product naming across the docs: replacement of the drive-time internal name **"Schematic"** with the public brand **"diagram" / "Diagram Design" / "diagram-design"** wherever it appears as the product's *name*, so the docs match the README and the distributed plugin branding.

This is a pure documentation change — the third drift class already tracked by `verify-docs-sync.py`, closed here for the noun-level inconsistency (that verifier covers structure; this covers wording):

- `skills/diagram-design/SKILL.md` — first-run gate dialog now reads *"This is your first diagram in this project"* (the README's First-run gate section already said "diagram"; SKILL.md was the odd one out).
- `skills/diagram-design/references/style-guide.md` — *"change the visual skin of Diagram Design"* instead of "...of Schematic".
- `skills/diagram-design/references/onboarding.md` — user-facing invocation examples now say *"Onboard diagram-design to/from …"* and *"Diagram Design's warm-neutral feel"*.

**What is deliberately left as-is:**
- The common noun `schematic(s)` in the sense of "wiring/circuit diagram" (`output-spec.md`, SKILL.md philosophy/anti-patterns, "schematic defaults/grammar" in onboarding.md) — it is a meaningful word there, not the product name.
- In-diagram example content under `assets/` (e.g. "Schematic skill" labels) — that is screenshot content predating the rename, out of scope for a docs PR.

Per CONTRIBUTING.md, this docs-only PR still bumps the distributed plugin package: `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` → **2.3.3** (via `scripts/bump-plugin-version.py`).

## Validation gates

All gates from the CONTRIBUTING.md table were run locally and pass (Python 3.14 local, CI is 3.11/3.12 matrix — pure-stdlib scripts, no platform-specific behavior touched):

- [x] `python3 scripts/test-plugin-package.py`
- [x] `python3 scripts/verify-plugin-package.py upstream/main` — **OK: Claude and Codex 2.3.3, marketplace paths, packaged skill**
- [x] `claude plugin validate . --strict` — validation passed
- [x] `python3 scripts/test-lint-a11y.py`
- [x] `python3 scripts/verify-semantic-motion.py --markdown-only`
- [x] `python3 scripts/verify-semantic-motion.py --example-only`
- [x] `python3 scripts/verify-motion.py --shipped`
- [x] `python3 scripts/lint-skin.py --all --baseline` — 100 file(s) checked, 20 skipped, 0 findings
- [x] `python3 scripts/verify-sequence-oauth.py`
- [x] `python3 scripts/verify-drawio-import.py`
- [x] `python3 scripts/verify-mermaid-import.py`
- [x] `python3 scripts/test-verify-motion.py`
- [x] `python3 scripts/verify-docs-sync.py`
- [x] `python3 scripts/test-self-check.py`
- [x] `python3 scripts/verify-geometry.py --all` — 102 file(s) checked, 0 findings
- [x] `python3 scripts/test-verify-geometry.py`
- [x] `git diff --exit-code` green after `python3 scripts/build-icons.py` (icons unchanged, up to date)

## Checklist

- [x] No new entries added to `scripts/lint-skin-baseline.txt`
- [x] Generated and source files are consistent
- [x] Accessible SVG contract satisfied (no example/template touched)
- [x] Plugin version bumped (2.3.3) and both manifests synchronized
- [x] Conventional Commits: `docs:` scope for the rename, `chore:` for the version bump
- [x] Code of Conduct respected

## Related issues

None — small, self-contained docs fix per the CONTRIBUTING.md guidance ("Small fixes and docs can go straight to a PR").