### PR TITLE
fix(drawio): keep import command reference in sync

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, or DP security matrix diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.5.2",
+  "version": "2.5.4",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, or DP security matrix diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.5.2",
+  "version": "2.5.4",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,9 @@ jobs:
       - name: Verify draw.io import script
         if: always()
         id: drawio
-        run: python scripts/verify-drawio-import.py
+        run: |
+          python scripts/verify-drawio-import.py
+          python scripts/test-verify-drawio-import.py
 
       - name: Verify Mermaid import script
         if: always()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ The helper refuses to run if the Claude and Codex versions already differ. If an
 | Skin conformance of every example and template (colors, fonts, a11y, assets, scripts) | `python3 scripts/lint-skin.py --all --baseline` |
 | A single file, e.g. a new example | `python3 scripts/lint-skin.py skills/diagram-design/assets/example-my-type.html` |
 | Sequence-doc consistency (ATL fragments, budgets) | `python3 scripts/verify-sequence-oauth.py` |
-| draw.io import path (real extractor vs fixtures + docs sync) | `python3 scripts/verify-drawio-import.py` |
+| draw.io import path (real extractor vs fixtures + docs sync) | `python3 scripts/verify-drawio-import.py && python3 scripts/test-verify-drawio-import.py` |
 | Mermaid import path (grammars, adversarial input, caps, docs sync) | `python3 scripts/verify-mermaid-import.py` |
 | Optional motion contract (fallbacks, controls, budgets, determinism) | `python3 scripts/test-verify-motion.py` |
 | Every shipped motion template/example | `python3 scripts/verify-motion.py --shipped` |
@@ -75,6 +75,7 @@ python3 scripts/test-plugin-package.py \
   && python3 scripts/lint-skin.py --all --baseline \
   && python3 scripts/verify-sequence-oauth.py \
   && python3 scripts/verify-drawio-import.py \
+  && python3 scripts/test-verify-drawio-import.py \
   && python3 scripts/verify-mermaid-import.py \
   && python3 scripts/test-verify-motion.py \
   && python3 scripts/verify-docs-sync.py \

--- a/scripts/test-verify-drawio-import.py
+++ b/scripts/test-verify-drawio-import.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Regression tests for the draw.io import verifier."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+REFERENCE = Path("skills/diagram-design/references/import-drawio.md")
+VERIFIER = Path("scripts/verify-drawio-import.py")
+
+
+def run_verifier(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(root / VERIFIER)],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="diagram-design-drawio-test-") as tmp_dir:
+        clone = Path(tmp_dir) / "repo"
+        shutil.copytree(
+            ROOT,
+            clone,
+            ignore=shutil.ignore_patterns(".git", "__pycache__"),
+        )
+
+        reference = clone / REFERENCE
+        stale_name = "/diagram-design:import"
+        valid_name = "/diagram-design:import-drawio"
+        text = reference.read_text(encoding="utf-8")
+        if valid_name not in text:
+            raise AssertionError("test fixture lacks the valid slash name")
+
+        valid = run_verifier(clone)
+        if valid.returncode != 0:
+            raise AssertionError(
+                f"valid slash command failed verification:\n{valid.stdout}\n{valid.stderr}"
+            )
+
+        reference.write_text(text.replace(valid_name, stale_name), encoding="utf-8")
+        stale = run_verifier(clone)
+        if stale.returncode == 0:
+            raise AssertionError("stale slash command unexpectedly passed verification")
+        if "slash command" not in stale.stderr:
+            raise AssertionError(
+                f"stale slash command lacked a focused diagnostic:\n{stale.stderr}"
+            )
+
+    print("OK: draw.io verifier rejects a stale slash command name")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-drawio-import.py
+++ b/scripts/verify-drawio-import.py
@@ -341,6 +341,16 @@ def check_security_and_limits(tmp: Path) -> None:
 
 def check_docs() -> None:
     import_text = IMPORT_REF.read_text(encoding="utf-8")
+    expected_slash_command = f"/diagram-design:{COMMAND.stem}"
+    documented_slash_commands = set(
+        re.findall(r"`(/diagram-design:[a-z0-9-]+)`", import_text)
+    )
+    if documented_slash_commands != {expected_slash_command}:
+        rendered = ", ".join(sorted(documented_slash_commands)) or "none"
+        fail(
+            "import-drawio.md slash command does not match "
+            f"{COMMAND.name}: expected {expected_slash_command}, found {rendered}"
+        )
     for needle in (
         "drawio_extract.py",
         "output-spec.md",

--- a/skills/diagram-design/references/import-drawio.md
+++ b/skills/diagram-design/references/import-drawio.md
@@ -6,7 +6,7 @@ Turn a `.drawio` file into an editorial-quality diagram at the format, size, and
 
 ## Trigger
 
-Load this file when the user points at a `.drawio`, `.drawio.xml`, `.drawio.png`, or `.drawio.svg` file and wants a diagram out of it — "convert this drawio", "redraw this diagram", "make this presentable", "この drawio をきれいにして", or the `/diagram-design:import` slash command.
+Load this file when the user points at a `.drawio`, `.drawio.xml`, `.drawio.png`, or `.drawio.svg` file and wants a diagram out of it — "convert this drawio", "redraw this diagram", "make this presentable", "この drawio をきれいにして", or the `/diagram-design:import-drawio` slash command.
 
 ---
 


### PR DESCRIPTION
## Problem

`skills/diagram-design/references/import-drawio.md` advertised `/diagram-design:import`, but the shipped command is `commands/import-drawio.md`, registered as `/diagram-design:import-drawio`. The existing verifier reported the slash command was consistent without checking its name.

Fixes #90.

## Approach

- correct the documented slash command;
- derive the expected slash name from the shipped command filename and require the reference to contain exactly that command;
- add an end-to-end adversarial regression that proves a stale command name is rejected;
- run that regression in CI and document it in the local complete-suite instructions;
- bump the synchronized Claude/Codex manifests from `2.5.2` to the currently unused `2.5.4`.

## Security and risk

Risk is low: the production change reads checked-in Markdown and compares bounded command-name strings. It adds no permissions, network access, secret access, or shell execution. Bandit reported zero medium/high findings; its low findings were fixed-argument `subprocess.run` calls with `shell=False` in the existing verifier/test pattern.

## TDD evidence

- **RED:** `python3 scripts/test-verify-drawio-import.py` exited 1 on the original behavior: `AssertionError: stale slash command unexpectedly passed verification`.
- **GREEN:** the same regression and `python3 scripts/verify-drawio-import.py` both passed after the fix.
- **Sabotage:** temporarily removing the new synchronization check made the regression exit 1 with the same assertion; restoring it returned GREEN.
- **Independent review:** one documentation drift finding was fixed; final re-review found no remaining correctness, security, portability, scope, or test issues.

## Validation

- complete repository-local CI-equivalent suite passed;
- `python3 scripts/verify-plugin-package.py origin/main` passed at synchronized version `2.5.4`;
- `npx --yes @anthropic-ai/claude-code@2.1.229 plugin validate . --strict` passed;
- `uvx --from bandit bandit -q -r scripts/verify-drawio-import.py scripts/test-verify-drawio-import.py`: zero medium/high findings;
- generated icon diff gate passed; `git diff --check` clean.
