### PR TITLE
docs(high-level): correct effective width checklist

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, or DP security matrix diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, or DP security matrix diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/scripts/test-verify-docs-sync.py
+++ b/scripts/test-verify-docs-sync.py
@@ -12,6 +12,37 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 VERIFY = ROOT / "scripts" / "verify-docs-sync.py"
 
+HIGH_LEVEL_REFERENCE = """\
+## 2. Layout formulas — deterministic geometry
+
+### 2.1 Canvas
+
+```
+has_vertical       = any(c.vertical for c in chevrons)
+right_strip_w      = 28  if has_vertical else 0
+strip_margin       = 8   if has_vertical else 0
+effective_w        = 1000 - right_strip_w - strip_margin
+```
+
+## 7. Reproducibility checklist (the taste gate)
+
+1. Check one.
+2. Check two.
+3. If a vertical chevron exists, `effective_w = 964`; otherwise, `effective_w = 1000`.
+4. Check four.
+5. Check five.
+6. Check six.
+7. Check seven.
+8. Check eight.
+9. Check nine.
+10. Check ten.
+11. Check eleven.
+12. Check twelve.
+13. Check thirteen.
+
+## 8. Anti-patterns
+"""
+
 
 def load_verify_module():
     sys.dont_write_bytecode = True
@@ -90,8 +121,37 @@ def main() -> int:
         if errors != [expected]:
             raise AssertionError(f"stale Pi prompt was not reported: {errors}")
 
+        errors = []
+        verify.check_high_level_reference(errors, HIGH_LEVEL_REFERENCE)
+        if errors:
+            raise AssertionError(f"valid High-Level reference failed: {errors}")
+
+        errors = []
+        verify.check_high_level_reference(
+            errors,
+            HIGH_LEVEL_REFERENCE.replace("effective_w = 964", "effective_w = 972", 1),
+        )
+        expected = (
+            "High-Level checklist item 3 has effective_w=972; "
+            "expected 1000 - 28 - 8 = 964"
+        )
+        if errors != [expected]:
+            raise AssertionError(f"stale effective width was not reported: {errors}")
+
+        errors = []
+        verify.check_high_level_reference(
+            errors,
+            HIGH_LEVEL_REFERENCE.replace("13. Check thirteen.", "11. Check thirteen."),
+        )
+        expected = (
+            "High-Level reproducibility checklist numbering is not sequential: "
+            "expected 1..13, found 1,2,3,4,5,6,7,8,9,10,11,12,11"
+        )
+        if errors != [expected]:
+            raise AssertionError(f"duplicate checklist number was not reported: {errors}")
+
     print(
-        "PASS: docs sync checks reference links and Claude/Pi profile-surface parity"
+        "PASS: docs sync checks references, profile surfaces, and High-Level invariants"
     )
     return 0
 

--- a/scripts/verify-docs-sync.py
+++ b/scripts/verify-docs-sync.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Verify that routing and browsing surfaces stay in sync with the skill.
 
-Five drift classes, each of which has shipped before:
+Seven drift classes, each of which has shipped before:
 
 1. The SKILL.md frontmatter description is the only text an agent sees before
    deciding to load the skill — every visual type in the selection table must
@@ -15,6 +15,8 @@ Five drift classes, each of which has shipped before:
    text a user reads *before installing*, so by ADR 0004's own argument they
    need every type's lexical hook too - and nothing else notices when they
    drift, because they are four separate copies of one sentence.
+7. The High-Level reproducibility checklist must agree with its canvas formula
+   and retain sequential numbering.
 """
 
 from __future__ import annotations
@@ -29,6 +31,7 @@ SKILL = ROOT / "skills/diagram-design/SKILL.md"
 GALLERY = ROOT / "skills/diagram-design/assets/index.html"
 ASSET_DIR = ROOT / "skills/diagram-design/assets"
 README = ROOT / "README.md"
+HIGH_LEVEL_REFERENCE = ROOT / "skills/diagram-design/references/type-high-level.md"
 VARIANTS = ("", "-dark", "-full")
 # Types whose selection-table name differs from its description vocabulary.
 DESCRIPTION_ALIASES = {
@@ -156,6 +159,54 @@ def check_profile_surfaces(errors: list[str], root: Path) -> None:
             )
 
 
+def check_high_level_reference(errors: list[str], markdown: str) -> None:
+    width_formula = re.search(
+        r"^effective_w\s*=\s*(\d+)\s*-\s*right_strip_w\s*-\s*strip_margin",
+        markdown,
+        re.MULTILINE,
+    )
+    right_strip = re.search(r"^right_strip_w\s*=\s*(\d+)\s+if", markdown, re.MULTILINE)
+    strip_margin = re.search(r"^strip_margin\s*=\s*(\d+)\s+if", markdown, re.MULTILINE)
+    if not all((width_formula, right_strip, strip_margin)):
+        errors.append("High-Level canvas is missing the effective-width formula")
+        return
+
+    checklist = re.search(
+        r"^## 7\. Reproducibility checklist[^\n]*\n(.*?)(?=^## |\Z)",
+        markdown,
+        re.MULTILINE | re.DOTALL,
+    )
+    if checklist is None:
+        errors.append("High-Level reproducibility checklist is missing")
+        return
+
+    items = re.findall(r"^(\d+)\.\s+(.+)$", checklist.group(1), re.MULTILINE)
+    numbers = [int(number) for number, _ in items]
+    expected_numbers = list(range(1, len(numbers) + 1))
+    if numbers != expected_numbers:
+        rendered = ",".join(str(number) for number in numbers)
+        errors.append(
+            "High-Level reproducibility checklist numbering is not sequential: "
+            f"expected 1..{len(numbers)}, found {rendered}"
+        )
+
+    item_three = next((text for number, text in items if number == "3"), "")
+    checklist_width = re.search(r"effective_w\s*=\s*(\d+)", item_three)
+    expected_width = (
+        int(width_formula.group(1))
+        - int(right_strip.group(1))
+        - int(strip_margin.group(1))
+    )
+    if checklist_width is None:
+        errors.append("High-Level checklist item 3 is missing effective_w")
+    elif int(checklist_width.group(1)) != expected_width:
+        errors.append(
+            f"High-Level checklist item 3 has effective_w={checklist_width.group(1)}; "
+            f"expected {width_formula.group(1)} - {right_strip.group(1)} - "
+            f"{strip_margin.group(1)} = {expected_width}"
+        )
+
+
 MANIFEST_DESCRIPTIONS = (
     (Path(".claude-plugin/plugin.json"), ("description",)),
     (Path(".claude-plugin/marketplace.json"), ("description",)),
@@ -220,6 +271,7 @@ def main() -> int:
         SKILL.parent,
     )
     check_profile_surfaces(errors, ROOT)
+    check_high_level_reference(errors, HIGH_LEVEL_REFERENCE.read_text(encoding="utf-8"))
     if errors:
         print("FAIL docs sync")
         for error in errors:
@@ -227,7 +279,7 @@ def main() -> int:
         return 1
     print(
         "OK docs sync: description hooks, gallery reachability, README tree, "
-        "reference links, profile surfaces, manifest descriptions"
+        "reference links, profile surfaces, manifest descriptions, High-Level invariants"
     )
     return 0
 

--- a/skills/diagram-design/references/type-high-level.md
+++ b/skills/diagram-design/references/type-high-level.md
@@ -420,7 +420,7 @@ Before emitting SVG, verify **every** item. If any fails, fix it — don't ship.
 
 1. Every cluster `node.cx` equals its chevron's `cx` (§2.2 + §2.7). This is what makes the chevron banner a real legend.
 2. Every chevron `width` is a multiple of 4 and ≥ 120.
-3. The reserved right strip (28 px) exists **iff** any vertical chevron is declared. If yes, `effective_w = 972`; if no, `effective_w = 1000`.
+3. The reserved right strip (28 px) exists **iff** any vertical chevron is declared. If yes, `effective_w = 964`; if no, `effective_w = 1000`.
 4. Exactly **one** `focal` node. If `focal` is unset in inputs, default to the first `kind: node` under chevron "Storage".
 5. Every edge whose endpoint is the focal node uses `style: primary` (accent stroke + `arrow-accent` marker).
 6. Every edge originating from a `kind: bar` component uses `style: trigger` (dashed + `arrow-sm`).
@@ -430,7 +430,7 @@ Before emitting SVG, verify **every** item. If any fails, fix it — don't ship.
 10. Each vertical chevron pairs **1:1** with exactly one `bar` or `cross-cutting` component (§5 pairing rule). `len(verticals) == len(bars) + len(crosscuts)`.
 11. `viewBox_h = max(540, strip_y_bot + 112)` — grow the canvas when multiple crosscuts are declared so the legend still fits.
 12. Custom component colors (§3.4) apply only to container + icon + name; connectors stay topology-driven. Cap at 2 custom-colored components in addition to the focal.
-11. The diagram passes SKILL.md §9 (4-px grid; ≤ 2 accent elements; mono only for technical content; hairlines; no shadows; no `rounded-2xl`).
+13. The diagram passes SKILL.md §9 (4-px grid; ≤ 2 accent elements; mono only for technical content; hairlines; no shadows; no `rounded-2xl`).
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Fixes two contradictions in the High-Level reproducibility checklist: `effective_w` is corrected from `972` to `964` when the 28 px vertical strip and 8 px strip margin are reserved (`1000 - 28 - 8`), matching §§2.1 and 5; the duplicated final item number is corrected from `11` to `13`.

Bumps both plugin manifests from `2.5.1` to `2.5.2` for the package version gate.

## Validation gates

- [x] `python3 scripts/test-lint-a11y.py`
- [x] `python3 scripts/lint-skin.py --all --baseline`
- [x] `python3 scripts/verify-sequence-oauth.py`
- [x] `python3 scripts/verify-drawio-import.py`
- [x] `python3 scripts/verify-mermaid-import.py`
- [x] `git diff --ignore-space-at-eol --exit-code` green after `python3 scripts/build-icons.py`
- [x] Docs updated in the same PR where behavior changed
- [x] Plugin package/version, strict Claude validation, docs sync, semantic motion, geometry, motion, self-check, and treemap gates pass

## Checklist

- [x] No new entries added to `scripts/lint-skin-baseline.txt`
- [x] Generated and source files are consistent (extractor ↔ verifier ↔ reference ↔ command)
- [x] Accessible SVG contract satisfied for new/changed examples (no examples changed)
- [x] Code of Conduct respected

## Related issues

No issue filed; this is a standalone documentation consistency fix.