### PR TITLE
fix(import): emit extractor output as UTF-8 on Windows

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.5.12",
+  "version": "2.5.15",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.5.11",
+  "version": "2.5.12",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.5.12",
+  "version": "2.5.15",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.5.11",
+  "version": "2.5.12",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/scripts/verify-drawio-import.py
+++ b/scripts/verify-drawio-import.py
@@ -10,7 +10,9 @@ Exit 0 only when all gates pass. Intended for local/PR checks alongside:
 from __future__ import annotations
 
 import base64
+import contextlib
 import importlib.util
+import io
 import json
 import os
 import re
@@ -99,6 +101,23 @@ def check_legacy_stdout_encoding(tmp: Path) -> None:
     )
     if file_process.returncode != 0 or destination.read_text(encoding="utf-8") != output:
         fail("draw.io --out no longer matches its UTF-8 stdout digest")
+
+    class CallerOwnedStdout(io.StringIO):
+        def __init__(self) -> None:
+            super().__init__()
+            self.reconfigured = False
+
+        def reconfigure(self, **_kwargs: object) -> None:
+            self.reconfigured = True
+
+    caller_stdout = CallerOwnedStdout()
+    extractor = load_extractor_module()
+    with contextlib.redirect_stdout(caller_stdout):
+        result = extractor.main([str(source)])
+    if result != 0 or caller_stdout.reconfigured:
+        fail("imported draw.io main() reconfigured its caller-owned stdout")
+    if "登录" not in caller_stdout.getvalue():
+        fail("imported draw.io main() did not write to its caller-owned stdout")
     ok("draw.io stdout stays lossless UTF-8 under a legacy Windows encoding")
 
 

--- a/scripts/verify-drawio-import.py
+++ b/scripts/verify-drawio-import.py
@@ -46,6 +46,10 @@ def ok(msg: str) -> None:
     print(f"OK: {msg}")
 
 
+def normalize_newlines(text: str) -> str:
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
 def run_extract(args: list[str]) -> str:
     proc = subprocess.run(
         [sys.executable, str(EXTRACT), *args],
@@ -99,7 +103,10 @@ def check_legacy_stdout_encoding(tmp: Path) -> None:
         stderr=subprocess.PIPE,
         env=env,
     )
-    if file_process.returncode != 0 or destination.read_text(encoding="utf-8") != output:
+    if file_process.returncode != 0:
+        fail("draw.io --out failed under a legacy Windows encoding")
+    file_output = destination.read_text(encoding="utf-8")
+    if normalize_newlines(file_output) != normalize_newlines(output):
         fail("draw.io --out no longer matches its UTF-8 stdout digest")
 
     class CallerOwnedStdout(io.StringIO):

--- a/scripts/verify-drawio-import.py
+++ b/scripts/verify-drawio-import.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import base64
 import importlib.util
 import json
+import os
 import re
 import struct
 import subprocess
@@ -54,6 +55,51 @@ def run_extract(args: list[str]) -> str:
     if proc.returncode != 0:
         fail(f"extractor exited {proc.returncode} for {args}: {proc.stderr.strip()}")
     return proc.stdout
+
+
+def check_legacy_stdout_encoding(tmp: Path) -> None:
+    source = tmp / "unicode-stdout.drawio"
+    source.write_text(
+        """<mxfile><diagram name="日本語">
+<mxGraphModel><root><mxCell id="0"/><mxCell id="1" parent="0"/>
+<mxCell id="2" value="登录&lt;br&gt;続行 ⇒ résumé" vertex="1" parent="1">
+<mxGeometry x="0" y="0" width="120" height="60" as="geometry"/>
+</mxCell></root></mxGraphModel></diagram></mxfile>""",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "cp1252"
+    env["PYTHONUTF8"] = "0"
+    process = subprocess.run(
+        [sys.executable, str(EXTRACT), str(source)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    if process.returncode != 0:
+        fail(
+            "draw.io extractor failed with legacy stdout encoding: "
+            + process.stderr.decode("utf-8", errors="replace").strip()
+        )
+    try:
+        output = process.stdout.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as error:
+        fail(f"draw.io extractor did not emit UTF-8 stdout: {error}")
+    for needle in ("日本語", "登录", "続行 ⇒ résumé", "⏎"):
+        if needle not in output:
+            fail(f"UTF-8 draw.io digest lost {needle!r}: {output!r}")
+    if "�" in output:
+        fail("UTF-8 draw.io digest contains a replacement character")
+    destination = tmp / "unicode-stdout.md"
+    file_process = subprocess.run(
+        [sys.executable, str(EXTRACT), str(source), "--out", str(destination)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    if file_process.returncode != 0 or destination.read_text(encoding="utf-8") != output:
+        fail("draw.io --out no longer matches its UTF-8 stdout digest")
+    ok("draw.io stdout stays lossless UTF-8 under a legacy Windows encoding")
 
 
 def load_extractor_module():
@@ -443,6 +489,7 @@ def main() -> int:
         check_files()
         check_parse_raw()
         check_containers(tmp)
+        check_legacy_stdout_encoding(tmp)
         check_digest_escaping(tmp)
         check_security_and_limits(tmp)
         check_docs()

--- a/scripts/verify-mermaid-import.py
+++ b/scripts/verify-mermaid-import.py
@@ -41,6 +41,10 @@ def ok(message: str) -> None:
     print(f"OK: {message}")
 
 
+def normalize_newlines(text: str) -> str:
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
 def invoke(args: list[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, str(EXTRACT), *args],
@@ -97,7 +101,10 @@ def check_legacy_stdout_encoding(tmp: Path) -> None:
         stderr=subprocess.PIPE,
         env=env,
     )
-    if file_process.returncode != 0 or destination.read_text(encoding="utf-8") != output:
+    if file_process.returncode != 0:
+        fail("Mermaid --out failed under a legacy Windows encoding")
+    file_output = destination.read_text(encoding="utf-8")
+    if normalize_newlines(file_output) != normalize_newlines(output):
         fail("Mermaid --out no longer matches its UTF-8 stdout digest")
 
     class CallerOwnedStdout(io.StringIO):

--- a/scripts/verify-mermaid-import.py
+++ b/scripts/verify-mermaid-import.py
@@ -8,7 +8,9 @@ command wiring. Exit 0 only when every gate passes.
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
 import json
 import os
 import subprocess
@@ -97,6 +99,23 @@ def check_legacy_stdout_encoding(tmp: Path) -> None:
     )
     if file_process.returncode != 0 or destination.read_text(encoding="utf-8") != output:
         fail("Mermaid --out no longer matches its UTF-8 stdout digest")
+
+    class CallerOwnedStdout(io.StringIO):
+        def __init__(self) -> None:
+            super().__init__()
+            self.reconfigured = False
+
+        def reconfigure(self, **_kwargs: object) -> None:
+            self.reconfigured = True
+
+    caller_stdout = CallerOwnedStdout()
+    extractor = load_extractor_module()
+    with contextlib.redirect_stdout(caller_stdout):
+        result = extractor.main([str(source)])
+    if result != 0 or caller_stdout.reconfigured:
+        fail("imported Mermaid main() reconfigured its caller-owned stdout")
+    if "登录" not in caller_stdout.getvalue():
+        fail("imported Mermaid main() did not write to its caller-owned stdout")
     ok("Mermaid stdout stays lossless UTF-8 under a legacy Windows encoding")
 
 

--- a/scripts/verify-mermaid-import.py
+++ b/scripts/verify-mermaid-import.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -56,6 +57,47 @@ def run_extract(args: list[str]) -> str:
             f"{process.stderr.strip()}"
         )
     return process.stdout
+
+
+def check_legacy_stdout_encoding(tmp: Path) -> None:
+    source = tmp / "unicode-stdout.mmd"
+    source.write_text(
+        'flowchart TD\nA["登录<br/>続行 ⇒"] --> B["résumé"]\n',
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "cp1252"
+    env["PYTHONUTF8"] = "0"
+    process = subprocess.run(
+        [sys.executable, str(EXTRACT), str(source)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    if process.returncode != 0:
+        fail(
+            "Mermaid extractor failed with legacy stdout encoding: "
+            + process.stderr.decode("utf-8", errors="replace").strip()
+        )
+    try:
+        output = process.stdout.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as error:
+        fail(f"Mermaid extractor did not emit UTF-8 stdout: {error}")
+    for needle in ("登录", "続行 ⇒", "résumé", "⏎"):
+        if needle not in output:
+            fail(f"UTF-8 Mermaid digest lost {needle!r}: {output!r}")
+    if "�" in output:
+        fail("UTF-8 Mermaid digest contains a replacement character")
+    destination = tmp / "unicode-stdout.md"
+    file_process = subprocess.run(
+        [sys.executable, str(EXTRACT), str(source), "--out", str(destination)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    if file_process.returncode != 0 or destination.read_text(encoding="utf-8") != output:
+        fail("Mermaid --out no longer matches its UTF-8 stdout digest")
+    ok("Mermaid stdout stays lossless UTF-8 under a legacy Windows encoding")
 
 
 def expect_error(args: list[str], message: str) -> None:
@@ -708,6 +750,7 @@ def main() -> int:
         check_shape_and_edge_vocabulary(tmp)
         check_frontmatter(tmp)
         check_markdown_and_grammars(tmp)
+        check_legacy_stdout_encoding(tmp)
         check_sequence_grammar_forms(tmp)
         check_adversarial(tmp)
         check_errors_and_limits(tmp)

--- a/skills/diagram-design/scripts/drawio_extract.py
+++ b/skills/diagram-design/scripts/drawio_extract.py
@@ -854,7 +854,6 @@ def select_pages(pages: list[Page], selector: str | None) -> list[Page]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    _configure_stdout_utf8()
     parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     parser.add_argument("file", help=".drawio / .xml / .drawio.png / .drawio.svg")
     parser.add_argument(
@@ -894,4 +893,5 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
+    _configure_stdout_utf8()
     raise SystemExit(main())

--- a/skills/diagram-design/scripts/drawio_extract.py
+++ b/skills/diagram-design/scripts/drawio_extract.py
@@ -43,6 +43,13 @@ MAX_INPUT_BYTES = 32 * 1024 * 1024
 MAX_XML_BYTES = 64 * 1024 * 1024
 
 
+def _configure_stdout_utf8() -> None:
+    """Emit digests as UTF-8 even when Windows selects a legacy codepage."""
+    reconfigure = getattr(sys.stdout, "reconfigure", None)
+    if reconfigure is not None:
+        reconfigure(encoding="utf-8", errors="strict")
+
+
 class PayloadTooLarge(ValueError):
     """Raised when compressed metadata expands beyond the supported limit."""
 
@@ -847,6 +854,7 @@ def select_pages(pages: list[Page], selector: str | None) -> list[Page]:
 
 
 def main(argv: list[str] | None = None) -> int:
+    _configure_stdout_utf8()
     parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     parser.add_argument("file", help=".drawio / .xml / .drawio.png / .drawio.svg")
     parser.add_argument(

--- a/skills/diagram-design/scripts/mermaid_extract.py
+++ b/skills/diagram-design/scripts/mermaid_extract.py
@@ -51,6 +51,13 @@ MARKDOWN_SUFFIXES = {".md", ".markdown", ".mdown", ".mkd"}
 MERMAID_SUFFIXES = {".mmd", ".mermaid"}
 
 
+def _configure_stdout_utf8() -> None:
+    """Emit digests as UTF-8 even when Windows selects a legacy codepage."""
+    reconfigure = getattr(sys.stdout, "reconfigure", None)
+    if reconfigure is not None:
+        reconfigure(encoding="utf-8", errors="strict")
+
+
 def _fail(message: str) -> NoReturn:
     print(f"mermaid_extract: {message}", file=sys.stderr)
     raise SystemExit(2)
@@ -1282,6 +1289,7 @@ def select_diagrams(diagrams: list[Diagram], selector: str | None) -> list[Diagr
 
 
 def main(argv: list[str] | None = None) -> int:
+    _configure_stdout_utf8()
     parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     parser.add_argument("file", help=".mmd, .mermaid, or Markdown with mermaid fences")
     parser.add_argument(

--- a/skills/diagram-design/scripts/mermaid_extract.py
+++ b/skills/diagram-design/scripts/mermaid_extract.py
@@ -1289,7 +1289,6 @@ def select_diagrams(diagrams: list[Diagram], selector: str | None) -> list[Diagr
 
 
 def main(argv: list[str] | None = None) -> int:
-    _configure_stdout_utf8()
     parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     parser.add_argument("file", help=".mmd, .mermaid, or Markdown with mermaid fences")
     parser.add_argument(
@@ -1330,4 +1329,5 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
+    _configure_stdout_utf8()
     raise SystemExit(main())


### PR DESCRIPTION
## Summary

- configure Mermaid and draw.io CLI stdout as strict UTF-8
- preserve non-ASCII labels under legacy Windows console encodings
- keep imported main() callers from mutating caller-owned stdout
- add cp1252 subprocess regressions and cross-platform `--out` parity checks for both extractors
- bump synchronized Claude, Codex, and Factory manifests to 2.5.15

## Validation

- `python3 scripts/verify-mermaid-import.py`
- `python3 scripts/verify-drawio-import.py`
- `python3 scripts/test-verify-drawio-import.py`
- `python3 scripts/test-plugin-package.py`
- `python3 scripts/verify-plugin-package.py origin/main`
- strict Claude package validation
- exact-head CI across Linux, Windows, and macOS on supported Python versions

Fixes #111
