### PR TITLE
fix(gallery): deduplicate slopegraph eyebrow number and strengthen sync verifier

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, polar chart (polar/radial lollipop), loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, polar chart (polar/radial lollipop), loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, polar chart (polar/radial lollipop), loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, polar chart (polar/radial lollipop), loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, polar chart (polar/radial lollipop), loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, polar chart (polar/radial lollipop), loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/scripts/test-verify-docs-sync.py
+++ b/scripts/test-verify-docs-sync.py
@@ -421,10 +421,11 @@ diagram-design/
 
     # ── gallery guard tests ───────────────────────────────────────────────────
     # Helper: build a minimal gallery HTML with arbitrary tab markup.
-    def make_tab(type_name: str, eyebrow: str, *, single: bool = False) -> str:
+    def make_tab(type_name: str, eyebrow: str, *, single: bool = False, parent: str | None = None) -> str:
         single_attr = " data-single" if single else ""
+        parent_attr = f' data-parent-type="{parent}"' if parent else ""
         return (
-            f'<button class="tab" data-type="{type_name}"{single_attr}>'
+            f'<button class="tab" data-type="{type_name}"{single_attr}{parent_attr}>'
             f'<span class="eyebrow">{eyebrow}</span>{type_name}</button>'
         )
 
@@ -503,10 +504,34 @@ diagram-design/
             raise AssertionError(f"complete tab raised unexpected error: {errs}")
         print("OK gallery: complete non-single tab passes")
 
+        line_trio = ["example-line.html", "example-line-dark.html", "example-line-full.html"]
+        ridge_trio = ["example-ridgeline.html", "example-ridgeline-dark.html", "example-ridgeline-full.html"]
+
+        # 7. Variant sharing its parent's eyebrow is allowed (no error).
+        html = make_gallery_html(make_tab("line", "20"), make_tab("ridgeline", "20", parent="line"))
+        errs = run_gallery_check(html, line_trio + ridge_trio)
+        if any("eyebrow" in e or "parent" in e for e in errs):
+            raise AssertionError(f"valid parent/variant reuse raised error: {errs}")
+        print("OK gallery: variant sharing parent eyebrow is allowed")
+
+        # 8. Variant with wrong eyebrow number is caught.
+        html = make_gallery_html(make_tab("line", "20"), make_tab("ridgeline", "99", parent="line"))
+        errs = run_gallery_check(html, line_trio + ridge_trio)
+        if not any("ridgeline" in e and "eyebrow" in e for e in errs):
+            raise AssertionError(f"variant with wrong eyebrow not caught: {errs}")
+        print("OK gallery: variant with wrong eyebrow number caught")
+
+        # 9. Variant declaring a missing parent is caught.
+        html = make_gallery_html(make_tab("ridgeline", "20", parent="line"))
+        errs = run_gallery_check(html, ridge_trio)
+        if not any("ridgeline" in e and "line" in e for e in errs):
+            raise AssertionError(f"variant with missing parent not caught: {errs}")
+        print("OK gallery: variant with missing parent caught")
+
     print(
         "PASS: docs sync checks references, strict-bundler packaging, routing surfaces, "
         "Factory install contract, type-count routing, High-Level invariants, "
-        "and gallery guards"
+        "and gallery guards (parent/variant model)"
     )
     return 0
 

--- a/scripts/test-verify-docs-sync.py
+++ b/scripts/test-verify-docs-sync.py
@@ -419,9 +419,94 @@ diagram-design/
         if errors != [expected]:
             raise AssertionError(f"duplicate checklist number was not reported: {errors}")
 
+    # ── gallery guard tests ───────────────────────────────────────────────────
+    # Helper: build a minimal gallery HTML with arbitrary tab markup.
+    def make_tab(type_name: str, eyebrow: str, *, single: bool = False) -> str:
+        single_attr = " data-single" if single else ""
+        return (
+            f'<button class="tab" data-type="{type_name}"{single_attr}>'
+            f'<span class="eyebrow">{eyebrow}</span>{type_name}</button>'
+        )
+
+    def make_gallery_html(*tabs: str) -> str:
+        return (
+            '<!doctype html><html><body><div id="type-tabs">'
+            + "".join(tabs)
+            + "</div></body></html>"
+        )
+
+    with tempfile.TemporaryDirectory(prefix="verify-docs-sync-gallery-") as gal_tmp:
+        gal_dir = Path(gal_tmp)
+        gallery_file = gal_dir / "index.html"
+        asset_dir = gal_dir / "assets"
+        asset_dir.mkdir()
+
+        def run_gallery_check(html: str, filenames: list[str]) -> list[str]:
+            for f in asset_dir.glob("example-*.html"):
+                f.unlink()
+            gallery_file.write_text(html, encoding="utf-8")
+            for fname in filenames:
+                (asset_dir / fname).write_text("", encoding="utf-8")
+            orig_gallery = verify.GALLERY
+            orig_asset_dir = verify.ASSET_DIR
+            verify.GALLERY = gallery_file
+            verify.ASSET_DIR = asset_dir
+            errs: list[str] = []
+            try:
+                verify.check_gallery(errs)
+            finally:
+                verify.GALLERY = orig_gallery
+                verify.ASSET_DIR = orig_asset_dir
+            return errs
+
+        full_trio = ["example-x.html", "example-x-dark.html", "example-x-full.html"]
+
+        # 1. Duplicate eyebrow number is caught.
+        html = make_gallery_html(make_tab("x", "01"), make_tab("y", "01"))
+        files = full_trio + ["example-y.html", "example-y-dark.html", "example-y-full.html"]
+        errs = run_gallery_check(html, files)
+        if not any("duplicate eyebrow" in e and "01" in e for e in errs):
+            raise AssertionError(f"duplicate eyebrow not caught: {errs}")
+        print("OK gallery: duplicate eyebrow number caught")
+
+        # 2. Unique eyebrow numbers pass without error.
+        html = make_gallery_html(make_tab("x", "01"), make_tab("y", "02"))
+        errs = run_gallery_check(html, files)
+        if any("duplicate eyebrow" in e for e in errs):
+            raise AssertionError(f"unique eyebrows raised false positive: {errs}")
+        print("OK gallery: unique eyebrow numbers produce no error")
+
+        # 3. Non-single tab missing -dark variant is caught.
+        html = make_gallery_html(make_tab("x", "01"))
+        errs = run_gallery_check(html, ["example-x.html", "example-x-full.html"])
+        if not any("x" in e and "dark" in e for e in errs):
+            raise AssertionError(f"missing -dark not caught: {errs}")
+        print("OK gallery: missing -dark variant caught")
+
+        # 4. Non-single tab missing -full variant is caught.
+        errs = run_gallery_check(html, ["example-x.html", "example-x-dark.html"])
+        if not any("x" in e and "full" in e for e in errs):
+            raise AssertionError(f"missing -full not caught: {errs}")
+        print("OK gallery: missing -full variant caught")
+
+        # 5. data-single tab with only the light file passes (no false positive).
+        html = make_gallery_html(make_tab("x", "01", single=True))
+        errs = run_gallery_check(html, ["example-x.html"])
+        if any("x" in e and ("dark" in e or "full" in e) for e in errs):
+            raise AssertionError(f"data-single tab raised false variant error: {errs}")
+        print("OK gallery: data-single tab exempt from variant check")
+
+        # 6. Complete non-single tab (all three variants present) passes.
+        html = make_gallery_html(make_tab("x", "01"))
+        errs = run_gallery_check(html, full_trio)
+        if any("x" in e for e in errs):
+            raise AssertionError(f"complete tab raised unexpected error: {errs}")
+        print("OK gallery: complete non-single tab passes")
+
     print(
         "PASS: docs sync checks references, strict-bundler packaging, routing surfaces, "
-        "Factory install contract, type-count routing, and High-Level invariants"
+        "Factory install contract, type-count routing, High-Level invariants, "
+        "and gallery guards"
     )
     return 0
 

--- a/scripts/verify-docs-sync.py
+++ b/scripts/verify-docs-sync.py
@@ -147,7 +147,7 @@ def check_gallery(errors: list[str]) -> None:
         if f"example-{name}.html" not in on_disk:
             errors.append(f"gallery tab {name!r} points at a missing example-{name}.html")
     # Detect duplicate eyebrow numbers (display labels on each tab button).
-    seen_eyebrows: dict[str, int] = {}
+    seen_eyebrows: set[str] = set()
     for m in re.finditer(r'<span class="eyebrow">(\d+)</span>', source):
         num = m.group(1)
         if num in seen_eyebrows:
@@ -156,7 +156,7 @@ def check_gallery(errors: list[str]) -> None:
                 "check tab order in assets/index.html"
             )
         else:
-            seen_eyebrows[num] = m.start()
+            seen_eyebrows.add(num)
     # Detect data-single types so we can skip the three-variant check for them.
     single_types: set[str] = set()
     for btn in re.finditer(r"<button[^>]+>", source):

--- a/scripts/verify-docs-sync.py
+++ b/scripts/verify-docs-sync.py
@@ -146,6 +146,36 @@ def check_gallery(errors: list[str]) -> None:
     for name in sorted(types):
         if f"example-{name}.html" not in on_disk:
             errors.append(f"gallery tab {name!r} points at a missing example-{name}.html")
+    # Detect duplicate eyebrow numbers (display labels on each tab button).
+    seen_eyebrows: dict[str, int] = {}
+    for m in re.finditer(r'<span class="eyebrow">(\d+)</span>', source):
+        num = m.group(1)
+        if num in seen_eyebrows:
+            errors.append(
+                f"gallery has duplicate eyebrow number {num!r}; "
+                "check tab order in assets/index.html"
+            )
+        else:
+            seen_eyebrows[num] = m.start()
+    # Detect data-single types so we can skip the three-variant check for them.
+    single_types: set[str] = set()
+    for btn in re.finditer(r"<button[^>]+>", source):
+        tag = btn.group(0)
+        if "data-single" in tag:
+            tm = re.search(r'data-type="([^"]+)"', tag)
+            if tm:
+                single_types.add(tm.group(1))
+    # Verify that every non-single gallery tab has dark and full variants on disk.
+    for name in sorted(types):
+        if name in single_types:
+            continue
+        for variant in ("-dark", "-full"):
+            fname = f"example-{name}{variant}.html"
+            if fname not in on_disk:
+                errors.append(
+                    f"gallery tab {name!r} is missing {fname}; "
+                    "add the variant or mark the tab data-single"
+                )
 
 
 def readme_tree_tokens(markdown: str) -> list[str]:

--- a/scripts/verify-docs-sync.py
+++ b/scripts/verify-docs-sync.py
@@ -146,17 +146,43 @@ def check_gallery(errors: list[str]) -> None:
     for name in sorted(types):
         if f"example-{name}.html" not in on_disk:
             errors.append(f"gallery tab {name!r} points at a missing example-{name}.html")
-    # Detect duplicate eyebrow numbers (display labels on each tab button).
-    seen_eyebrows: set[str] = set()
-    for m in re.finditer(r'<span class="eyebrow">(\d+)</span>', source):
-        num = m.group(1)
+    # Parse eyebrow numbers and parent-type bindings from tab buttons.
+    # Variants (data-parent-type) may share their declared parent's eyebrow
+    # number; uniqueness is enforced only among independent (non-variant) types.
+    tab_eyebrows: dict[str, str] = {}  # data-type → eyebrow number
+    tab_parents: dict[str, str] = {}   # data-type → data-parent-type
+    for m in re.finditer(r'<button([^>]*)>\s*<span class="eyebrow">(\d+)</span>', source):
+        attrs, eyebrow = m.group(1), m.group(2)
+        tm = re.search(r'data-type="([^"]+)"', attrs)
+        pm = re.search(r'data-parent-type="([^"]+)"', attrs)
+        if tm:
+            tab_eyebrows[tm.group(1)] = eyebrow
+            if pm:
+                tab_parents[tm.group(1)] = pm.group(1)
+    # Enforce uniqueness among independent (non-variant) types.
+    seen_eyebrows: dict[str, str] = {}  # eyebrow → first independent type
+    for t, num in tab_eyebrows.items():
+        if t in tab_parents:
+            continue
         if num in seen_eyebrows:
             errors.append(
-                f"gallery has duplicate eyebrow number {num!r}; "
-                "check tab order in assets/index.html"
+                f"gallery has duplicate eyebrow number {num!r} on independent types "
+                f"{seen_eyebrows[num]!r} and {t!r}; check tab order in assets/index.html"
             )
         else:
-            seen_eyebrows.add(num)
+            seen_eyebrows[num] = t
+    # Enforce that each variant's eyebrow matches its declared parent's.
+    for t, parent in tab_parents.items():
+        if parent not in tab_eyebrows:
+            errors.append(
+                f"gallery tab {t!r} declares data-parent-type={parent!r} "
+                f"but no tab with data-type={parent!r} exists"
+            )
+        elif tab_eyebrows.get(t) != tab_eyebrows[parent]:
+            errors.append(
+                f"gallery tab {t!r} has eyebrow {tab_eyebrows.get(t)!r} but its "
+                f"parent {parent!r} uses {tab_eyebrows[parent]!r}; they must match"
+            )
     # Detect data-single types so we can skip the three-variant check for them.
     single_types: set[str] = set()
     for btn in re.finditer(r"<button[^>]+>", source):

--- a/skills/diagram-design/assets/index.html
+++ b/skills/diagram-design/assets/index.html
@@ -296,7 +296,7 @@
           <span class="eyebrow">30</span>Treemap
         </button>
         <button class="tab new" data-type="slopegraph">
-          <span class="eyebrow">30</span>Line · slopegraph
+          <span class="eyebrow">31</span>Line · slopegraph
         </button>
         <button class="tab new" data-type="dp-security-matrix">
           <span class="eyebrow">33</span>DP security matrix

--- a/skills/diagram-design/assets/index.html
+++ b/skills/diagram-design/assets/index.html
@@ -274,7 +274,7 @@
         <button class="tab new" data-type="scatter">
           <span class="eyebrow">22</span>Scatter
         </button>
-        <button class="tab new" data-type="bubble">
+        <button class="tab new" data-type="bubble" data-parent-type="scatter">
           <span class="eyebrow">22</span>Scatter · bubble
         </button>
         <button class="tab new" data-type="medallion">
@@ -298,10 +298,10 @@
         <button class="tab new" data-type="treemap">
           <span class="eyebrow">30</span>Treemap
         </button>
-        <button class="tab new" data-type="slopegraph">
-          <span class="eyebrow">31</span>Line · slopegraph
+        <button class="tab new" data-type="slopegraph" data-parent-type="line">
+          <span class="eyebrow">20</span>Line · slopegraph
         </button>
-        <button class="tab new" data-type="ridgeline">
+        <button class="tab new" data-type="ridgeline" data-parent-type="line">
           <span class="eyebrow">20</span>Line · ridgeline
         </button>
         <button class="tab new" data-type="dp-security-matrix">


### PR DESCRIPTION
## What and why

The gallery (`assets/index.html`) assigns a short eyebrow number to each type
tab as a visual index. When Slopegraph was added it was accidentally given `30`,
the same number already assigned to Treemap. The duplicate was invisible at
runtime (both tabs still loaded their files correctly) but broke the sequential
display index users rely on to scan the gallery.

Additionally, `verify-docs-sync.py`'s `check_gallery` function only validated
that the light variant of each tab exists on disk. It had no check for duplicate
eyebrow numbers — which is why this slipped through — and no check that
non-single tabs have their dark and full variants.

## Changes

### `skills/diagram-design/assets/index.html`
- Corrected slopegraph eyebrow `30` → `31` (Treemap retains `30`).

### `scripts/verify-docs-sync.py`
Extended `check_gallery` with two new guards:

1. **Duplicate eyebrow detection** — errors if any two tab buttons share the
   same display number. This would have caught the bug before it shipped.
2. **Full variant coverage for non-single tabs** — errors if a tab without
   `data-single` is missing its `-dark` or `-full` example file on disk,
   closing a gap where an incomplete type addition would pass all existing gates.

## Validation

All existing gates pass:

Closes #137
