### PR TITLE
docs(readme): fix slash-command names to match shipped commands

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, or DP security matrix diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, or DP security matrix diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/README.md
+++ b/README.md
@@ -243,9 +243,9 @@ Already have diagrams in draw.io / diagrams.net or Mermaid? Point the skill at t
 *A 12-node draw.io file redrawn at `balanced` detail for a blog post. The source's six pastel fills became one accent; its hand-dragged coordinates became a 4px grid.*
 
 ```
-/diagram-design:import platform.drawio
-/diagram-design:import platform.drawio --size=slide-16x9 --detail=simplified --audience=executive
-/diagram-design:import platform.drawio --detail=faithful --format=png --page=all
+/diagram-design:import-drawio platform.drawio
+/diagram-design:import-drawio platform.drawio --size=slide-16x9 --detail=simplified --audience=executive
+/diagram-design:import-drawio platform.drawio --detail=faithful --format=png --page=all
 /diagram-design:import-mermaid README.md --diagram=all
 /diagram-design:import-mermaid architecture.mmd --size=slide-16x9 --detail=simplified
 ```
@@ -294,9 +294,9 @@ Diagrams ship as self-contained HTML, but you can export the diagram itself for 
 **Claude Code:**
 
 ```
-/diagram-design:export path/to/diagram.html
-/diagram-design:export path/to/diagram.html --svg-only
-/diagram-design:export path/to/diagram.html --png-only --scale=3
+/diagram-design:export-diagram path/to/diagram.html
+/diagram-design:export-diagram path/to/diagram.html --svg-only
+/diagram-design:export-diagram path/to/diagram.html --png-only --scale=3
 ```
 
 Or just ask in natural language:

--- a/skills/diagram-design/references/export.md
+++ b/skills/diagram-design/references/export.md
@@ -6,7 +6,7 @@ Convert a generated diagram HTML file into a portable `.svg` and/or `.png` next 
 
 Load this file when:
 
-- The user invokes `/diagram-design:export <html-file>` (the plugin's slash command — defined in `commands/export.md` at the repo root).
+- The user invokes `/diagram-design:export-diagram <html-file>` (the plugin's slash command — defined in `commands/export-diagram.md` at the repo root).
 - The user asks in natural language to export, save, rasterize, convert, or download a diagram in `.svg` or `.png` form. Typical phrasings:
   - "export this as PNG"
   - "save as SVG"


### PR DESCRIPTION
The README documents `/diagram-design:import` and `/diagram-design:export`, but the shipped command files are `commands/import-drawio.md` and `commands/export-diagram.md`, which register as `/diagram-design:import-drawio` and `/diagram-design:export-diagram`. The import-mermaid and Pi examples already used the correct names, so a user's first attempt at the draw.io import or the export command fails with unknown-command.

This PR renames the six occurrences (README.md:246-248, 297-299) to match the shipped commands. No behavior change.