### PR TITLE
docs(readme): add Trendshift badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Editorial diagrams your designer won't hate.**
 
+<a href="https://trendshift.io/repositories/26141?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-26141" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/repositories/26141" alt="cathrynlavery%2Fdiagram-design | Trendshift" width="250" height="55"/></a>
+
 ![Content site architecture](docs/screenshots/architecture.png)
 
 ![The self-improving loop](docs/screenshots/loop.png)


### PR DESCRIPTION
## What does this PR do?

Adds the project's Trendshift badge (repository ID 26141) to the top of the README, just below the tagline, linking to the diagram-design page on trendshift.io. Documentation-only change; no code, skin, or import behavior is affected.

## Validation gates

<!-- Docs-only change (README badge). No code/skin/import/icon behavior changed, so the build and verifier gates below are not applicable. -->

- [ ] `python3 scripts/test-lint-a11y.py`
- [ ] `python3 scripts/lint-skin.py --all --baseline`
- [ ] `python3 scripts/verify-sequence-oauth.py`
- [ ] `python3 scripts/verify-drawio-import.py`
- [ ] `python3 scripts/verify-mermaid-import.py`
- [ ] `git diff --exit-code` green after `python3 scripts/build-icons.py` (if icons changed)
- [x] Docs updated in the same PR where behavior changed

## Checklist

- [x] No new entries added to `scripts/lint-skin-baseline.txt`
- [x] Generated and source files are consistent (extractor ↔ verifier ↔ reference ↔ command)
- [x] Accessible SVG contract satisfied for new/changed examples
- [x] Code of Conduct respected

## Related issues

<!-- None. -->
