### PR TITLE
fix(lint): enforce viewBox presence and title length cap

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, or DP security matrix diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"
@@ -23,3 +23,4 @@
     "semantic-patterns"
   ]
 }
+

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, or DP security matrix diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"
@@ -42,3 +42,4 @@
     "brandColor": "#b5523a"
   }
 }
+

--- a/scripts/lint-skin.py
+++ b/scripts/lint-skin.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import math
 import re
 import sys
 from dataclasses import dataclass, field
@@ -353,12 +354,16 @@ def lint_accessible_svgs(text, expected_slug, allow_template_placeholders=False)
         if not viewbox:
             add(svg.line, svg.offset, "diagram <svg> must have a viewBox attribute")
         else:
-            parts = viewbox.split()
+            parts = re.split(r"[\s,]+", viewbox.strip())
             valid = False
             if len(parts) == 4:
                 try:
                     nums = [float(p) for p in parts]
-                    valid = nums[2] > 0 and nums[3] > 0
+                    valid = (
+                        all(math.isfinite(n) for n in nums)
+                        and nums[2] > 0
+                        and nums[3] > 0
+                    )
                 except ValueError:
                     pass
             if not valid:

--- a/scripts/lint-skin.py
+++ b/scripts/lint-skin.py
@@ -356,7 +356,8 @@ def lint_accessible_svgs(text, expected_slug, allow_template_placeholders=False)
         else:
             parts = re.split(r"[\s,]+", viewbox.strip())
             valid = False
-            if len(parts) == 4:
+            _svg_num_re = re.compile(r"^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$")
+            if len(parts) == 4 and all(_svg_num_re.match(p) for p in parts):
                 try:
                     nums = [float(p) for p in parts]
                     valid = (

--- a/scripts/lint-skin.py
+++ b/scripts/lint-skin.py
@@ -349,6 +349,25 @@ def lint_accessible_svgs(text, expected_slug, allow_template_placeholders=False)
         if (svg.attrs.get("role") or "").casefold() != "img":
             add(svg.line, svg.offset, 'diagram <svg> must carry role="img"')
 
+        viewbox = svg.attrs.get("viewbox")  # HTMLParser lowercases all attribute names
+        if not viewbox:
+            add(svg.line, svg.offset, "diagram <svg> must have a viewBox attribute")
+        else:
+            parts = viewbox.split()
+            valid = False
+            if len(parts) == 4:
+                try:
+                    nums = [float(p) for p in parts]
+                    valid = nums[2] > 0 and nums[3] > 0
+                except ValueError:
+                    pass
+            if not valid:
+                add(
+                    svg.line,
+                    svg.offset,
+                    f'viewBox "{viewbox}" is not valid (expected "min-x min-y width height" with positive size)',
+                )
+
         labelled_by = (svg.attrs.get("aria-labelledby") or "").split()
         accessible_name_ids = labelled_by + [
             element.element_id
@@ -402,8 +421,15 @@ def lint_accessible_svgs(text, expected_slug, allow_template_placeholders=False)
                     title.offset,
                     "<title> must be the first child element of <svg>",
                 )
-            if not "".join(title.text).strip():
+            title_text = "".join(title.text).strip()
+            if not title_text:
                 add(title.line, title.offset, "<title> must not be empty")
+            elif len(title_text) > 60:
+                add(
+                    title.line,
+                    title.offset,
+                    f"<title> must be 60 characters or fewer (got {len(title_text)})",
+                )
 
         if description is None:
             add(svg.line, svg.offset, "diagram <svg> must contain a <desc>")

--- a/scripts/test-lint-a11y.py
+++ b/scripts/test-lint-a11y.py
@@ -18,7 +18,7 @@ BUILD_ICONS = ROOT / "scripts/build-icons.py"
 MOTION_TEMPLATE = ROOT / "skills/diagram-design/assets/template-motion.html"
 
 VALID_SVG = """\
-<svg xmlns="http://www.w3.org/2000/svg" role="img"
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" role="img"
      aria-labelledby="fixture-title fixture-desc">
   <title id="fixture-title">Fixture diagram</title>
   <desc id="fixture-desc">Diagram showing a fixture connected to a result.</desc>
@@ -154,6 +154,24 @@ def main() -> int:
             "duplicate-naming-ids",
             VALID_SVG + VALID_SVG,
             'duplicate accessible-name id="fixture-desc" is not allowed',
+            directory,
+        )
+        require_failure(
+            "missing-viewbox",
+            VALID_SVG.replace(' viewBox="0 0 800 600"', ""),
+            "diagram <svg> must have a viewBox attribute",
+            directory,
+        )
+        require_failure(
+            "invalid-viewbox",
+            VALID_SVG.replace('viewBox="0 0 800 600"', 'viewBox="0 0 -10 100"'),
+            'viewBox "0 0 -10 100" is not valid (expected "min-x min-y width height" with positive size)',
+            directory,
+        )
+        require_failure(
+            "title-too-long",
+            VALID_SVG.replace("Fixture diagram", "A" * 61),
+            "<title> must be 60 characters or fewer (got 61)",
             directory,
         )
         require_pass(

--- a/scripts/test-lint-a11y.py
+++ b/scripts/test-lint-a11y.py
@@ -197,6 +197,14 @@ def main() -> int:
             'viewBox "0 0 800 inf" is not valid (expected "min-x min-y width height" with positive size)',
             directory,
         )
+        require_failure(
+            "viewbox-underscore-width",
+            VALID_SVG.replace('viewBox="0 0 800 600"', 'viewBox="0 0 1_000 600"').replace(
+                "fixture-title", "viewbox-underscore-width-title"
+            ).replace("fixture-desc", "viewbox-underscore-width-desc"),
+            'viewBox "0 0 1_000 600" is not valid (expected "min-x min-y width height" with positive size)',
+            directory,
+        )
         require_pass(
             "decorative",
             '<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true">'

--- a/scripts/test-lint-a11y.py
+++ b/scripts/test-lint-a11y.py
@@ -175,6 +175,29 @@ def main() -> int:
             directory,
         )
         require_pass(
+            "viewbox-comma-separated",
+            VALID_SVG.replace('viewBox="0 0 800 600"', 'viewBox="0,0,800,600"').replace(
+                "fixture-title", "viewbox-comma-separated-title"
+            ).replace("fixture-desc", "viewbox-comma-separated-desc"),
+            directory,
+        )
+        require_failure(
+            "viewbox-nonfinite-width",
+            VALID_SVG.replace('viewBox="0 0 800 600"', 'viewBox="0 0 inf 600"').replace(
+                "fixture-title", "viewbox-nonfinite-width-title"
+            ).replace("fixture-desc", "viewbox-nonfinite-width-desc"),
+            'viewBox "0 0 inf 600" is not valid (expected "min-x min-y width height" with positive size)',
+            directory,
+        )
+        require_failure(
+            "viewbox-nonfinite-height",
+            VALID_SVG.replace('viewBox="0 0 800 600"', 'viewBox="0 0 800 inf"').replace(
+                "fixture-title", "viewbox-nonfinite-height-title"
+            ).replace("fixture-desc", "viewbox-nonfinite-height-desc"),
+            'viewBox "0 0 800 inf" is not valid (expected "min-x min-y width height" with positive size)',
+            directory,
+        )
+        require_pass(
             "decorative",
             '<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true">'
             '<path d="M0 0h1v1z"/></svg>\n',


### PR DESCRIPTION
## What this changes and why

Two accessibility rules are documented in `CONTRIBUTING.md` but were never
enforced by `scripts/lint-skin.py`. This PR closes both gaps.

### 1. `viewBox` validation
Every non-decorative `<svg>` must carry a `viewBox` attribute. Without it
the diagram cannot scale correctly in different containers, and coordinate
systems used by `verify-geometry.py` become unreliable. The check requires:
- the `viewBox` attribute to be present
- exactly four numeric tokens (`min-x min-y width height`)
- positive width and height values

### 2. `<title>` length cap (60 characters)
`CONTRIBUTING.md` already states: "`<title>` is the short subject name
(≈ the `<h1>`, ≤ 60 chars)". The linter checked that `<title>` was
non-empty but never enforced the length limit. This PR enforces it.

---

## Files changed

| File | Change |
|---|---|
| `scripts/lint-skin.py` | Added `viewBox` check and title length check inside `lint_accessible_svgs()` |
| `scripts/test-lint-a11y.py` | Updated `VALID_SVG` to include `viewBox`; added 3 adversarial cases |

---

## New adversarial test cases

| Test name | What it catches |
|---|---|
| `missing-viewbox` | `<svg>` with no `viewBox` attribute |
| `invalid-viewbox` | `viewBox` with negative dimensions (e.g. `"0 0 -10 100"`) |
| `title-too-long` | `<title>` text exceeding 60 characters |

---

## Gates run

- `python3 scripts/test-lint-a11y.py` — **47/47 OK** (including all 3 new cases)
- `python3 scripts/lint-skin.py --all --baseline` — **0 findings across 102 files**

All 102 shipped examples already have valid `viewBox` attributes and
titles within 60 characters, so no example files needed to change.

---

## Notes for reviewers

- `HTMLParser` lowercases all attribute names, so `viewBox` in source HTML
  is accessed as `svg.attrs.get("viewbox")` — this matches the existing
  pattern used throughout `AccessibleSvgParser`.
- Error messages are pure ASCII to avoid Windows stdout encoding issues
  with `cp1252` (the `≤` glyph was replaced with "60 characters or fewer").
- The `viewBox` check only applies to non-decorative SVGs
  (`aria-hidden="true"` SVGs remain exempt, consistent with all other
  checks in `lint_accessible_svgs()`).

Closes #68