### PR TITLE
feat(line): add bump chart as a Line variant

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, polar chart (polar/radial lollipop), loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.6.6",
+  "version": "2.6.9",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, polar chart (polar/radial lollipop), loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.6.6",
+  "version": "2.6.9",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, polar chart (polar/radial lollipop), loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.6.6",
+  "version": "2.6.9",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,15 @@ jobs:
         if: always()
         id: bubble_tests
         run: python scripts/test-verify-bubble.py
+      - name: Verify bump chart rank grid
+        if: always()
+        id: bump
+        run: python scripts/verify-bump.py --all
+
+      - name: Verify bump checker
+        if: always()
+        id: bump_tests
+        run: python scripts/test-verify-bump.py
 
       # lint-render.py's oracle is pixels, so the browser is part of the contract:
       # pin Playwright exactly, and let that pin choose the Chromium build. Bump
@@ -361,6 +370,8 @@ jobs:
           echo "| Ridgeline Checker | ${{ steps.ridgeline_tests.outcome == 'success' && '✅ Passed' || (steps.ridgeline_tests.outcome == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Bubble Position & Area | ${{ steps.bubble.outcome == 'success' && '✅ Passed' || (steps.bubble.outcome == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Bubble Checker | ${{ steps.bubble_tests.outcome == 'success' && '✅ Passed' || (steps.bubble_tests.outcome == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Bump Chart Rank Grid | ${{ steps.bump.outcome == 'success' && '✅ Passed' || (steps.bump.outcome == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Bump Checker | ${{ steps.bump_tests.outcome == 'success' && '✅ Passed' || (steps.bump_tests.outcome == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Primitive Icons & Documentation | ${{ steps.icons.outcome == 'success' && '✅ Passed' || (steps.icons.outcome == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Render Linter Self-Test | ${{ steps.render_selftest.outcome == 'success' && '✅ Passed' || (steps.render_selftest.outcome == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Rendered Layout (paint oracle) | ${{ steps.render.outcome == 'success' && '✅ Passed' || (steps.render.outcome == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,8 @@ The helper refuses to run if the Claude and Codex versions already differ. If an
 | Sankey checker behaves (pass + adversarial cases) | `python3 scripts/test-verify-sankey.py` |
 | Bubble positions sit on shared axis scales and area encodes every declared size | `python3 scripts/verify-bubble.py --all` |
 | Bubble checker behaves (pass + adversarial cases) | `python3 scripts/test-verify-bubble.py` |
+| Bump vertices sit exactly on one rank grid and every endpoint label is placed on both axes | `python3 scripts/verify-bump.py --all` |
+| Bump checker behaves (pass + adversarial cases) | `python3 scripts/test-verify-bump.py` |
 | Generated icon assets are up to date (`icons.html`, `primitive-icons.md`) | `python3 scripts/build-icons.py` then `git diff --exit-code` on the two generated files |
 
 The semantic-pattern gate also caps `skills/diagram-design/SKILL.md` at 40,000 bytes so the installed skill remains practical to load. If that gate fails, reduce duplication or move detail into a routed reference; do not remove routing vocabulary from frontmatter.
@@ -120,7 +122,9 @@ python3 scripts/test-plugin-package.py \
   && python3 scripts/verify-sankey.py --all \
   && python3 scripts/test-verify-sankey.py \
   && python3 scripts/verify-bubble.py --all \
-  && python3 scripts/test-verify-bubble.py
+  && python3 scripts/test-verify-bubble.py \
+  && python3 scripts/verify-bump.py --all \
+  && python3 scripts/test-verify-bump.py
 ```
 
 ### If a gate fails
@@ -132,6 +136,7 @@ python3 scripts/test-plugin-package.py \
 - **`verify-slopegraph.py`:** the two axes disagree about scale or origin, or an endpoint is drawn somewhere other than where its own declared value belongs. Fix the coordinate, never the label — and never move a point to stop two endpoint labels colliding, because crowded labels mean the values really are close.
 - **`verify-ridgeline.py`:** a ridge is drawn on its own amplitude, a baseline sits off the stack's pitch or away from its drawn rule, a ridge is sampled on its own x positions, or a printed range is wider than the bins it claims. Fix the geometry or the declaration so they state one thing — never renormalise a single ridge to make it readable, and never move a baseline to buy one ridge headroom.
 - **`verify-bubble.py`:** a bubble is drawn off the shared axis scale its peers describe, its radius disagrees with the one area constant (`r = K·√size`), a second bubble wears the accent, an overlapping smaller bubble is painted under a larger one, or a bound label/tick disagrees with the mark it names. Fix the geometry, never the binding — and never nudge a bubble to open up space, because crowded bubbles mean the values really are close.
+- **`verify-bump.py`:** a vertex sits off the rank grid the figure itself declares, a snapshot's ranks are not a permutation of 1..N, a segment curves or arrives by a relative command, or an endpoint label is missing a coordinate, drawn inboard of the end it names, or off the gutter its peers share. Fix the geometry or the declaration, never the label — and never nudge a vertex off its row to dodge a label collision, because a rank between two ranks is not a rank.
 - **`verify-geometry.py`:** a label mask overlaps a node declared later in the document, so the node fill clips the label at render time. Move the label to a free segment of its connector — keep the 6–10px gap from the stroke required by SKILL.md §6, and do not shrink the mask to sneak under the check.
 - **Icon assets:** you changed `scripts/vendor/icons/` or `scripts/build-icons.py` and the generated files went stale. Rerun `python3 scripts/build-icons.py` and commit the regenerated files.
 

--- a/scripts/test-verify-bump.py
+++ b/scripts/test-verify-bump.py
@@ -8,6 +8,13 @@ two series tying at a rank the footnote's tie-break rule forbids, a spline
 invented between quarterly snapshots, a printed rank disagreeing with the
 declared one, a label drawn on a neighbour's row.
 
+The endpoint-placement cases (9b-9g) pin the half of that contract a row
+check cannot see. A label states two things - which series it belongs to
+(its row) and which END of that series (its column) - and the second was
+previously unverified, so a coordinate could be deleted or slid along its
+row and still be certified. Each case names one coordinate and one
+direction, because a case named for more than it proves hides the rest.
+
 The synthetic figures at the end prove the checker reads the FIGURE's own grid
 rather than memorising the shipped layout: a valid bump chart at a different
 top and pitch must pass, and the budget rules must fire on series and snapshot
@@ -40,6 +47,12 @@ FOCAL_D = 'd="M320,88 L440,144 L560,256 L680,368"'
 FOCAL_PATH = ('<path data-series="legacy-http" data-ranks="1,2,4,6" '
               'd="M320,88 L440,144 L560,256 L680,368" fill="none" '
               'stroke="#eb6c36" stroke-width="2.4"/>')
+# The focal series' left-gutter name label, and the gutter it shares with the
+# five other series. The shipped left gutter is x=272 (names) against a first
+# column at x=320; the right gutter mirrors it from x=728.
+FIRST_NAME = ('data-series="legacy-http" data-end="first" data-role="name" '
+              'x="272" y="91.5"')
+FIRST_NAME_GUTTER = 'data-role="name" x="272"' 
 
 
 def invoke(argv):
@@ -224,6 +237,71 @@ def main() -> int:
             source.replace('      <text data-series="legacy-http" data-end="first" data-role="rank" x="304" y="91.5" fill="#4f5d75" font-size="9" font-family="\'Geist Mono\', monospace" text-anchor="end">#1</text>\n', "", 1),
             source, "prints no first rank",
             "a series with no first rank label",
+        )
+
+        # 9b. A coordinate that is absent is not a coordinate that is
+        #     unverified: SVG defaults a missing x or y to 0, so the browser
+        #     draws the label at the edge of the frame. Deleting one used to
+        #     be certified, because the check compared nothing and said OK.
+        case(
+            failures, directory, "label-no-y",
+            source.replace(FIRST_NAME, FIRST_NAME.replace(' y="91.5"', ""), 1),
+            source, "has no readable y",
+            "an endpoint label with no y coordinate",
+        )
+        case(
+            failures, directory, "label-no-x",
+            source.replace(FIRST_NAME, FIRST_NAME.replace(' x="272"', ""), 1),
+            source, "has no readable x",
+            "an endpoint label with no x coordinate",
+        )
+
+        # 9c. Present but unreadable is the same defect wearing an attribute.
+        case(
+            failures, directory, "label-empty-y",
+            source.replace(FIRST_NAME, FIRST_NAME.replace('y="91.5"', 'y=""'), 1),
+            source, "has no readable y",
+            "an endpoint label whose y is present but empty",
+        )
+
+        # 9d. "1e400" parses as a number and overflows to inf, which sits
+        #     further than any tolerance from every real coordinate - so a
+        #     distance test passes it by default unless finiteness is required.
+        case(
+            failures, directory, "label-non-finite-x",
+            source.replace(FIRST_NAME, FIRST_NAME.replace('x="272"', 'x="1e400"'), 1),
+            source, "has no readable x",
+            "an endpoint label whose x overflows to infinity",
+        )
+
+        # 9e. The reported repro: one first-end label slid from its gutter
+        #     toward the middle of the plot. Its row is untouched and every
+        #     rank it prints is still correct, so row proximity alone clears it.
+        case(
+            failures, directory, "label-x-inboard",
+            source.replace(FIRST_NAME, FIRST_NAME.replace('x="272"', 'x="500"'), 1),
+            source, "inboard of the first endpoint",
+            "a first-end label moved toward the middle of the chart",
+        )
+
+        # 9f. The same displacement applied to every name label in the gutter.
+        #     The gutter stays perfectly self-consistent, so only the endpoint
+        #     test can fire - which is what makes it independent of 9g.
+        case(
+            failures, directory, "label-gutter-inboard",
+            source.replace(FIRST_NAME_GUTTER, 'data-role="name" x="500"'),
+            source, "inboard of the first endpoint",
+            "a whole first-end name gutter moved inside the plot",
+        )
+
+        # 9g. And the other direction: one label slid further out. It stays
+        #     outboard of its endpoint, so only its disagreement with the
+        #     gutter its five peers share reveals it.
+        case(
+            failures, directory, "label-off-gutter",
+            source.replace(FIRST_NAME, FIRST_NAME.replace('x="272"', 'x="240"'), 1),
+            source, "gutter its",
+            "a first-end label moved off the gutter its peers share",
         )
 
         # 10. Transforms: on the series, on an ancestor, and from CSS. Raw

--- a/scripts/test-verify-bump.py
+++ b/scripts/test-verify-bump.py
@@ -171,6 +171,17 @@ def main() -> int:
             "a spline between two snapshots",
         )
 
+        # 4b. Relative commands: `l120,56` renders against the previous point
+        #     while the parsed numbers read as absolute, so folding case would
+        #     certify a figure at positions it never drew. Refused outright.
+        case(
+            failures, directory, "relative-path",
+            source.replace('d="M320,88 L440,144 L560,256 L680,368"',
+                           'd="M320,88 l120,56 l120,112 l120,112"'),
+            source, "relative path commands",
+            "a series drawn with relative path commands",
+        )
+
         # 5. A printed rank disagreeing with the declared one.
         case(
             failures, directory, "mislabelled",
@@ -363,6 +374,8 @@ def main() -> int:
         for name, fixture, expect, describe in (
             ("too-many-series", synthetic(9, 4), "budget",
              "nine series against a budget of eight"),
+            ("too-few-series", synthetic(3, 4), "budget",
+             "three series against a budget floor of four"),
             ("too-many-cols", synthetic(4, 7), "budget",
              "seven snapshots against a budget of six"),
             ("too-few-cols", synthetic(4, 2), "slopegraph",

--- a/scripts/test-verify-bump.py
+++ b/scripts/test-verify-bump.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Adversarial tests for verify-bump.py — both polarities.
+
+Per ADR 0005, a geometric contract is a checker plus fixtures proving it fires
+when it should and stays quiet when it shouldn't. Each mutation below renders
+perfectly and no other gate would catch it: a vertex nudged off its rank row,
+two series tying at a rank the footnote's tie-break rule forbids, a spline
+invented between quarterly snapshots, a printed rank disagreeing with the
+declared one, a label drawn on a neighbour's row.
+
+The synthetic figures at the end prove the checker reads the FIGURE's own grid
+rather than memorising the shipped layout: a valid bump chart at a different
+top and pitch must pass, and the budget rules must fire on series and snapshot
+counts the shipped example cannot be mutated into. The last case pins the
+scope treaty with the sibling checker: verify-slopegraph must skip a bump
+chart rather than reject it for lacking <line> elements it never claimed.
+
+Usage: python3 scripts/test-verify-bump.py
+Exit: 0 all pass, 1 a case failed.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CHECKER = ROOT / "scripts/verify-bump.py"
+SIBLING = ROOT / "scripts/verify-slopegraph.py"
+GOOD = ROOT / "skills/diagram-design/assets/example-bump.html"
+
+CHILD_ENV = {**os.environ, "PYTHONIOENCODING": "utf-8"}
+
+# Anchors, all literal excerpts of the shipped example. A fixture that fails to
+# build means the example moved, which is itself worth knowing.
+FOCAL_D = 'd="M320,88 L440,144 L560,256 L680,368"'
+FOCAL_PATH = ('<path data-series="legacy-http" data-ranks="1,2,4,6" '
+              'd="M320,88 L440,144 L560,256 L680,368" fill="none" '
+              'stroke="#eb6c36" stroke-width="2.4"/>')
+
+
+def invoke(argv):
+    result = subprocess.run(
+        argv, capture_output=True, text=True,
+        encoding="utf-8", errors="replace", env=CHILD_ENV,
+    )
+    return result.returncode, (result.stdout or "") + (result.stderr or "")
+
+
+def run(*paths):
+    return invoke([sys.executable, str(CHECKER), *(str(p) for p in paths)])
+
+
+def write(directory, name, source):
+    path = directory / name
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+def case(failures, directory, name, source, original, expect, describe):
+    """One mutation: it must be a real edit, and it must be rejected."""
+    if source == original:
+        failures.append("could not build the %s fixture (anchor moved)" % name)
+        return
+    code, output = run(write(directory, "%s.html" % name, source))
+    if code == 0:
+        failures.append("%s was accepted" % describe)
+    elif expect not in output:
+        failures.append("%s was reported without the expected reason: %s"
+                        % (describe, output.strip()))
+    else:
+        print("OK: %s is rejected" % describe)
+
+
+def synthetic(n_series, n_cols, top=100, pitch=40, x0=200, dx=150):
+    """A minimal valid bump chart: n_series over n_cols, ranks rotating."""
+    xs = [x0 + i * dx for i in range(n_cols)]
+    parts = [
+        '<html><head><title>synthetic bump chart</title></head><body>',
+        '<svg viewBox="0 0 1000 600" role="img" aria-labelledby="t d">',
+        '<title id="t">synthetic bump chart</title>',
+        '<desc id="d">bump chart fixture</desc>',
+    ]
+    for i, x in enumerate(xs):
+        parts.append('<text data-axis="%d" data-state="T%d" x="%d" y="560">T%d</text>'
+                     % (i, i, x, i))
+    for s in range(n_series):
+        ranks = [((s + c) % n_series) + 1 for c in range(n_cols)]
+        pts = ["%d,%d" % (x, top + (r - 1) * pitch) for x, r in zip(xs, ranks)]
+        d = "M" + pts[0] + " " + " ".join("L" + p for p in pts[1:])
+        focal = s == 0
+        stroke = "#eb6c36" if focal else "rgba(45,49,66,0.70)"
+        width = "2.4" if focal else "1.2"
+        parts.append('<path data-series="s%d" data-ranks="%s" d="%s" fill="none" '
+                     'stroke="%s" stroke-width="%s"/>'
+                     % (s, ",".join(map(str, ranks)), d, stroke, width))
+        radius = "4" if focal else "3"
+        for x, r in zip(xs, ranks):
+            parts.append('<circle cx="%d" cy="%d" r="%s" fill="%s"/>'
+                         % (x, top + (r - 1) * pitch, radius, stroke))
+        first_y = top + (ranks[0] - 1) * pitch + 3.5
+        last_y = top + (ranks[-1] - 1) * pitch + 3.5
+        parts.append('<text data-series="s%d" data-end="first" data-role="name" '
+                     'x="%d" y="%g" text-anchor="end">s%d</text>'
+                     % (s, xs[0] - 48, first_y, s))
+        parts.append('<text data-series="s%d" data-end="first" data-role="rank" '
+                     'x="%d" y="%g" text-anchor="end">#%d</text>'
+                     % (s, xs[0] - 16, first_y, ranks[0]))
+        parts.append('<text data-series="s%d" data-end="last" data-role="rank" '
+                     'x="%d" y="%g">#%d</text>'
+                     % (s, xs[-1] + 16, last_y, ranks[-1]))
+        parts.append('<text data-series="s%d" data-end="last" data-role="name" '
+                     'x="%d" y="%g">s%d</text>'
+                     % (s, xs[-1] + 48, last_y, s))
+    parts.append("</svg></body></html>")
+    return "\n".join(parts)
+
+
+def main() -> int:
+    source = GOOD.read_text(encoding="utf-8")
+    failures = []
+
+    with tempfile.TemporaryDirectory() as raw:
+        directory = Path(raw)
+
+        # 1. The shipped example must pass untouched.
+        code, output = run(GOOD)
+        if code != 0:
+            failures.append("clean example was rejected: %s" % output.strip())
+        else:
+            print("OK: the shipped bump chart passes")
+
+        # 2. Nudge one vertex off its rank row, dot moved with it so only the
+        #    grid lies. Reads as a rank between two ranks.
+        case(
+            failures, directory, "off-grid",
+            source.replace("L560,256 L680,368", "L560,250 L680,368")
+                  .replace('<circle cx="560" cy="256" r="4"',
+                           '<circle cx="560" cy="250" r="4"'),
+            source, "grid puts that rank",
+            "a vertex nudged off its rank row",
+        )
+
+        # 3. A tie: two series both claiming #1 at the last snapshot, leaving
+        #    #2 empty. Both directions of the permutation rule fire.
+        case(
+            failures, directory, "tied-rank",
+            source.replace('data-series="authx" data-ranks="2,3,3,2"',
+                           'data-series="authx" data-ranks="2,3,3,1"')
+                  .replace("L560,200 L680,144", "L560,200 L680,88")
+                  .replace('<circle cx="680" cy="144" r="3" fill="rgba(45,49,66,0.80)"/>',
+                           '<circle cx="680" cy="88" r="3" fill="rgba(45,49,66,0.80)"/>')
+                  .replace('data-series="authx" data-end="last" data-role="rank" x="696" y="147.5" fill="#4f5d75" font-size="9" font-family="\'Geist Mono\', monospace">#2<',
+                           'data-series="authx" data-end="last" data-role="rank" x="696" y="91.5" fill="#4f5d75" font-size="9" font-family="\'Geist Mono\', monospace">#1<')
+                  .replace('data-series="authx" data-end="last" data-role="name" x="728" y="147.5"',
+                           'data-series="authx" data-end="last" data-role="name" x="728" y="91.5"'),
+            source, "tie-break",
+            "two series tying at one rank",
+        )
+
+        # 4. A curved segment. The endpoints are identical; only the path
+        #    between them - which nobody measured - changes.
+        case(
+            failures, directory, "spline",
+            source.replace('d="M320,88 L440,144 L560,256 L680,368"',
+                           'd="M320,88 C400,88 400,144 440,144 L560,256 L680,368"'),
+            source, "invents a trajectory",
+            "a spline between two snapshots",
+        )
+
+        # 5. A printed rank disagreeing with the declared one.
+        case(
+            failures, directory, "mislabelled",
+            source.replace('font-family="\'Geist Mono\', monospace">#6<',
+                           'font-family="\'Geist Mono\', monospace">#5<', 1),
+            source, "must state one number",
+            "a printed rank its geometry does not draw",
+        )
+
+        # 6. A rank label without its # sigil reads as a magnitude.
+        case(
+            failures, directory, "bare-rank",
+            source.replace('font-family="\'Geist Mono\', monospace">#6<',
+                           'font-family="\'Geist Mono\', monospace">6<', 1),
+            source, "cannot be mistaken for a magnitude",
+            "a rank label printed without its sigil",
+        )
+
+        # 7. A label drawn on a neighbour's row renames the line.
+        case(
+            failures, directory, "wrong-row",
+            source.replace('data-series="legacy-http" data-end="last" data-role="name" x="728" y="371.5"',
+                           'data-series="legacy-http" data-end="last" data-role="name" x="728" y="315.5"'),
+            source, "renames the line",
+            "a name label drawn beside another series' endpoint",
+        )
+
+        # 8. A name label whose visible text disagrees with its binding.
+        case(
+            failures, directory, "renamed",
+            source.replace('font-family="\'Geist\', sans-serif">legacy-http</text>',
+                           'font-family="\'Geist\', sans-serif">legacy</text>', 1),
+            source, "binding must agree",
+            "a name label reading a different name than it binds",
+        )
+
+        # 9. A missing label: the reader traces a line to an unlabelled end.
+        case(
+            failures, directory, "unlabelled",
+            source.replace('      <text data-series="legacy-http" data-end="first" data-role="rank" x="304" y="91.5" fill="#4f5d75" font-size="9" font-family="\'Geist Mono\', monospace" text-anchor="end">#1</text>\n', "", 1),
+            source, "prints no first rank",
+            "a series with no first rank label",
+        )
+
+        # 10. Transforms: on the series, on an ancestor, and from CSS. Raw
+        #     coordinates are the basis, so any of the three moves the rendered
+        #     mark away from the rank it was checked against.
+        case(
+            failures, directory, "transformed",
+            source.replace('<path data-series="legacy-http"',
+                           '<path transform="translate(0 8)" data-series="legacy-http"'),
+            source, "moves the rendered mark",
+            "a transform on a series path",
+        )
+        case(
+            failures, directory, "wrapped",
+            source.replace(FOCAL_PATH, '<g transform="translate(0 8)">' + FOCAL_PATH + "</g>", 1),
+            source, "ancestor",
+            "a series wrapped in a transformed group",
+        )
+        case(
+            failures, directory, "css-transform",
+            source.replace("<style>", "<style>\n    svg path { transform: scaleY(1.1); }", 1),
+            source, "CSS `transform`",
+            "a CSS transform reaching the figure",
+        )
+
+        # 11. Caption text swapped while the bindings stay put — the exact
+        #     defect data-state exists to catch.
+        case(
+            failures, directory, "caption-swap",
+            source.replace('text-anchor="middle">Q1</text>', 'text-anchor="middle">Q2</text>', 1),
+            source, "binding must agree",
+            "a caption whose visible text was edited without its binding",
+        )
+        case(
+            failures, directory, "caption-gone",
+            source.replace('      <text data-axis="2" data-state="Q3" x="560" y="416" fill="#4f5d75" font-size="9" font-family="\'Geist Mono\', monospace" letter-spacing="0.14em" text-anchor="middle">Q3</text>\n', "", 1),
+            source, "no caption for snapshot 3",
+            "a snapshot with no caption",
+        )
+
+        # 12. A second accent series spends the accent entirely.
+        case(
+            failures, directory, "two-focal",
+            source.replace('d="M320,144 L440,200 L560,200 L680,144" fill="none" stroke="rgba(45,49,66,0.80)" stroke-width="1.2"',
+                           'd="M320,144 L440,200 L560,200 L680,144" fill="none" stroke="#eb6c36" stroke-width="2.4"'),
+            source, "exactly one editorially focal",
+            "two series carrying the accent stroke",
+        )
+
+        # 13. Colour and weight sending focus to different series.
+        case(
+            failures, directory, "weight-mismatch",
+            source.replace('stroke="#eb6c36" stroke-width="2.4"/>',
+                           'stroke="#eb6c36" stroke-width="1.2"/>', 1),
+            source, "focus cue",
+            "a focal stroke at non-focal weight",
+        )
+
+        # 14. Dots: a vertex with no dot, and a focal dot at non-focal size.
+        case(
+            failures, directory, "dotless",
+            source.replace('      <circle cx="560" cy="256" r="4" fill="#eb6c36"/>\n', "", 1),
+            source, "no dot at",
+            "a vertex with no dot",
+        )
+        case(
+            failures, directory, "small-dot",
+            source.replace('<circle cx="680" cy="368" r="4" fill="#eb6c36"/>',
+                           '<circle cx="680" cy="368" r="3" fill="#eb6c36"/>'),
+            source, "dot size",
+            "a focal vertex with a non-focal dot",
+        )
+
+        # 15. Unreadable declarations are findings, never skips.
+        case(
+            failures, directory, "no-ranks",
+            source.replace(' data-ranks="1,2,4,6"', "", 1),
+            source, "no data-ranks",
+            "a series path with no declared ranks",
+        )
+        case(
+            failures, directory, "junk-ranks",
+            source.replace('data-ranks="1,2,4,6"', 'data-ranks="1,2,four,6"', 1),
+            source, "not a rank",
+            "a rank that is not a whole number",
+        )
+        case(
+            failures, directory, "junk-path",
+            source.replace(FOCAL_D, 'd="M banana"', 1),
+            source, "cannot verify its positions",
+            "a series path this checker cannot read",
+        )
+        case(
+            failures, directory, "count-mismatch",
+            source.replace('data-ranks="1,2,4,6"', 'data-ranks="1,2,4"', 1),
+            source, "every declared rank needs its vertex",
+            "a series with more points than ranks",
+        )
+
+        # 16. A series visiting a private column redraws time.
+        case(
+            failures, directory, "own-columns",
+            source.replace("L560,256 L680,368", "L564,256 L680,368")
+                  .replace('<circle cx="560" cy="256" r="4"', '<circle cx="564" cy="256" r="4"'),
+            source, "visit the same snapshots",
+            "a series visiting its own private column",
+        )
+
+        # 17. Single-quoted attributes must be read, not silently dropped —
+        #     the same fault the slopegraph checker fixed. Positive case: the
+        #     figure verifies; the falsified twin proves it was read at all.
+        singled = source.replace(FOCAL_PATH,
+                                 FOCAL_PATH.replace('"', "'").replace("<path", "<path", 1), 1)
+        code, output = run(write(directory, "single-quoted.html", singled))
+        if code != 0:
+            failures.append("single-quoted attributes were rejected: %s" % output.strip())
+        else:
+            print("OK: single-quoted attributes are read")
+        case(
+            failures, directory, "single-quoted-lie",
+            singled.replace("data-ranks='1,2,4,6'", "data-ranks='1,2,4,5'", 1),
+            source, "grid puts that rank",
+            "a falsified rank in single-quoted attributes",
+        )
+
+        # 18. Fail closed on a file that claims the type and yields nothing.
+        empty = ("<html><head><title>quarterly bump chart</title></head>"
+                 "<body><svg><title>bump chart of nothing</title></svg></body></html>")
+        code, output = run(write(directory, "empty.html", empty))
+        if code == 0:
+            failures.append("a bump chart with no verifiable series was accepted")
+        elif "Refusing to report OK" not in output:
+            failures.append("empty figure reported without the fail-closed reason: %s"
+                            % output.strip())
+        else:
+            print("OK: a bump chart this checker cannot read is refused")
+
+        # 19. Synthetics: the checker reads the figure's own grid, and the
+        #     budget rules fire on counts a mutation cannot reach.
+        clean = synthetic(4, 4)
+        code, output = run(write(directory, "synthetic.html", clean))
+        if code != 0:
+            failures.append("a valid synthetic at a different top/pitch was rejected: %s"
+                            % output.strip())
+        else:
+            print("OK: a valid bump chart on a different grid passes")
+
+        for name, fixture, expect, describe in (
+            ("too-many-series", synthetic(9, 4), "budget",
+             "nine series against a budget of eight"),
+            ("too-many-cols", synthetic(4, 7), "budget",
+             "seven snapshots against a budget of six"),
+            ("too-few-cols", synthetic(4, 2), "slopegraph",
+             "two snapshots, which is a slopegraph"),
+        ):
+            code, output = run(write(directory, "%s.html" % name, fixture))
+            if code == 0:
+                failures.append("%s was accepted" % describe)
+            elif expect not in output:
+                failures.append("%s was reported without the expected reason: %s"
+                                % (describe, output.strip()))
+            else:
+                print("OK: %s is rejected" % describe)
+
+        # 20. The scope treaty. verify-slopegraph binds its contract to <line>
+        #     elements; a bump chart binds the same data-series vocabulary to
+        #     <path>. The sibling must SKIP the shipped bump example - holding
+        #     it to the slopegraph contract rejects it for lacking elements it
+        #     never claimed to have.
+        code, output = invoke([sys.executable, str(SIBLING), str(GOOD)])
+        if code != 0:
+            failures.append("verify-slopegraph claims the bump example: %s" % output.strip())
+        elif "no slopegraph found" not in output:
+            failures.append("verify-slopegraph checked the bump example instead of "
+                            "skipping it: %s" % output.strip())
+        else:
+            print("OK: verify-slopegraph skips the bump chart (scope treaty holds)")
+
+    for failure in failures:
+        print("FAIL: %s" % failure)
+    if failures:
+        print("\n%d case(s) failed." % len(failures))
+        return 1
+    print("\nAll bump checker cases passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-bump.py
+++ b/scripts/verify-bump.py
@@ -1,0 +1,719 @@
+#!/usr/bin/env python3
+"""Verify that a bump chart's drawn positions match the ranks it declares.
+
+A bump chart makes one claim: **vertical position is rank, and nothing else**.
+Rank is ordinal, so unlike every other chart gate in this repo the geometry is
+EXACT - each vertex belongs on `y = top + (rank - 1) x pitch` with no tolerance
+worth granting, because rank has no fractions and no rounding. Every way of
+breaking the claim renders perfectly: a vertex nudged off its row reads as a
+rank between two ranks, two series sharing a row at one snapshot claim a tie
+the ranking key cannot produce, and a curved segment invents a trajectory
+between snapshots that were only measured quarterly.
+
+Six invariants:
+
+1. ONE RANK GRID - every vertex of every series maps rank to y through the same
+   linear map, derived from the figure itself and then enforced exactly. A
+   figure whose rows are unevenly pitched reads relative movement wrong.
+
+2. PERMUTATION PER SNAPSHOT - each column's declared ranks are exactly
+   1..N, each used once. A duplicated rank is a tie the footnote's tie-break
+   rule says cannot happen; a skipped rank is an empty row the reader fills
+   with a series that is not there.
+
+3. STRAIGHT SEGMENTS - a data-series path is M followed by L commands only.
+   A spline between two quarterly snapshots draws data nobody measured; the
+   draft this gate came from calls them subway curves and bans them outright.
+
+4. SHARED COLUMNS - every series visits the same x positions in the same
+   order, and each snapshot caption sits on the column it names, bound with
+   data-axis and data-state exactly as the slopegraph binds its two.
+
+5. LABELS BOUND TO MEANING - each series prints its name and its rank at
+   first and last appearance, each label bound by data-series / data-end /
+   data-role, each printed "#k" agreeing with the declared rank, and each
+   sitting on its own series' row rather than a neighbour's.
+
+6. FAIL CLOSED - zero parseable series, a path that declares data-series but
+   cannot be read, a vertex with no dot, or a transform anywhere near verified
+   geometry is a finding, never a skip. A checker that reports OK because it
+   found nothing to compare is the bug, not the gate.
+
+WHAT THIS DOES NOT CHECK, deliberately:
+
+- **The ranking key.** Rank by what, ties broken how - that is the footnote's
+  job, and prose is not parsed. Every check here is internal consistency.
+- **Late entry and early exit.** The draft permits a series to start or stop
+  mid-figure; the shipped grammar does not use it yet, so a series with fewer
+  vertices than columns is a finding until the grammar grows a way to declare
+  a gap. Widening this without a declaration attribute would let a truncated
+  series pass as a deliberate exit.
+
+Usage:
+    python3 scripts/verify-bump.py --all
+    python3 scripts/verify-bump.py skills/diagram-design/assets/example-bump.html
+
+Exit: 0 clean, 1 findings, 2 usage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+ASSET_DIR = ROOT / "skills/diagram-design/assets"
+
+PATH_RE = re.compile(r"<path\b(?P<attrs>[^>]*?)/?>", re.IGNORECASE)
+CIRCLE_RE = re.compile(r"<circle\b(?P<attrs>[^>]*?)/?>", re.IGNORECASE)
+TEXT_RE = re.compile(r"<text\b(?P<attrs>[^>]*)>(?P<body>.*?)</text>", re.IGNORECASE | re.DOTALL)
+COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+NAMED_RE = re.compile(r"<(?P<tag>title|desc)\b[^>]*>(?P<body>.*?)</(?P=tag)>",
+                      re.IGNORECASE | re.DOTALL)
+GROUP_OPEN_RE = re.compile(r"<(?:g|svg)\b(?P<attrs>[^>]*?)(?P<selfclose>/?)>", re.IGNORECASE)
+GROUP_CLOSE_RE = re.compile(r"</(?:g|svg)\s*>", re.IGNORECASE)
+STYLE_RE = re.compile(r"<style\b[^>]*>(?P<body>.*?)</style>", re.IGNORECASE | re.DOTALL)
+# `transform:` but not `text-transform:` - the editorial template uses the latter.
+CSS_TRANSFORM_RE = re.compile(r"(?<![\w-])transform\s*:", re.IGNORECASE)
+TAG_RE = re.compile(r"<[^>]+>")
+# Both quote styles, for the same reason verify-slopegraph gives: a
+# single-quoted attribute must be read, not silently dropped from the set.
+ATTR_RE = re.compile(
+    r"""(?P<name>[\w:-]+)\s*=\s*(?P<quote>["'])(?P<value>.*?)(?P=quote)""",
+    re.DOTALL,
+)
+DECLARES_RANKS_RE = re.compile(r"\bdata-ranks\s*=", re.IGNORECASE)
+NUM_RE = re.compile(r"[-+]?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][-+]?\d+)?")
+RANK_LABEL_RE = re.compile(r"^#(\d+)$")
+
+# Rank is ordinal and the shipped coordinates are integers, so the only slack
+# granted is float formatting - far below half a pixel, let alone half a row.
+GRID_TOLERANCE = 0.01     # px, a vertex against the rank grid
+DOT_TOLERANCE = 0.01      # px, a dot against its vertex
+CAPTION_TOLERANCE = 0.5   # px, a snapshot caption against its column
+LABEL_ROW_OFFSET = 3.5    # px, a label baseline below its vertex, per the reference
+MIN_SNAPSHOTS, MAX_SNAPSHOTS = 3, 6
+MAX_SERIES = 8
+FOCAL_WIDTH, PLAIN_WIDTH = 2.4, 1.2
+ACCENTS = {"#eb6c36", "#f08a59"}   # light and dark skin accent tokens
+
+
+class Series:
+    __slots__ = ("name", "ranks", "points", "stroke", "width", "offset")
+
+    def __init__(self, name, ranks, points, stroke, width, offset):
+        self.name = name
+        self.ranks = ranks
+        self.points = points
+        self.stroke = stroke
+        self.width = width
+        self.offset = offset
+
+    @property
+    def focal(self):
+        return self.stroke in ACCENTS
+
+
+def attrs_of(raw: str) -> dict:
+    found = {}
+    for match in ATTR_RE.finditer(raw):
+        name = match.group("name").lower()
+        if name not in found:            # a browser keeps the FIRST of a repeat
+            found[name] = html.unescape(match.group("value"))
+    return found
+
+
+def number(value):
+    if value is None:
+        return None
+    match = NUM_RE.fullmatch(value.strip())
+    if not match:
+        return None
+    try:
+        return float(match.group(0))
+    except ValueError:
+        return None
+
+
+def line_of(source: str, offset: int) -> int:
+    return source.count("\n", 0, offset) + 1
+
+
+def plain(body: str) -> str:
+    return TAG_RE.sub("", html.unescape(body)).strip()
+
+
+def blank_comments(source: str) -> str:
+    """Comments replaced with spaces, offsets preserved."""
+    return COMMENT_RE.sub(lambda m: " " * len(m.group(0)), source)
+
+
+def named_text(source: str) -> str:
+    return " ".join(
+        plain(m.group("body")).lower() for m in NAMED_RE.finditer(source)
+    )
+
+
+def looks_like_bump(path: Path, source: str) -> bool:
+    """Does this file present itself as a bump chart?
+
+    Generous on the vocabulary this contract binds: `data-ranks` belongs to no
+    other chart in this repo, so any file declaring it is held to the contract
+    even if nothing else parses - that combination is the fail-closed case.
+    """
+    if path.name.startswith("example-bump"):
+        return True
+    if DECLARES_RANKS_RE.search(source):
+        return True
+    return "bump chart" in named_text(source)
+
+
+def parse_d(d: str):
+    """(commands, points) for a polyline path, or (None, None) if unreadable."""
+    commands = re.findall(r"[A-Za-z]", d)
+    numbers = [float(n) for n in NUM_RE.findall(d)]
+    if len(numbers) % 2 != 0:
+        return None, None
+    points = list(zip(numbers[0::2], numbers[1::2]))
+    return commands, points
+
+
+def parse_series(source: str, findings: list, name: str) -> list:
+    series = []
+    for match in PATH_RE.finditer(source):
+        raw = match.group("attrs")
+        attrs = attrs_of(raw)
+        label = attrs.get("data-series")
+        if label is None:
+            if DECLARES_RANKS_RE.search(raw):
+                findings.append(
+                    "%s:%d: a <path> declares data-ranks but no data-series — a "
+                    "ranked line must say which series it draws, or its labels "
+                    "cannot be bound to it"
+                    % (name, line_of(source, match.start()))
+                )
+            continue
+        ranks_raw = attrs.get("data-ranks")
+        if ranks_raw is None:
+            findings.append(
+                "%s:%d: series %r declares data-series but no data-ranks — the "
+                "declared ranks are the basis every drawn position is verified "
+                "against, so a path without them cannot be checked"
+                % (name, line_of(source, match.start()), label)
+            )
+            continue
+        try:
+            ranks = [int(part.strip()) for part in ranks_raw.split(",")]
+        except ValueError:
+            findings.append(
+                "%s:%d: series %r has data-ranks=%r, which is not a comma list of "
+                "integers — rank is ordinal, and a rank that is not a whole number "
+                "is not a rank"
+                % (name, line_of(source, match.start()), label, ranks_raw)
+            )
+            continue
+        commands, points = parse_d(attrs.get("d", ""))
+        if commands is None or not points:
+            findings.append(
+                "%s:%d: series %r has a path this checker cannot read — cannot "
+                "verify its positions" % (name, line_of(source, match.start()), label)
+            )
+            continue
+        # Straight segments only. A curve between two snapshots draws data
+        # nobody measured; M + L* is the entire permitted grammar.
+        if [c.upper() for c in commands] != ["M"] + ["L"] * (len(points) - 1):
+            findings.append(
+                "%s:%d: series %r draws %s — a bump chart joins adjacent snapshots "
+                "with straight segments only. A spline invents a trajectory between "
+                "ranks that were only measured at the snapshots"
+                % (name, line_of(source, match.start()), label, "/".join(commands))
+            )
+            continue
+        if len(points) != len(ranks):
+            findings.append(
+                "%s:%d: series %r declares %d ranks but draws %d points — every "
+                "declared rank needs its vertex and every vertex its rank"
+                % (name, line_of(source, match.start()), label, len(ranks), len(points))
+            )
+            continue
+        width = number(attrs.get("stroke-width"))
+        series.append(Series(label, ranks, points,
+                             (attrs.get("stroke") or "").strip().lower(),
+                             width, match.start()))
+    return series
+
+
+def transformed_spans(source: str) -> list:
+    events = []
+    for match in GROUP_OPEN_RE.finditer(source):
+        if match.group("selfclose"):
+            continue
+        attrs = attrs_of(match.group("attrs"))
+        events.append((match.start(), "open", "transform" in attrs))
+    for match in GROUP_CLOSE_RE.finditer(source):
+        events.append((match.start(), "close", False))
+    events.sort()
+    spans, stack = [], []
+    for position, kind, transformed in events:
+        if kind == "open":
+            stack.append((position, transformed))
+        elif stack:
+            start, was_transformed = stack.pop()
+            if was_transformed:
+                spans.append((start, position))
+    for start, was_transformed in stack:
+        if was_transformed:
+            spans.append((start, len(source)))
+    return spans
+
+
+def check_transforms(source: str, findings: list, name: str) -> None:
+    """No transform may move verified geometry or a bound label."""
+    spans = transformed_spans(source)
+
+    def enclosed(offset):
+        return any(start <= offset <= end for start, end in spans)
+
+    def report(offset, what, how):
+        findings.append(
+            "%s:%d: %s carries %s — this checker validates raw coordinates, so a "
+            "transform moves the rendered mark away from the rank it was checked "
+            "against. Bake the offset into the coordinates instead"
+            % (name, line_of(source, offset), what, how)
+        )
+
+    for match in PATH_RE.finditer(source):
+        attrs = attrs_of(match.group("attrs"))
+        if "data-series" not in attrs:
+            continue
+        what = "series %r" % attrs["data-series"]
+        if "transform" in attrs:
+            report(match.start(), what, "transform=%r" % attrs["transform"])
+        elif enclosed(match.start()):
+            report(match.start(), what, "an ancestor <g>/<svg> transform")
+
+    for match in TEXT_RE.finditer(source):
+        attrs = attrs_of(match.group("attrs"))
+        if "data-series" not in attrs and "data-axis" not in attrs:
+            continue
+        what = "a bound label (%s)" % plain(match.group("body"))[:20]
+        if "transform" in attrs:
+            report(match.start(), what, "transform=%r" % attrs["transform"])
+        elif enclosed(match.start()):
+            report(match.start(), what, "an ancestor <g>/<svg> transform")
+
+    for match in STYLE_RE.finditer(source):
+        found = CSS_TRANSFORM_RE.search(match.group("body"))
+        if found:
+            findings.append(
+                "%s:%d: a CSS `transform` declaration — this checker cannot tell "
+                "which marks it applies to, and a transform on verified geometry "
+                "invalidates every coordinate here"
+                % (name, line_of(source, match.start("body") + found.start()))
+            )
+
+
+def check_columns(series: list, findings: list, source: str, name: str) -> None:
+    """Every series visits the same x positions, in increasing order."""
+    reference = [round(x, 3) for x, _ in series[0].points]
+    if sorted(set(reference)) != reference:
+        findings.append(
+            "%s:%d: series %r visits columns at x=%s, which is not strictly "
+            "increasing — snapshots are ordered, and a column visited twice or out "
+            "of order redraws time"
+            % (name, line_of(source, series[0].offset), series[0].name,
+               "/".join("%g" % x for x in reference))
+        )
+        return
+    for s in series[1:]:
+        xs = [round(x, 3) for x, _ in s.points]
+        if xs != reference:
+            findings.append(
+                "%s:%d: series %r visits columns at x=%s but %r set them at %s — "
+                "every series must visit the same snapshots or the columns stop "
+                "meaning moments"
+                % (name, line_of(source, s.offset), s.name,
+                   "/".join("%g" % x for x in xs), series[0].name,
+                   "/".join("%g" % x for x in reference))
+            )
+
+
+def rank_map(series: list):
+    """(top, pitch) derived from the figure, or None if it cannot be derived."""
+    pairs = {}
+    for s in series:
+        for rank, (_, y) in zip(s.ranks, s.points):
+            pairs.setdefault(rank, y)
+    if len(pairs) < 2:
+        return None
+    ranks = sorted(pairs)
+    r0, r1 = ranks[0], ranks[-1]
+    pitch = (pairs[r1] - pairs[r0]) / (r1 - r0)
+    top = pairs[r0] - (r0 - 1) * pitch
+    if pitch <= 0:
+        return None
+    return top, pitch
+
+
+def check_grid(series: list, findings: list, source: str, name: str) -> None:
+    """Every vertex sits exactly on the one rank grid; every column is a permutation."""
+    derived = rank_map(series)
+    if derived is None:
+        findings.append(
+            "%s: no downward rank grid could be derived — the figure's vertices "
+            "must place rank 1 at the top and each further rank one fixed pitch "
+            "below it. Refusing to report OK on a grid this checker could not read"
+            % name
+        )
+        return
+    top, pitch = derived
+    for s in series:
+        for rank, (x, y) in zip(s.ranks, s.points):
+            if rank < 1:
+                findings.append(
+                    "%s:%d: series %r declares rank %d — ranks count from 1"
+                    % (name, line_of(source, s.offset), s.name, rank)
+                )
+                continue
+            expected = top + (rank - 1) * pitch
+            if abs(y - expected) > GRID_TOLERANCE:
+                findings.append(
+                    "%s:%d: series %r draws rank %d at y=%g, but the figure's grid "
+                    "puts that rank at y=%g — rank is ordinal, so there is no honest "
+                    "reason for a vertex to sit off its row. A nudge to dodge a "
+                    "label collision reads as a rank between two ranks"
+                    % (name, line_of(source, s.offset), s.name, rank, y, expected)
+                )
+
+    total = len(series)
+    columns = len(series[0].points)
+    for column in range(columns):
+        seen = {}
+        for s in series:
+            if column < len(s.ranks):
+                seen.setdefault(s.ranks[column], []).append(s.name)
+        for rank, owners in sorted(seen.items()):
+            if len(owners) > 1:
+                findings.append(
+                    "%s: snapshot %d ranks %s all at #%d — the footnote's tie-break "
+                    "rule exists so that a rank is held by exactly one series"
+                    % (name, column + 1, "/".join(repr(o) for o in owners), rank)
+                )
+        missing = [r for r in range(1, total + 1) if r not in seen]
+        for rank in missing:
+            findings.append(
+                "%s: snapshot %d has no series at rank #%d — with %d series each "
+                "snapshot must use each rank 1..%d exactly once, or an empty row "
+                "invites the reader to fill it"
+                % (name, column + 1, rank, total, total)
+            )
+
+
+def check_dots(series: list, source: str, findings: list, name: str) -> None:
+    """Every vertex carries its dot, sized by focus."""
+    dots = []
+    for match in CIRCLE_RE.finditer(source):
+        attrs = attrs_of(match.group("attrs"))
+        cx, cy, r = (number(attrs.get(k)) for k in ("cx", "cy", "r"))
+        if None not in (cx, cy, r):
+            dots.append((cx, cy, r))
+    for s in series:
+        want = 4.0 if s.focal else 3.0
+        for rank, (x, y) in zip(s.ranks, s.points):
+            hit = [r for cx, cy, r in dots
+                   if abs(cx - x) <= DOT_TOLERANCE and abs(cy - y) <= DOT_TOLERANCE]
+            if not hit:
+                findings.append(
+                    "%s:%d: series %r has no dot at its rank-%d vertex (%g,%g) — "
+                    "the dots are the readable positions, so a vertex without one "
+                    "is a rank the reader cannot fix on a row"
+                    % (name, line_of(source, s.offset), s.name, rank, x, y)
+                )
+            elif want not in hit:
+                findings.append(
+                    "%s:%d: series %r has a dot of r=%s at (%g,%g), but a %s series "
+                    "takes r=%g — dot size is the focus cue that survives greyscale"
+                    % (name, line_of(source, s.offset), s.name,
+                       "/".join("%g" % r for r in hit), x, y,
+                       "focal" if s.focal else "non-focal", want)
+                )
+
+
+def check_focus(series: list, findings: list, source: str, name: str) -> None:
+    """Exactly one focal series, and stroke weight agreeing with stroke colour."""
+    focal = [s for s in series if s.focal]
+    if len(focal) != 1:
+        findings.append(
+            "%s: %d series carry the accent stroke — the accent marks exactly one "
+            "editorially focal series, and spending it twice spends it entirely"
+            % (name, len(focal))
+        )
+    for s in series:
+        want = FOCAL_WIDTH if s.focal else PLAIN_WIDTH
+        if s.width is None or abs(s.width - want) > 1e-9:
+            findings.append(
+                "%s:%d: series %r has stroke-width=%s but a %s series takes %g — "
+                "weight is the focus cue, so a mismatch between colour and weight "
+                "sends the two cues to different series"
+                % (name, line_of(source, s.offset), s.name,
+                   "%g" % s.width if s.width is not None else "?",
+                   "focal" if s.focal else "non-focal", want)
+            )
+
+
+def collect_bound_labels(source: str, findings: list, name: str) -> dict:
+    bound = {}
+    for match in TEXT_RE.finditer(source):
+        attrs = attrs_of(match.group("attrs"))
+        label = attrs.get("data-series")
+        if label is None:
+            continue
+        end = attrs.get("data-end")
+        role = attrs.get("data-role")
+        key = (label, end, role)
+        if key in bound:
+            findings.append(
+                "%s:%d: a second %s %s label for series %r — one label per binding, "
+                "or a reader has two statements and no way to pick"
+                % (name, line_of(source, match.start()), end, role, label)
+            )
+            continue
+        bound[key] = (plain(match.group("body")), number(attrs.get("y")), match.start())
+    return bound
+
+
+def check_labels(series: list, source: str, findings: list, name: str) -> None:
+    """Names and ranks printed at both ends, bound, agreeing, and on their row."""
+    bound = collect_bound_labels(source, findings, name)
+    declared = {s.name: s for s in series}
+
+    for (label, end, role), (body, y, offset) in sorted(
+        bound.items(), key=lambda item: item[1][2]
+    ):
+        if label not in declared:
+            findings.append(
+                "%s:%d: a %s label names series %r, which no path declares — a "
+                "label with no mark is not verifiable and reads as data"
+                % (name, line_of(source, offset), role, label)
+            )
+            continue
+        if end not in ("first", "last"):
+            findings.append(
+                "%s:%d: label for series %r has data-end=%r, which is neither "
+                "'first' nor 'last'" % (name, line_of(source, offset), label, end)
+            )
+            continue
+        s = declared[label]
+        vertex_y = s.points[0][1] if end == "first" else s.points[-1][1]
+        # Row placement: nearer another series' same-end vertex than its own
+        # means the label renames a line, with every number still correct.
+        if y is not None:
+            own = abs(y - (vertex_y + LABEL_ROW_OFFSET))
+            for other in series:
+                if other.name == label:
+                    continue
+                other_y = other.points[0][1] if end == "first" else other.points[-1][1]
+                if abs(y - (other_y + LABEL_ROW_OFFSET)) < own:
+                    findings.append(
+                        "%s:%d: the %s %s label for series %r is drawn at y=%g, "
+                        "nearer %r's endpoint than its own — a label on the wrong "
+                        "row renames the line"
+                        % (name, line_of(source, offset), end, role, label, y,
+                           other.name)
+                    )
+                    break
+        if role == "rank":
+            match = RANK_LABEL_RE.match(body)
+            declared_rank = s.ranks[0] if end == "first" else s.ranks[-1]
+            if not match:
+                findings.append(
+                    "%s:%d: series %r prints its %s rank as %r — a rank label is "
+                    "'#' and the rank, so it cannot be mistaken for a magnitude"
+                    % (name, line_of(source, offset), label, end, body)
+                )
+            elif int(match.group(1)) != declared_rank:
+                findings.append(
+                    "%s:%d: series %r prints %s rank %r but declares rank %d — the "
+                    "label and the geometry must state one number"
+                    % (name, line_of(source, offset), label, end, body, declared_rank)
+                )
+        elif role == "name":
+            if body != label:
+                findings.append(
+                    "%s:%d: a name label bound to series %r reads %r — the visible "
+                    "name and its binding must agree"
+                    % (name, line_of(source, offset), label, body)
+                )
+
+    for s in series:
+        for end in ("first", "last"):
+            for role in ("name", "rank"):
+                if (s.name, end, role) not in bound:
+                    findings.append(
+                        "%s:%d: series %r prints no %s %s label — a bump chart "
+                        "labels each series where it enters and where it leaves, or "
+                        "the reader traces a line to an unlabelled end"
+                        % (name, line_of(source, s.offset), s.name, end, role)
+                    )
+
+
+def check_captions(series: list, source: str, findings: list, name: str) -> None:
+    """One caption per snapshot column, on its column, text bound by data-state."""
+    columns = [x for x, _ in series[0].points]
+    seen = {}
+    for match in TEXT_RE.finditer(source):
+        attrs = attrs_of(match.group("attrs"))
+        axis = attrs.get("data-axis")
+        if axis is None:
+            continue
+        if not axis.isdigit() or not 0 <= int(axis) < len(columns):
+            findings.append(
+                "%s:%d: a snapshot caption has data-axis=%r, which is not a column "
+                "index 0..%d" % (name, line_of(source, match.start()), axis,
+                                 len(columns) - 1)
+            )
+            continue
+        index = int(axis)
+        if index in seen:
+            findings.append(
+                "%s:%d: a second caption for snapshot %d — one column, one caption"
+                % (name, line_of(source, match.start()), index + 1)
+            )
+            continue
+        seen[index] = (number(attrs.get("x")), plain(match.group("body")),
+                       attrs.get("data-state"), match.start())
+
+    labels = []
+    for index in range(len(columns)):
+        if index not in seen:
+            findings.append(
+                "%s: no caption for snapshot %d (data-axis=\"%d\") — unbound "
+                "captions can be swapped, which redraws when everything happened"
+                % (name, index + 1, index)
+            )
+            continue
+        x, body, declared, offset = seen[index]
+        if x is None or abs(x - columns[index]) > CAPTION_TOLERANCE:
+            findings.append(
+                "%s:%d: the caption for snapshot %d (%r) is drawn at x=%s but its "
+                "column is at x=%g — a caption off its column renames the moment"
+                % (name, line_of(source, offset), index + 1, body[:20],
+                   "%g" % x if x is not None else "?", columns[index])
+            )
+        if declared is None:
+            findings.append(
+                "%s:%d: the caption for snapshot %d (%r) has no data-state — its "
+                "visible text is unbound, so it can be exchanged with another "
+                "caption and nothing here would notice"
+                % (name, line_of(source, offset), index + 1, body[:20])
+            )
+        elif body != declared:
+            findings.append(
+                "%s:%d: the caption for snapshot %d reads %r but declares "
+                "data-state=%r — the visible caption and its binding must agree"
+                % (name, line_of(source, offset), index + 1, body[:20], declared)
+            )
+        labels.append(body)
+    if len(labels) == len(columns) and len(set(labels)) != len(labels):
+        findings.append(
+            "%s: two snapshot captions read the same — two moments the reader "
+            "cannot tell apart is not an ordering" % name
+        )
+
+
+def check_source(path: Path, raw: str) -> list:
+    source = blank_comments(raw)
+    findings: list = []
+    series = parse_series(source, findings, path.name)
+
+    if len(series) < 2:
+        findings.append(
+            "%s: presents as a bump chart but declares %d verifiable series — every "
+            "ranked line needs data-series with data-ranks. Refusing to report OK "
+            "on a file this checker could not read" % (path.name, len(series))
+        )
+        return findings
+
+    if len(series) > MAX_SERIES:
+        findings.append(
+            "%s: %d series against a budget of %d — past that the crossings stop "
+            "being readable and the figure becomes spaghetti with a legend"
+            % (path.name, len(series), MAX_SERIES)
+        )
+    columns = len(series[0].points)
+    if not MIN_SNAPSHOTS <= columns <= MAX_SNAPSHOTS:
+        findings.append(
+            "%s: %d snapshots against a budget of %d-%d — two snapshots are a "
+            "slopegraph, and past %d the columns compress until rank changes "
+            "cannot be followed"
+            % (path.name, columns, MIN_SNAPSHOTS, MAX_SNAPSHOTS, MAX_SNAPSHOTS)
+        )
+
+    check_transforms(source, findings, path.name)
+    check_columns(series, findings, source, path.name)
+    check_grid(series, findings, source, path.name)
+    check_dots(series, source, findings, path.name)
+    check_focus(series, findings, source, path.name)
+    check_labels(series, source, findings, path.name)
+    check_captions(series, source, findings, path.name)
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify bump chart positions against the ranks they declare."
+    )
+    parser.add_argument("paths", nargs="*", help="HTML files to check")
+    parser.add_argument(
+        "--all", action="store_true",
+        help="check every shipped example that presents as a bump chart",
+    )
+    args = parser.parse_args()
+    if not args.all and not args.paths:
+        parser.print_help()
+        return 2
+
+    if args.all:
+        targets = sorted(ASSET_DIR.glob("example-*.html"))
+    else:
+        targets = [Path(p) for p in args.paths]
+
+    findings: list = []
+    checked = 0
+    skipped = 0
+    for path in targets:
+        if not path.is_file():
+            print("error: %s is not a readable file" % path, file=sys.stderr)
+            return 2
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as error:
+            print("error: cannot read %s: %s" % (path, error), file=sys.stderr)
+            return 2
+        if not looks_like_bump(path, raw):
+            skipped += 1
+            continue
+        findings.extend(check_source(path, raw))
+        checked += 1
+
+    for finding in findings:
+        print(finding)
+    tail = " (%d file(s) skipped as out of scope)" % skipped if skipped else ""
+    if findings:
+        print("\n%d bump finding(s) across %d file(s).%s"
+              % (len(findings), checked, tail))
+        return 1
+    if not checked:
+        print("OK bump: no bump chart found to check%s" % tail)
+        return 0
+    print("OK bump: %d file(s), every vertex exactly on one rank grid, every "
+          "snapshot a permutation, straight segments only, and every printed rank, "
+          "name and caption bound to what it describes%s" % (checked, tail))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-bump.py
+++ b/scripts/verify-bump.py
@@ -31,15 +31,22 @@ Six invariants:
    order, and each snapshot caption sits on the column it names, bound with
    data-axis and data-state exactly as the slopegraph binds its two.
 
-5. LABELS BOUND TO MEANING - each series prints its name and its rank at
-   first and last appearance, each label bound by data-series / data-end /
-   data-role, each printed "#k" agreeing with the declared rank, and each
-   sitting on its own series' row rather than a neighbour's.
+5. LABELS BOUND TO MEANING AND PLACED ON BOTH AXES - each series prints its
+   name and its rank at first and last appearance, each label bound by
+   data-series / data-end / data-role, each printed "#k" agreeing with the
+   declared rank, each sitting on its own series' row rather than a
+   neighbour's, and each in the gutter outboard of the end it names. Row and
+   column answer different questions - WHICH SERIES and WHICH END - so a
+   label with an impeccable row and a deleted or displaced x is misplaced
+   and used to be certified.
 
 6. FAIL CLOSED - zero parseable series, a path that declares data-series but
-   cannot be read, a vertex with no dot, or a transform anywhere near verified
-   geometry is a finding, never a skip. A checker that reports OK because it
-   found nothing to compare is the bug, not the gate.
+   cannot be read, a vertex with no dot, a label coordinate that is absent,
+   empty or non-finite, or a transform anywhere near verified geometry is a
+   finding, never a skip. A checker that reports OK because it found nothing
+   to compare is the bug, not the gate. An absent attribute is the loudest
+   version of this: it is not an unspecified position, it is the browser's
+   default one, and it renders.
 
 WHAT THIS DOES NOT CHECK, deliberately:
 
@@ -62,6 +69,7 @@ from __future__ import annotations
 
 import argparse
 import html
+import math
 import re
 import sys
 from pathlib import Path
@@ -129,15 +137,23 @@ def attrs_of(raw: str) -> dict:
 
 
 def number(value):
+    """An SVG coordinate, or None when it cannot be placed.
+
+    None covers absent, unparseable AND non-finite, because every caller
+    treats None as "report this" rather than "skip this". "1e400" parses and
+    overflows to inf, which compares further-than-any-tolerance from every
+    real coordinate and would otherwise sail through a naive distance test.
+    """
     if value is None:
         return None
     match = NUM_RE.fullmatch(value.strip())
     if not match:
         return None
     try:
-        return float(match.group(0))
+        parsed = float(match.group(0))
     except ValueError:
         return None
+    return parsed if math.isfinite(parsed) else None
 
 
 def line_of(source: str, offset: int) -> int:
@@ -496,17 +512,29 @@ def collect_bound_labels(source: str, findings: list, name: str) -> dict:
                 % (name, line_of(source, match.start()), end, role, label)
             )
             continue
-        bound[key] = (plain(match.group("body")), number(attrs.get("y")), match.start())
+        bound[key] = (plain(match.group("body")), number(attrs.get("x")),
+                      number(attrs.get("y")), match.start())
     return bound
 
 
 def check_labels(series: list, source: str, findings: list, name: str) -> None:
-    """Names and ranks printed at both ends, bound, agreeing, and on their row."""
+    """Names and ranks printed at both ends, bound, agreeing, and placed.
+
+    Placement is verified on BOTH axes, because each answers a different
+    question and neither implies the other. The row (y) says which series a
+    label belongs to; the column (x) says which END of that series it belongs
+    to. A first-end label slid along its own row into the middle of the plot
+    keeps every rank correct and every row correct while reading against the
+    wrong snapshot - so a row-only check certifies it.
+    """
     bound = collect_bound_labels(source, findings, name)
     declared = {s.name: s for s in series}
+    # check_columns has already established that every series shares these.
+    columns = [x for x, _ in series[0].points]
+    gutters = {}
 
-    for (label, end, role), (body, y, offset) in sorted(
-        bound.items(), key=lambda item: item[1][2]
+    for (label, end, role), (body, x, y, offset) in sorted(
+        bound.items(), key=lambda item: item[1][3]
     ):
         if label not in declared:
             findings.append(
@@ -523,23 +551,56 @@ def check_labels(series: list, source: str, findings: list, name: str) -> None:
             continue
         s = declared[label]
         vertex_y = s.points[0][1] if end == "first" else s.points[-1][1]
+        endpoint_x = columns[0] if end == "first" else columns[-1]
+
+        # Both coordinates must be readable before either can be judged. An
+        # absent x or y is not "unspecified": SVG defaults it to 0, so the
+        # browser draws the label hard against the edge of the frame while a
+        # checker that skips the comparison reports the figure clean. That
+        # skip is invariant 6's named failure, so it is a finding here.
+        unplaced = [axis for axis, value in (("x", x), ("y", y)) if value is None]
+        if unplaced:
+            findings.append(
+                "%s:%d: the %s %s label for series %r has no readable %s — the "
+                "browser falls back to 0 and draws it at the edge of the frame, "
+                "so an unreadable coordinate is a misplaced label, never an "
+                "unchecked one"
+                % (name, line_of(source, offset), end, role, label,
+                   " or ".join(unplaced))
+            )
+            continue
+
+        gutters.setdefault((end, role), []).append((x, label, offset))
+
+        # Column placement: a label inboard of its own endpoint sits over the
+        # plot, beside a snapshot it does not describe.
+        if (end == "first" and x > endpoint_x + GRID_TOLERANCE) or (
+            end == "last" and x < endpoint_x - GRID_TOLERANCE
+        ):
+            findings.append(
+                "%s:%d: the %s %s label for series %r is drawn at x=%g, inboard "
+                "of the %s endpoint at x=%g — a label inside the plot is read "
+                "against whichever snapshot it lands on"
+                % (name, line_of(source, offset), end, role, label, x, end,
+                   endpoint_x)
+            )
+
         # Row placement: nearer another series' same-end vertex than its own
         # means the label renames a line, with every number still correct.
-        if y is not None:
-            own = abs(y - (vertex_y + LABEL_ROW_OFFSET))
-            for other in series:
-                if other.name == label:
-                    continue
-                other_y = other.points[0][1] if end == "first" else other.points[-1][1]
-                if abs(y - (other_y + LABEL_ROW_OFFSET)) < own:
-                    findings.append(
-                        "%s:%d: the %s %s label for series %r is drawn at y=%g, "
-                        "nearer %r's endpoint than its own — a label on the wrong "
-                        "row renames the line"
-                        % (name, line_of(source, offset), end, role, label, y,
-                           other.name)
-                    )
-                    break
+        own = abs(y - (vertex_y + LABEL_ROW_OFFSET))
+        for other in series:
+            if other.name == label:
+                continue
+            other_y = other.points[0][1] if end == "first" else other.points[-1][1]
+            if abs(y - (other_y + LABEL_ROW_OFFSET)) < own:
+                findings.append(
+                    "%s:%d: the %s %s label for series %r is drawn at y=%g, "
+                    "nearer %r's endpoint than its own — a label on the wrong "
+                    "row renames the line"
+                    % (name, line_of(source, offset), end, role, label, y,
+                       other.name)
+                )
+                break
         if role == "rank":
             match = RANK_LABEL_RE.match(body)
             declared_rank = s.ranks[0] if end == "first" else s.ranks[-1]
@@ -573,6 +634,30 @@ def check_labels(series: list, source: str, findings: list, name: str) -> None:
                         "the reader traces a line to an unlabelled end"
                         % (name, line_of(source, s.offset), s.name, end, role)
                     )
+
+    # Every label sharing an end and a role is one gutter, so the figure
+    # declares its own gutter x the way it declares its own rank grid: by
+    # agreement across series, with no constant written down here. The
+    # inboard test above catches a label dragged across its endpoint; this
+    # catches one slid the other way, which stays outboard and keeps its row.
+    # How far out the gutter as a whole sits is a layout question and belongs
+    # to lint-render.py - this gate only requires that there BE one gutter.
+    for (end, role), placed in sorted(gutters.items()):
+        if len(placed) < 2:
+            continue
+        tally = {}
+        for x, _, _ in placed:
+            tally[x] = tally.get(x, 0) + 1
+        gutter = max(sorted(tally), key=lambda value: tally[value])
+        for x, label, offset in placed:
+            if abs(x - gutter) > GRID_TOLERANCE:
+                findings.append(
+                    "%s:%d: the %s %s label for series %r is drawn at x=%g, off "
+                    "the x=%g gutter its %d peers share — one label out of "
+                    "column points at a snapshot of its own"
+                    % (name, line_of(source, offset), end, role, label, x,
+                       gutter, tally[gutter])
+                )
 
 
 def check_captions(series: list, source: str, findings: list, name: str) -> None:

--- a/scripts/verify-bump.py
+++ b/scripts/verify-bump.py
@@ -21,9 +21,11 @@ Six invariants:
    rule says cannot happen; a skipped rank is an empty row the reader fills
    with a series that is not there.
 
-3. STRAIGHT SEGMENTS - a data-series path is M followed by L commands only.
-   A spline between two quarterly snapshots draws data nobody measured; the
-   draft this gate came from calls them subway curves and bans them outright.
+3. STRAIGHT SEGMENTS - a data-series path is absolute M followed by absolute
+   L commands only. A spline between two quarterly snapshots draws data nobody
+   measured; the draft this gate came from calls them subway curves and bans
+   them outright. Relative commands are refused rather than folded into their
+   absolute twins, because their numbers are not where the marks land.
 
 4. SHARED COLUMNS - every series visits the same x positions in the same
    order, and each snapshot caption sits on the column it names, bound with
@@ -96,7 +98,7 @@ DOT_TOLERANCE = 0.01      # px, a dot against its vertex
 CAPTION_TOLERANCE = 0.5   # px, a snapshot caption against its column
 LABEL_ROW_OFFSET = 3.5    # px, a label baseline below its vertex, per the reference
 MIN_SNAPSHOTS, MAX_SNAPSHOTS = 3, 6
-MAX_SERIES = 8
+MIN_SERIES, MAX_SERIES = 4, 8
 FOCAL_WIDTH, PLAIN_WIDTH = 2.4, 1.2
 ACCENTS = {"#eb6c36", "#f08a59"}   # light and dark skin accent tokens
 
@@ -222,9 +224,22 @@ def parse_series(source: str, findings: list, name: str) -> list:
                 "verify its positions" % (name, line_of(source, match.start()), label)
             )
             continue
-        # Straight segments only. A curve between two snapshots draws data
-        # nobody measured; M + L* is the entire permitted grammar.
-        if [c.upper() for c in commands] != ["M"] + ["L"] * (len(points) - 1):
+        # Straight segments in ABSOLUTE commands only: M + L* is the entire
+        # permitted grammar. A curve between two snapshots draws data nobody
+        # measured. And a relative command is refused rather than folded into
+        # its absolute twin - `l120,56` renders against the previous point
+        # while the numbers this checker reads look like absolute coordinates,
+        # so folding case would certify a figure at positions it never drew.
+        if any(c.islower() for c in commands):
+            findings.append(
+                "%s:%d: series %r uses relative path commands (%s) — a relative "
+                "coordinate renders against the previous point, so the numbers "
+                "this checker reads are not where the marks land. Write the path "
+                "in absolute M/L commands"
+                % (name, line_of(source, match.start()), label, "/".join(commands))
+            )
+            continue
+        if commands != ["M"] + ["L"] * (len(points) - 1):
             findings.append(
                 "%s:%d: series %r draws %s — a bump chart joins adjacent snapshots "
                 "with straight segments only. A spline invents a trajectory between "
@@ -642,6 +657,13 @@ def check_source(path: Path, raw: str) -> list:
             "%s: %d series against a budget of %d — past that the crossings stop "
             "being readable and the figure becomes spaghetti with a legend"
             % (path.name, len(series), MAX_SERIES)
+        )
+    elif len(series) < MIN_SERIES:
+        findings.append(
+            "%s: %d series against a budget of %d-%d — below %d a sentence or a "
+            "pair of slopes says it shorter, and rank stops being a crowd worth "
+            "charting"
+            % (path.name, len(series), MIN_SERIES, MAX_SERIES, MIN_SERIES)
         )
     columns = len(series[0].points)
     if not MIN_SNAPSHOTS <= columns <= MAX_SNAPSHOTS:

--- a/scripts/verify-slopegraph.py
+++ b/scripts/verify-slopegraph.py
@@ -110,6 +110,13 @@ ATTR_RE = re.compile(
     re.DOTALL,
 )
 DECLARES_SERIES_RE = re.compile(r"\bdata-series\s*=", re.IGNORECASE)
+# Scope detection to the ELEMENT this contract binds. `data-series` alone is
+# shared vocabulary across the chart variants - a bump chart binds it to
+# <path>, and holding that file to the slopegraph contract rejects a figure
+# for lacking <line> elements it never claimed to have. A slopegraph whose
+# <line> is malformed still matches here, so the fail-closed case is kept.
+LINE_DECLARES_SERIES_RE = re.compile(
+    r"<line\b[^>]*?\bdata-series\s*=", re.IGNORECASE | re.DOTALL)
 
 # Coordinates ship rounded to one decimal, so a point can sit 0.05px from its
 # true position honestly; an author rounding to whole pixels can sit 0.5px off.
@@ -273,7 +280,7 @@ def looks_like_slopegraph(path: Path, source: str) -> bool:
     """
     if path.name.startswith("example-slopegraph"):
         return True
-    if DECLARES_SERIES_RE.search(source):
+    if LINE_DECLARES_SERIES_RE.search(source):
         return True
     described = named_text(source)
     return "slopegraph" in described or "slope graph" in described

--- a/skills/diagram-design/SKILL.md
+++ b/skills/diagram-design/SKILL.md
@@ -102,7 +102,7 @@ The pattern owns semantic primitives and its tighter budget; the type owns layou
 | Ranked hierarchy or conversion drop-off | **Pyramid / funnel** | [type-pyramid.md](references/type-pyramid.md) |
 | Quantitative comparison across categories | **Bar chart** | [type-bar.md](references/type-bar.md) |
 | Part-of-whole where the relative sizes are the story | **Treemap** | [type-treemap.md](references/type-treemap.md) |
-| Continuous trends over time, change between exactly two states (slopegraph), or one distribution per series (ridgeline) | **Line chart** | [type-line.md](references/type-line.md) |
+| Continuous trends over time, change between exactly two states (slopegraph), one distribution per series (ridgeline), or rank movement across several snapshots (bump) | **Line chart** | [type-line.md](references/type-line.md) |
 | Tasks and phases on a timeline | **Gantt** | [type-gantt.md](references/type-gantt.md) |
 | Distribution and correlation between two variables, or three with area-sized marks (bubble) | **Scatter plot** | [type-scatter.md](references/type-scatter.md) |
 | End-to-end data stack on a container cluster | **High-Level** | [type-high-level.md](references/type-high-level.md) |

--- a/skills/diagram-design/assets/example-bump-dark.html
+++ b/skills/diagram-design/assets/example-bump-dark.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Package rank by quarter · Bump chart</title>
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --color-paper:  #2d3142;
+      --color-ink:    #f5f5f5;
+      --color-muted:  #bfc0c0;
+      --color-accent: #f08a59;
+      --font-sans:    'Geist', system-ui, sans-serif;
+      --font-serif:   'Instrument Serif', serif;
+      --font-mono:    'Geist Mono', ui-monospace, monospace;
+    }
+    body { font-family: var(--font-sans); background: var(--color-paper); color: var(--color-ink); min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 3rem 2rem; }
+    .frame { max-width: 1200px; width: 100%; }
+    .eyebrow { font-family: var(--font-mono); font-size: 0.66rem; font-weight: 500; letter-spacing: 0.18em; text-transform: uppercase; color: var(--color-muted); margin-bottom: 0.5rem; }
+    h1 { font-family: var(--font-serif); font-size: clamp(1.5rem, 2.4vw + 0.75rem, 2rem); font-weight: 400; letter-spacing: -0.02em; line-height: 1.15; margin-bottom: 1.5rem; }
+    svg { width: 100%; min-width: 760px; display: block; }
+  </style>
+</head>
+<body>
+  <div class="frame">
+    <p class="eyebrow">Bump chart · Diagram Design</p>
+    <h1>The default everyone stopped choosing</h1>
+
+    <svg viewBox="0 0 1000 500" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="bump-dark-title bump-dark-desc">
+      <title id="bump-dark-title">The default everyone stopped choosing</title>
+      <desc id="bump-dark-desc">Bump chart ranking six internal packages by weekly downloads across four quarters; legacy-http slides from first to sixth while fetch-kit takes the top rank in the second quarter and keeps it.</desc>
+      <defs>
+        <pattern id="dots" width="22" height="22" patternUnits="userSpaceOnUse">
+          <circle cx="1" cy="1" r="0.9" fill="rgba(245,245,245,0.10)"/>
+        </pattern>
+      </defs>
+
+      <rect width="100%" height="100%" fill="#2d3142"/>
+      <rect width="100%" height="100%" fill="url(#dots)" opacity="0.55"/>
+
+      <!-- Rank is ORDINAL: every vertex sits exactly on a rank row, y = 88 + 56 x
+           (rank - 1), and every snapshot's ranks are a permutation of 1..6.
+           scripts/verify-bump.py enforces both against the ranks each series
+           declares - there is no tolerance, because rank has no fractions. -->
+      <text transform="rotate(-90 24 228)" x="24" y="228" fill="#bfc0c0" font-size="7" font-family="'Geist Mono', monospace" letter-spacing="0.14em" text-anchor="middle">RANK BY WEEKLY DOWNLOADS · 1 = MOST</text>
+
+      <!-- One axis rule per snapshot. No gridlines: the dots are the readable
+           positions and each series prints its first and last rank. -->
+      <line x1="320" y1="64" x2="320" y2="392" stroke="rgba(245,245,245,0.25)" stroke-width="1"/>
+      <text data-axis="0" data-state="Q1" x="320" y="416" fill="#bfc0c0" font-size="9" font-family="'Geist Mono', monospace" letter-spacing="0.14em" text-anchor="middle">Q1</text>
+      <line x1="440" y1="64" x2="440" y2="392" stroke="rgba(245,245,245,0.25)" stroke-width="1"/>
+      <text data-axis="1" data-state="Q2" x="440" y="416" fill="#bfc0c0" font-size="9" font-family="'Geist Mono', monospace" letter-spacing="0.14em" text-anchor="middle">Q2</text>
+      <line x1="560" y1="64" x2="560" y2="392" stroke="rgba(245,245,245,0.25)" stroke-width="1"/>
+      <text data-axis="2" data-state="Q3" x="560" y="416" fill="#bfc0c0" font-size="9" font-family="'Geist Mono', monospace" letter-spacing="0.14em" text-anchor="middle">Q3</text>
+      <line x1="680" y1="64" x2="680" y2="392" stroke="rgba(245,245,245,0.25)" stroke-width="1"/>
+      <text data-axis="3" data-state="Q4" x="680" y="416" fill="#bfc0c0" font-size="9" font-family="'Geist Mono', monospace" letter-spacing="0.14em" text-anchor="middle">Q4</text>
+
+      <!-- Straight segments between adjacent snapshots - never splines, which
+           invent a trajectory between ranks that were only measured quarterly.
+           Ramp ordered by Q1 rank: strongest tone was highest-ranked at Q1. -->
+      <path data-series="authx" data-ranks="2,3,3,2" d="M320,144 L440,200 L560,200 L680,144" fill="none" stroke="rgba(245,245,245,0.80)" stroke-width="1.2"/>
+      <circle cx="320" cy="144" r="3" fill="rgba(245,245,245,0.80)"/>
+      <circle cx="440" cy="200" r="3" fill="rgba(245,245,245,0.80)"/>
+      <circle cx="560" cy="200" r="3" fill="rgba(245,245,245,0.80)"/>
+      <circle cx="680" cy="144" r="3" fill="rgba(245,245,245,0.80)"/>
+      <text data-series="authx" data-end="first" data-role="name" x="272" y="147.5" fill="#f5f5f5" font-size="11" font-weight="500" font-family="'Geist', sans-serif" text-anchor="end">authx</text>
+      <text data-series="authx" data-end="first" data-role="rank" x="304" y="147.5" fill="#bfc0c0" font-size="9" font-family="'Geist Mono', monospace" text-anchor="end">#2</text>
+      <text data-series="authx" data-end="last" data-role="rank" x="696" y="147.5" fill="#bfc0c0" font-size="9" font-family="'Geist Mono', monospace">#2</text>
+      <text data-series="authx" data-end="last" data-role="name" x="728" y="147.5" fill="#f5f5f5" font-size="11" font-weight="500" font-family="'Geist', sans-serif">authx</text>
+
+      <path data-series="fetch-kit" data-ranks="3,1,1,1" d="M320,200 L440,88 L560,88 L680,88" fill="none" stroke="rgba(245,245,245,0.75)" stroke-width="1.2"/>
+      <circle cx="320" cy="200" r="3" fill="rgba(245,245,245,0.75)"/>
+      <circle cx="440" cy="88" r="3" fill="rgba(245,245,245,0.75)"/>
+      <circle cx="560" cy="88" r="3" fill="rgba(245,245,245,0.75)"/>
+      <circle cx="680" cy="88" r="3" fill="rgba(245,245,245,0.75)"/>
+      <text data-series="fetch-kit" data-end="first" data-role="name" x="272" y="203.5" fill="#f5f5f5" font-size="11" font-weight="500" font-family="'Geist', sans-serif" text-anchor="end">fetch-kit</text>
+      <text data-series="fetch-kit" data-end="first" data-role="rank" x="304" y="203.5" fill="#bfc0c0" font-size="9" font-family="'Geist Mono', monospace" text-anchor="end">#3</text>
+      <text data-series="fetch-kit" data-end="last" data-role="rank" x="696" y="91.5" fill="#bfc0c0" font-size="9" font-family="'Geist Mono', monospace">#1</text>
+      <text data-series="fetch-kit" data-end="last" data-role="name" x="728" y="91.5" fill="#f5f5f5" font-size="11" font-weight="500" font-family="'Geist', sans-serif">fetch-kit</text>
+
+      <path data-series="queuelib" data-ranks="4,5,5,4" d="M320,256 L440,312 L560,312 L680,256" fill="none" stroke="rgba(245,245,245,0.70)" stroke-width="1.2"/>
+      <circle cx="320" cy="256" r="3" fill="rgba(245,245,245,0.70)"/>
+      <circle cx="440" cy="312" r="3" fill="rgba(245,245,245,0.70)"/>
+      <circle cx="560" cy="312" r="3" fill="rgba(245,245,245,0.70)"/>
+      <circle cx="680" cy="256" r="3" fill="rgba(245,245,245,0.70)"/>
+      <text data-series="queuelib" data-end="first" data-role="name" x="272" y="259.5" fill="#f5f5f5" font-size="11" font-weight="500" font-family="'Geist', sans-serif" text-anchor="end">queuelib</text>
+      <text data-series="queuelib" data-end="first" data-role="rank" x="304" y="259.5" fill="#bfc0c0" font-size="9" font-family="'Geist Mono', monospace" text-anchor="end">#4</text>
+      <text data-series="queuelib" data-end="last" data-role="rank" x="696" y="259.5" fill="#bfc0c0" font-size="9" font-family="'Geist Mono', monospace">#4</text>
+      <text data-series="queuelib" data-end="last" data-role="name" x="728" y="259.5" fill="#f5f5f5" font-size="11" font-weight="500" font-family="'Geist', sans-serif">queuelib</text>
+
+      <path data-series="logfmt" data-ranks="5,4,2,3" d="M320,312 L440,256 L560,144 L680,200" fill="none" stroke="rgba(245,245,245,0.66)" stroke-width="1.2"/>
+      <circle cx="320" cy="312" r="3" fill="rgba(245,245,245,0.66)"/>
+      <circle cx="440" cy="256" r="3" fill="rgba(245,245,245,0.66)"/>
+      <circle cx="560" cy="144" r="3" fill="rgba(245,245,245,0.66)"/>
+      <circle cx="680" cy="200" r="3" fill="rgba(245,245,245,0.66)"/>
+      <text data-series="logfmt" data-end="first" data-role="name" x="272" y="315.5" fill="#f5f5f5" font-size="11" font-weight="500" font-family="'Geist', sans-serif" text-anchor="end">logfmt</text>
+      <text data-series="logfmt" data-end="first" data-role="rank" x="304" y="315.5" fill="#bfc0c0" font-size="9" font-family="'Geist Mono', monospace" text-anchor="end">#5</text>
+      <text data-series="logfmt" data-end="last" data-role="rank" x="696" y="203.5" fill="#bfc0c0" font-size="9" font-family="'Geist Mono', monospace">#3</text>
+      <text data-series="logfmt" data-end="last" data-role="name" x="728" y="203.5" fill="#f5f5f5" font-size="11" font-weight="500" font-family="'Geist', sans-serif">logfmt</text>
+
+      <path data-series="schema-gen" data-ranks="6,6,6,5" d="M320,368 L440,368 L560,368 L680,312" fill="none" stroke="rgba(245,245,245,0.62)" stroke-width="1.2"/>
+      <circle cx="320" cy="368" r="3" fill="rgba(245,245,245,0.62)"/>
+      <circle cx="440" cy="368" r="3" fill="rgba(245,245,245,0.62)"/>
+      <circle cx="560" cy="368" r="3" fill="rgba(245,245,245,0.62)"/>
+      <circle cx="680" cy="312" r="3" fill="rgba(245,245,245,0.62)"/>
+      <text data-series="schema-gen" data-end="first" data-role="name" x="272" y="371.5" fill="#f5f5f5" font-size="11" font-weight="500" font-family="'Geist', sans-serif" text-anchor="end">schema-gen</text>
+      <text data-series="schema-gen" data-end="first" data-role="rank" x="304" y="371.5" fill="#bfc0c0" font-size="9" font-family="'Geist Mono', monospace" text-anchor="end">#6</text>
+      <text data-series="schema-gen" data-end="last" data-role="rank" x="696" y="315.5" fill="#bfc0c0" font-size="9" font-family="'Geist Mono', monospace">#5</text>
+      <text data-series="schema-gen" data-end="last" data-role="name" x="728" y="315.5" fill="#f5f5f5" font-size="11" font-weight="500" font-family="'Geist', sans-serif">schema-gen</text>
+
+      <!-- legacy-http FOCAL - and it is the series that FELL. The accent marks the
+           editorially focal line, never the winner. Focus is carried by stroke
+           weight, not tone, for the reason the slopegraph section gives: the
+           accent measures 2.86:1 on light paper. Drawn last so its descent
+           crosses over, not under, the lines it overtakes downward. -->
+      <path data-series="legacy-http" data-ranks="1,2,4,6" d="M320,88 L440,144 L560,256 L680,368" fill="none" stroke="#f08a59" stroke-width="2.4"/>
+      <circle cx="320" cy="88" r="4" fill="#f08a59"/>
+      <circle cx="440" cy="144" r="4" fill="#f08a59"/>
+      <circle cx="560" cy="256" r="4" fill="#f08a59"/>
+      <circle cx="680" cy="368" r="4" fill="#f08a59"/>
+      <text data-series="legacy-http" data-end="first" data-role="name" x="272" y="91.5" fill="#f5f5f5" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="end">legacy-http</text>
+      <text data-series="legacy-http" data-end="first" data-role="rank" x="304" y="91.5" fill="#bfc0c0" font-size="9" font-family="'Geist Mono', monospace" text-anchor="end">#1</text>
+      <text data-series="legacy-http" data-end="last" data-role="rank" x="696" y="371.5" fill="#bfc0c0" font-size="9" font-family="'Geist Mono', monospace">#6</text>
+      <text data-series="legacy-http" data-end="last" data-role="name" x="728" y="371.5" fill="#f5f5f5" font-size="11" font-weight="600" font-family="'Geist', sans-serif">legacy-http</text>
+
+      <!-- Legend -->
+      <line x1="40" y1="462" x2="960" y2="462" stroke="rgba(245,245,245,0.10)" stroke-width="0.8"/>
+      <text x="40" y="478" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.18em">LEGEND</text>
+      <text x="960" y="478" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.06em" text-anchor="end">RANKED BY WEEKLY DOWNLOADS, TIES KEEP PRIOR ORDER · SAME MEASURE EVERY QUARTER · ILLUSTRATIVE FIGURES, NOT A MEASURED REGISTRY</text>
+
+      <line x1="40" y1="492" x2="64" y2="492" stroke="#f08a59" stroke-width="2.4"/>
+      <circle cx="52" cy="492" r="4" fill="#f08a59"/>
+      <text x="72" y="496" fill="#bfc0c0" font-size="8.5" font-family="'Geist', sans-serif">legacy-http · focal, first to sixth in a year</text>
+      <line x1="320" y1="492" x2="344" y2="492" stroke="rgba(245,245,245,0.80)" stroke-width="1.2"/>
+      <circle cx="332" cy="492" r="3" fill="rgba(245,245,245,0.80)"/>
+      <text x="352" y="496" fill="#bfc0c0" font-size="8.5" font-family="'Geist', sans-serif">Other packages · strongest tone was highest-ranked in Q1</text>
+    </svg>
+  </div>
+</body>
+</html>

--- a/skills/diagram-design/assets/example-bump-full.html
+++ b/skills/diagram-design/assets/example-bump-full.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Package rank by quarter · Bump chart</title>
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { --color-paper:#f5f5f5; --color-paper-2:#ececec; --color-ink:#2d3142; --color-muted:#4f5d75; --color-soft:#7a8399; --color-rule:rgba(45,49,66,0.12); --color-accent:#eb6c36; --font-sans:'Geist',system-ui,sans-serif; --font-serif:'Instrument Serif',serif; --font-mono:'Geist Mono',ui-monospace,monospace; }
+    body { font-family: var(--font-sans); background: var(--color-paper); min-height: 100vh; padding: 3rem 2rem; color: var(--color-ink); }
+    .container { max-width: 1200px; margin: 0 auto; }
+    .header { margin-bottom: 2.5rem; }
+    .header-eyebrow { font-family: var(--font-mono); font-size: 0.66rem; font-weight: 500; letter-spacing: 0.18em; text-transform: uppercase; color: var(--color-muted); margin-bottom: 0.75rem; }
+    h1 { font-family: var(--font-serif); font-size: clamp(1.75rem, 3vw + 1rem, 2.5rem); font-weight: 400; letter-spacing: -0.02em; line-height: 1.1; margin-bottom: 0.5rem; }
+    .subtitle { font-size: 1rem; line-height: 1.55; color: var(--color-muted); max-width: 58ch; }
+    .diagram-container { background: var(--color-paper-2); border-radius: 8px; border: 1px solid var(--color-rule); padding: 1.5rem; overflow-x: auto; }
+    svg { width: 100%; min-width: 760px; display: block; }
+    .cards { display: grid; grid-template-columns: 1.1fr 1fr 0.9fr; gap: 1rem; margin-top: 1.5rem; }
+    @media (max-width: 720px) { .cards { grid-template-columns: 1fr; } }
+    .card { background: #fff; border-radius: 6px; border: 1px solid var(--color-rule); padding: 1.25rem; }
+    .card .eyebrow { font-family: var(--font-mono); font-size: 0.5rem; letter-spacing: 0.18em; text-transform: uppercase; color: var(--color-muted); margin-bottom: 0.5rem; }
+    .card-header { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.875rem; padding-bottom: 0.875rem; border-bottom: 1px solid rgba(45,49,66,0.08); }
+    .card-dot { width: 7px; height: 7px; border-radius: 50%; }
+    .card-dot.coral { background: var(--color-accent); }
+    .card-dot.ink-strong { background: rgba(45,49,66,0.80); }
+    .card-dot.ink-light { background: rgba(45,49,66,0.62); }
+    .card h3 { font-size: 0.875rem; font-weight: 600; }
+    .card p { color: var(--color-muted); font-size: 0.8125rem; line-height: 1.55; }
+    .footer { margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid rgba(45,49,66,0.10); font-family: var(--font-mono); font-size: 0.72rem; letter-spacing: 0.06em; color: var(--color-muted); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 0.5rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <p class="header-eyebrow">Bump chart · Diagram Design</p>
+      <h1>The default everyone stopped choosing</h1>
+      <p class="subtitle">Six internal packages ranked by weekly downloads, quarter by quarter. legacy-http entered the year in first place and left it in last; fetch-kit took the top rank in Q2 and never gave it back. Position is the only encoding — the vertical axis is rank, not volume.</p>
+    </div>
+    <div class="diagram-container">
+    <svg viewBox="0 0 1000 500" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="bump-full-title bump-full-desc">
+        <title id="bump-full-title">The default everyone stopped choosing</title>
+        <desc id="bump-full-desc">Bump chart ranking six internal packages by weekly downloads across four quarters; legacy-http slides from first to sixth while fetch-kit takes the top rank in the second quarter and keeps it.</desc>
+        <defs>
+          <pattern id="dots" width="22" height="22" patternUnits="userSpaceOnUse">
+            <circle cx="1" cy="1" r="0.9" fill="rgba(45,49,66,0.10)"/>
+          </pattern>
+        </defs>
+
+        <rect width="100%" height="100%" fill="#f5f5f5"/>
+        <rect width="100%" height="100%" fill="url(#dots)" opacity="0.55"/>
+
+        <!-- Rank is ORDINAL: every vertex sits exactly on a rank row, y = 88 + 56 x
+             (rank - 1), and every snapshot's ranks are a permutation of 1..6.
+             scripts/verify-bump.py enforces both against the ranks each series
+             declares - there is no tolerance, because rank has no fractions. -->
+        <text transform="rotate(-90 24 228)" x="24" y="228" fill="#4f5d75" font-size="7" font-family="'Geist Mono', monospace" letter-spacing="0.14em" text-anchor="middle">RANK BY WEEKLY DOWNLOADS · 1 = MOST</text>
+
+        <!-- One axis rule per snapshot. No gridlines: the dots are the readable
+             positions and each series prints its first and last rank. -->
+        <line x1="320" y1="64" x2="320" y2="392" stroke="rgba(45,49,66,0.25)" stroke-width="1"/>
+        <text data-axis="0" data-state="Q1" x="320" y="416" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" letter-spacing="0.14em" text-anchor="middle">Q1</text>
+        <line x1="440" y1="64" x2="440" y2="392" stroke="rgba(45,49,66,0.25)" stroke-width="1"/>
+        <text data-axis="1" data-state="Q2" x="440" y="416" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" letter-spacing="0.14em" text-anchor="middle">Q2</text>
+        <line x1="560" y1="64" x2="560" y2="392" stroke="rgba(45,49,66,0.25)" stroke-width="1"/>
+        <text data-axis="2" data-state="Q3" x="560" y="416" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" letter-spacing="0.14em" text-anchor="middle">Q3</text>
+        <line x1="680" y1="64" x2="680" y2="392" stroke="rgba(45,49,66,0.25)" stroke-width="1"/>
+        <text data-axis="3" data-state="Q4" x="680" y="416" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" letter-spacing="0.14em" text-anchor="middle">Q4</text>
+
+        <!-- Straight segments between adjacent snapshots - never splines, which
+             invent a trajectory between ranks that were only measured quarterly.
+             Ramp ordered by Q1 rank: strongest tone was highest-ranked at Q1. -->
+        <path data-series="authx" data-ranks="2,3,3,2" d="M320,144 L440,200 L560,200 L680,144" fill="none" stroke="rgba(45,49,66,0.80)" stroke-width="1.2"/>
+        <circle cx="320" cy="144" r="3" fill="rgba(45,49,66,0.80)"/>
+        <circle cx="440" cy="200" r="3" fill="rgba(45,49,66,0.80)"/>
+        <circle cx="560" cy="200" r="3" fill="rgba(45,49,66,0.80)"/>
+        <circle cx="680" cy="144" r="3" fill="rgba(45,49,66,0.80)"/>
+        <text data-series="authx" data-end="first" data-role="name" x="272" y="147.5" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif" text-anchor="end">authx</text>
+        <text data-series="authx" data-end="first" data-role="rank" x="304" y="147.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" text-anchor="end">#2</text>
+        <text data-series="authx" data-end="last" data-role="rank" x="696" y="147.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace">#2</text>
+        <text data-series="authx" data-end="last" data-role="name" x="728" y="147.5" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif">authx</text>
+
+        <path data-series="fetch-kit" data-ranks="3,1,1,1" d="M320,200 L440,88 L560,88 L680,88" fill="none" stroke="rgba(45,49,66,0.75)" stroke-width="1.2"/>
+        <circle cx="320" cy="200" r="3" fill="rgba(45,49,66,0.75)"/>
+        <circle cx="440" cy="88" r="3" fill="rgba(45,49,66,0.75)"/>
+        <circle cx="560" cy="88" r="3" fill="rgba(45,49,66,0.75)"/>
+        <circle cx="680" cy="88" r="3" fill="rgba(45,49,66,0.75)"/>
+        <text data-series="fetch-kit" data-end="first" data-role="name" x="272" y="203.5" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif" text-anchor="end">fetch-kit</text>
+        <text data-series="fetch-kit" data-end="first" data-role="rank" x="304" y="203.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" text-anchor="end">#3</text>
+        <text data-series="fetch-kit" data-end="last" data-role="rank" x="696" y="91.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace">#1</text>
+        <text data-series="fetch-kit" data-end="last" data-role="name" x="728" y="91.5" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif">fetch-kit</text>
+
+        <path data-series="queuelib" data-ranks="4,5,5,4" d="M320,256 L440,312 L560,312 L680,256" fill="none" stroke="rgba(45,49,66,0.70)" stroke-width="1.2"/>
+        <circle cx="320" cy="256" r="3" fill="rgba(45,49,66,0.70)"/>
+        <circle cx="440" cy="312" r="3" fill="rgba(45,49,66,0.70)"/>
+        <circle cx="560" cy="312" r="3" fill="rgba(45,49,66,0.70)"/>
+        <circle cx="680" cy="256" r="3" fill="rgba(45,49,66,0.70)"/>
+        <text data-series="queuelib" data-end="first" data-role="name" x="272" y="259.5" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif" text-anchor="end">queuelib</text>
+        <text data-series="queuelib" data-end="first" data-role="rank" x="304" y="259.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" text-anchor="end">#4</text>
+        <text data-series="queuelib" data-end="last" data-role="rank" x="696" y="259.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace">#4</text>
+        <text data-series="queuelib" data-end="last" data-role="name" x="728" y="259.5" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif">queuelib</text>
+
+        <path data-series="logfmt" data-ranks="5,4,2,3" d="M320,312 L440,256 L560,144 L680,200" fill="none" stroke="rgba(45,49,66,0.66)" stroke-width="1.2"/>
+        <circle cx="320" cy="312" r="3" fill="rgba(45,49,66,0.66)"/>
+        <circle cx="440" cy="256" r="3" fill="rgba(45,49,66,0.66)"/>
+        <circle cx="560" cy="144" r="3" fill="rgba(45,49,66,0.66)"/>
+        <circle cx="680" cy="200" r="3" fill="rgba(45,49,66,0.66)"/>
+        <text data-series="logfmt" data-end="first" data-role="name" x="272" y="315.5" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif" text-anchor="end">logfmt</text>
+        <text data-series="logfmt" data-end="first" data-role="rank" x="304" y="315.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" text-anchor="end">#5</text>
+        <text data-series="logfmt" data-end="last" data-role="rank" x="696" y="203.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace">#3</text>
+        <text data-series="logfmt" data-end="last" data-role="name" x="728" y="203.5" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif">logfmt</text>
+
+        <path data-series="schema-gen" data-ranks="6,6,6,5" d="M320,368 L440,368 L560,368 L680,312" fill="none" stroke="rgba(45,49,66,0.62)" stroke-width="1.2"/>
+        <circle cx="320" cy="368" r="3" fill="rgba(45,49,66,0.62)"/>
+        <circle cx="440" cy="368" r="3" fill="rgba(45,49,66,0.62)"/>
+        <circle cx="560" cy="368" r="3" fill="rgba(45,49,66,0.62)"/>
+        <circle cx="680" cy="312" r="3" fill="rgba(45,49,66,0.62)"/>
+        <text data-series="schema-gen" data-end="first" data-role="name" x="272" y="371.5" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif" text-anchor="end">schema-gen</text>
+        <text data-series="schema-gen" data-end="first" data-role="rank" x="304" y="371.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" text-anchor="end">#6</text>
+        <text data-series="schema-gen" data-end="last" data-role="rank" x="696" y="315.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace">#5</text>
+        <text data-series="schema-gen" data-end="last" data-role="name" x="728" y="315.5" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif">schema-gen</text>
+
+        <!-- legacy-http FOCAL - and it is the series that FELL. The accent marks the
+             editorially focal line, never the winner. Focus is carried by stroke
+             weight, not tone, for the reason the slopegraph section gives: the
+             accent measures 2.86:1 on light paper. Drawn last so its descent
+             crosses over, not under, the lines it overtakes downward. -->
+        <path data-series="legacy-http" data-ranks="1,2,4,6" d="M320,88 L440,144 L560,256 L680,368" fill="none" stroke="#eb6c36" stroke-width="2.4"/>
+        <circle cx="320" cy="88" r="4" fill="#eb6c36"/>
+        <circle cx="440" cy="144" r="4" fill="#eb6c36"/>
+        <circle cx="560" cy="256" r="4" fill="#eb6c36"/>
+        <circle cx="680" cy="368" r="4" fill="#eb6c36"/>
+        <text data-series="legacy-http" data-end="first" data-role="name" x="272" y="91.5" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="end">legacy-http</text>
+        <text data-series="legacy-http" data-end="first" data-role="rank" x="304" y="91.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" text-anchor="end">#1</text>
+        <text data-series="legacy-http" data-end="last" data-role="rank" x="696" y="371.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace">#6</text>
+        <text data-series="legacy-http" data-end="last" data-role="name" x="728" y="371.5" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif">legacy-http</text>
+
+        <!-- Legend -->
+        <line x1="40" y1="462" x2="960" y2="462" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
+        <text x="40" y="478" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.18em">LEGEND</text>
+        <text x="960" y="478" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.06em" text-anchor="end">RANKED BY WEEKLY DOWNLOADS, TIES KEEP PRIOR ORDER · SAME MEASURE EVERY QUARTER · ILLUSTRATIVE FIGURES, NOT A MEASURED REGISTRY</text>
+
+        <line x1="40" y1="492" x2="64" y2="492" stroke="#eb6c36" stroke-width="2.4"/>
+        <circle cx="52" cy="492" r="4" fill="#eb6c36"/>
+        <text x="72" y="496" fill="#4f5d75" font-size="8.5" font-family="'Geist', sans-serif">legacy-http · focal, first to sixth in a year</text>
+        <line x1="320" y1="492" x2="344" y2="492" stroke="rgba(45,49,66,0.80)" stroke-width="1.2"/>
+        <circle cx="332" cy="492" r="3" fill="rgba(45,49,66,0.80)"/>
+        <text x="352" y="496" fill="#4f5d75" font-size="8.5" font-family="'Geist', sans-serif">Other packages · strongest tone was highest-ranked in Q1</text>
+      </svg>
+    </div>
+    <div class="cards">
+      <div class="card">
+        <p class="eyebrow">FOCAL · LEGACY-HTTP</p>
+        <div class="card-header"><span class="card-dot coral"></span><h3>First to sixth in four quarters, and never a sudden drop</h3></div>
+        <p>One rank, then two more, then two more. No single quarter looks alarming, which is exactly how a default dies — each straight segment joins two measured ranks and says nothing about the weeks between, so the chart claims the decline happened, not when in each quarter it happened.</p>
+      </div>
+      <div class="card">
+        <div class="card-header"><span class="card-dot ink-strong"></span><h3>fetch-kit took first place in Q2 and the line goes flat</h3></div>
+        <p>A flat line at rank one is the strongest claim a bump chart makes: nothing displaced it for three consecutive snapshots. Note what it does not say — downloads could have doubled or halved in that time. Rank hides magnitude; that trade is the price of reading position at a glance.</p>
+      </div>
+      <div class="card">
+        <div class="card-header"><span class="card-dot ink-light"></span><h3>schema-gen moved one rank and that is the whole story</h3></div>
+        <p>Three flat quarters, then a single step up — inherited from legacy-http falling past it, not from growth of its own. A bump chart cannot tell those apart, which is why the footnote names the ranking key: the reader who needs magnitude follows the measure, not the picture.</p>
+      </div>
+    </div>
+    <div class="footer">
+      <span>rank by weekly internal downloads · quarterly snapshots · illustrative</span>
+      <span>example · diagram design</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/skills/diagram-design/assets/example-bump.html
+++ b/skills/diagram-design/assets/example-bump.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Package rank by quarter · Bump chart</title>
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --color-paper:  #f5f5f5;
+      --color-ink:    #2d3142;
+      --color-muted:  #4f5d75;
+      --color-accent: #eb6c36;
+      --font-sans:    'Geist', system-ui, sans-serif;
+      --font-serif:   'Instrument Serif', serif;
+      --font-mono:    'Geist Mono', ui-monospace, monospace;
+    }
+    body { font-family: var(--font-sans); background: var(--color-paper); color: var(--color-ink); min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 3rem 2rem; }
+    .frame { max-width: 1200px; width: 100%; }
+    .eyebrow { font-family: var(--font-mono); font-size: 0.66rem; font-weight: 500; letter-spacing: 0.18em; text-transform: uppercase; color: var(--color-muted); margin-bottom: 0.5rem; }
+    h1 { font-family: var(--font-serif); font-size: clamp(1.5rem, 2.4vw + 0.75rem, 2rem); font-weight: 400; letter-spacing: -0.02em; line-height: 1.15; margin-bottom: 1.5rem; }
+    svg { width: 100%; min-width: 760px; display: block; }
+  </style>
+</head>
+<body>
+  <div class="frame">
+    <p class="eyebrow">Bump chart · Diagram Design</p>
+    <h1>The default everyone stopped choosing</h1>
+
+    <svg viewBox="0 0 1000 500" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="bump-title bump-desc">
+      <title id="bump-title">The default everyone stopped choosing</title>
+      <desc id="bump-desc">Bump chart ranking six internal packages by weekly downloads across four quarters; legacy-http slides from first to sixth while fetch-kit takes the top rank in the second quarter and keeps it.</desc>
+      <defs>
+        <pattern id="dots" width="22" height="22" patternUnits="userSpaceOnUse">
+          <circle cx="1" cy="1" r="0.9" fill="rgba(45,49,66,0.10)"/>
+        </pattern>
+      </defs>
+
+      <rect width="100%" height="100%" fill="#f5f5f5"/>
+      <rect width="100%" height="100%" fill="url(#dots)" opacity="0.55"/>
+
+      <!-- Rank is ORDINAL: every vertex sits exactly on a rank row, y = 88 + 56 x
+           (rank - 1), and every snapshot's ranks are a permutation of 1..6.
+           scripts/verify-bump.py enforces both against the ranks each series
+           declares - there is no tolerance, because rank has no fractions. -->
+      <text transform="rotate(-90 24 228)" x="24" y="228" fill="#4f5d75" font-size="7" font-family="'Geist Mono', monospace" letter-spacing="0.14em" text-anchor="middle">RANK BY WEEKLY DOWNLOADS · 1 = MOST</text>
+
+      <!-- One axis rule per snapshot. No gridlines: the dots are the readable
+           positions and each series prints its first and last rank. -->
+      <line x1="320" y1="64" x2="320" y2="392" stroke="rgba(45,49,66,0.25)" stroke-width="1"/>
+      <text data-axis="0" data-state="Q1" x="320" y="416" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" letter-spacing="0.14em" text-anchor="middle">Q1</text>
+      <line x1="440" y1="64" x2="440" y2="392" stroke="rgba(45,49,66,0.25)" stroke-width="1"/>
+      <text data-axis="1" data-state="Q2" x="440" y="416" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" letter-spacing="0.14em" text-anchor="middle">Q2</text>
+      <line x1="560" y1="64" x2="560" y2="392" stroke="rgba(45,49,66,0.25)" stroke-width="1"/>
+      <text data-axis="2" data-state="Q3" x="560" y="416" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" letter-spacing="0.14em" text-anchor="middle">Q3</text>
+      <line x1="680" y1="64" x2="680" y2="392" stroke="rgba(45,49,66,0.25)" stroke-width="1"/>
+      <text data-axis="3" data-state="Q4" x="680" y="416" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" letter-spacing="0.14em" text-anchor="middle">Q4</text>
+
+      <!-- Straight segments between adjacent snapshots - never splines, which
+           invent a trajectory between ranks that were only measured quarterly.
+           Ramp ordered by Q1 rank: strongest tone was highest-ranked at Q1. -->
+      <path data-series="authx" data-ranks="2,3,3,2" d="M320,144 L440,200 L560,200 L680,144" fill="none" stroke="rgba(45,49,66,0.80)" stroke-width="1.2"/>
+      <circle cx="320" cy="144" r="3" fill="rgba(45,49,66,0.80)"/>
+      <circle cx="440" cy="200" r="3" fill="rgba(45,49,66,0.80)"/>
+      <circle cx="560" cy="200" r="3" fill="rgba(45,49,66,0.80)"/>
+      <circle cx="680" cy="144" r="3" fill="rgba(45,49,66,0.80)"/>
+      <text data-series="authx" data-end="first" data-role="name" x="272" y="147.5" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif" text-anchor="end">authx</text>
+      <text data-series="authx" data-end="first" data-role="rank" x="304" y="147.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" text-anchor="end">#2</text>
+      <text data-series="authx" data-end="last" data-role="rank" x="696" y="147.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace">#2</text>
+      <text data-series="authx" data-end="last" data-role="name" x="728" y="147.5" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif">authx</text>
+
+      <path data-series="fetch-kit" data-ranks="3,1,1,1" d="M320,200 L440,88 L560,88 L680,88" fill="none" stroke="rgba(45,49,66,0.75)" stroke-width="1.2"/>
+      <circle cx="320" cy="200" r="3" fill="rgba(45,49,66,0.75)"/>
+      <circle cx="440" cy="88" r="3" fill="rgba(45,49,66,0.75)"/>
+      <circle cx="560" cy="88" r="3" fill="rgba(45,49,66,0.75)"/>
+      <circle cx="680" cy="88" r="3" fill="rgba(45,49,66,0.75)"/>
+      <text data-series="fetch-kit" data-end="first" data-role="name" x="272" y="203.5" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif" text-anchor="end">fetch-kit</text>
+      <text data-series="fetch-kit" data-end="first" data-role="rank" x="304" y="203.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" text-anchor="end">#3</text>
+      <text data-series="fetch-kit" data-end="last" data-role="rank" x="696" y="91.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace">#1</text>
+      <text data-series="fetch-kit" data-end="last" data-role="name" x="728" y="91.5" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif">fetch-kit</text>
+
+      <path data-series="queuelib" data-ranks="4,5,5,4" d="M320,256 L440,312 L560,312 L680,256" fill="none" stroke="rgba(45,49,66,0.70)" stroke-width="1.2"/>
+      <circle cx="320" cy="256" r="3" fill="rgba(45,49,66,0.70)"/>
+      <circle cx="440" cy="312" r="3" fill="rgba(45,49,66,0.70)"/>
+      <circle cx="560" cy="312" r="3" fill="rgba(45,49,66,0.70)"/>
+      <circle cx="680" cy="256" r="3" fill="rgba(45,49,66,0.70)"/>
+      <text data-series="queuelib" data-end="first" data-role="name" x="272" y="259.5" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif" text-anchor="end">queuelib</text>
+      <text data-series="queuelib" data-end="first" data-role="rank" x="304" y="259.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" text-anchor="end">#4</text>
+      <text data-series="queuelib" data-end="last" data-role="rank" x="696" y="259.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace">#4</text>
+      <text data-series="queuelib" data-end="last" data-role="name" x="728" y="259.5" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif">queuelib</text>
+
+      <path data-series="logfmt" data-ranks="5,4,2,3" d="M320,312 L440,256 L560,144 L680,200" fill="none" stroke="rgba(45,49,66,0.66)" stroke-width="1.2"/>
+      <circle cx="320" cy="312" r="3" fill="rgba(45,49,66,0.66)"/>
+      <circle cx="440" cy="256" r="3" fill="rgba(45,49,66,0.66)"/>
+      <circle cx="560" cy="144" r="3" fill="rgba(45,49,66,0.66)"/>
+      <circle cx="680" cy="200" r="3" fill="rgba(45,49,66,0.66)"/>
+      <text data-series="logfmt" data-end="first" data-role="name" x="272" y="315.5" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif" text-anchor="end">logfmt</text>
+      <text data-series="logfmt" data-end="first" data-role="rank" x="304" y="315.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" text-anchor="end">#5</text>
+      <text data-series="logfmt" data-end="last" data-role="rank" x="696" y="203.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace">#3</text>
+      <text data-series="logfmt" data-end="last" data-role="name" x="728" y="203.5" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif">logfmt</text>
+
+      <path data-series="schema-gen" data-ranks="6,6,6,5" d="M320,368 L440,368 L560,368 L680,312" fill="none" stroke="rgba(45,49,66,0.62)" stroke-width="1.2"/>
+      <circle cx="320" cy="368" r="3" fill="rgba(45,49,66,0.62)"/>
+      <circle cx="440" cy="368" r="3" fill="rgba(45,49,66,0.62)"/>
+      <circle cx="560" cy="368" r="3" fill="rgba(45,49,66,0.62)"/>
+      <circle cx="680" cy="312" r="3" fill="rgba(45,49,66,0.62)"/>
+      <text data-series="schema-gen" data-end="first" data-role="name" x="272" y="371.5" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif" text-anchor="end">schema-gen</text>
+      <text data-series="schema-gen" data-end="first" data-role="rank" x="304" y="371.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" text-anchor="end">#6</text>
+      <text data-series="schema-gen" data-end="last" data-role="rank" x="696" y="315.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace">#5</text>
+      <text data-series="schema-gen" data-end="last" data-role="name" x="728" y="315.5" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif">schema-gen</text>
+
+      <!-- legacy-http FOCAL - and it is the series that FELL. The accent marks the
+           editorially focal line, never the winner. Focus is carried by stroke
+           weight, not tone, for the reason the slopegraph section gives: the
+           accent measures 2.86:1 on light paper. Drawn last so its descent
+           crosses over, not under, the lines it overtakes downward. -->
+      <path data-series="legacy-http" data-ranks="1,2,4,6" d="M320,88 L440,144 L560,256 L680,368" fill="none" stroke="#eb6c36" stroke-width="2.4"/>
+      <circle cx="320" cy="88" r="4" fill="#eb6c36"/>
+      <circle cx="440" cy="144" r="4" fill="#eb6c36"/>
+      <circle cx="560" cy="256" r="4" fill="#eb6c36"/>
+      <circle cx="680" cy="368" r="4" fill="#eb6c36"/>
+      <text data-series="legacy-http" data-end="first" data-role="name" x="272" y="91.5" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="end">legacy-http</text>
+      <text data-series="legacy-http" data-end="first" data-role="rank" x="304" y="91.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" text-anchor="end">#1</text>
+      <text data-series="legacy-http" data-end="last" data-role="rank" x="696" y="371.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace">#6</text>
+      <text data-series="legacy-http" data-end="last" data-role="name" x="728" y="371.5" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif">legacy-http</text>
+
+      <!-- Legend -->
+      <line x1="40" y1="462" x2="960" y2="462" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
+      <text x="40" y="478" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.18em">LEGEND</text>
+      <text x="960" y="478" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.06em" text-anchor="end">RANKED BY WEEKLY DOWNLOADS, TIES KEEP PRIOR ORDER · SAME MEASURE EVERY QUARTER · ILLUSTRATIVE FIGURES, NOT A MEASURED REGISTRY</text>
+
+      <line x1="40" y1="492" x2="64" y2="492" stroke="#eb6c36" stroke-width="2.4"/>
+      <circle cx="52" cy="492" r="4" fill="#eb6c36"/>
+      <text x="72" y="496" fill="#4f5d75" font-size="8.5" font-family="'Geist', sans-serif">legacy-http · focal, first to sixth in a year</text>
+      <line x1="320" y1="492" x2="344" y2="492" stroke="rgba(45,49,66,0.80)" stroke-width="1.2"/>
+      <circle cx="332" cy="492" r="3" fill="rgba(45,49,66,0.80)"/>
+      <text x="352" y="496" fill="#4f5d75" font-size="8.5" font-family="'Geist', sans-serif">Other packages · strongest tone was highest-ranked in Q1</text>
+    </svg>
+  </div>
+</body>
+</html>

--- a/skills/diagram-design/assets/index.html
+++ b/skills/diagram-design/assets/index.html
@@ -299,7 +299,10 @@
           <span class="eyebrow">30</span>Treemap
         </button>
         <button class="tab new" data-type="slopegraph">
-          <span class="eyebrow">30</span>Line · slopegraph
+          <span class="eyebrow">20</span>Line · slopegraph
+        </button>
+        <button class="tab new" data-type="bump">
+          <span class="eyebrow">20</span>Line · bump
         </button>
         <button class="tab new" data-type="ridgeline">
           <span class="eyebrow">20</span>Line · ridgeline

--- a/skills/diagram-design/references/type-line.md
+++ b/skills/diagram-design/references/type-line.md
@@ -215,7 +215,7 @@ Not for: exactly two snapshots (that is the **slopegraph** above); magnitude sto
 - **One vertical axis rule per snapshot**, evenly pitched inside the plot, with the label gutters of the slopegraph: names right-aligned ending at `x=272` and first ranks at `x=304` on the left, mirrored from `x=696` (ranks) and `x=728` (names) on the right. The shipped example runs four axes at `x` 320/440/560/680 — the same 360px run as the slopegraph, spent in three segments instead of one.
 - **Rank rows on a fixed pitch.** The shipped grid is `y = 88 + 56 × (rank − 1)`. Rank is ordinal, so — unlike the slopegraph, whose endpoint `y` values are data-scaled and grid-exempt — **every vertex lands exactly on the 4px grid**, and `scripts/verify-bump.py` enforces the row placement with no tolerance at all. There is no honest reason for a vertex to sit off its row.
 - **Straight segments between adjacent snapshots, dots at every vertex** (`r=3`, focal `r=4`). Never splines: a curve between two quarterly snapshots draws a trajectory nobody measured. The draft this variant came from calls them subway curves and bans them outright.
-- **Labels at first and last appearance** — name and rank (`#1`…`#6`, the sigil keeps a rank from reading as a magnitude) at both ends, each on its own series' row.
+- **Labels at first and last appearance** — name and rank (`#1`…`#6`, the sigil keeps a rank from reading as a magnitude) at both ends, each on its own series' row **and in the gutter outboard of the end it names**. Both coordinates are required and both are checked: the row says which series a label belongs to, the column says which *end* of it, and neither implies the other. A first-end label slid along its row into the plot prints every rank correctly and reads against the wrong snapshot.
 - **Snapshot captions** in Geist Mono 9px, centred under each axis, bound with `data-axis` / `data-state` exactly as the slopegraph binds its two.
 - **Series count 4–8, snapshots 3–6.** Two snapshots are a slopegraph; past six the columns compress until rank changes cannot be followed.
 - **No gridlines.** The dots are the readable positions and the axis rules are the columns.
@@ -244,7 +244,7 @@ The binding contract is the slopegraph's, one level up: the path declares its ra
 <text data-axis="0" data-state="Q1" x="320" y="416" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" letter-spacing="0.14em" text-anchor="middle">Q1</text>
 ```
 
-`data-ranks` is the basis of every geometric check, so a series whose labels go missing stays in the verified set and the missing label is itself reported. `scripts/verify-bump.py` covers the grid, the permutations, the segments, the dots, the focus pairing, the label bindings and the captions; `scripts/test-verify-bump.py` proves each check in both polarities.
+`data-ranks` is the basis of every geometric check, so a series whose labels go missing stays in the verified set and the missing label is itself reported. `scripts/verify-bump.py` covers the grid, the permutations, the segments, the dots, the focus pairing, the label bindings, label placement on both axes and the captions; `scripts/test-verify-bump.py` proves each check in both polarities. The gutter x is read off the figure — every label sharing an end and a role must agree on one column — so a resized plot needs no constant changed here.
 
 ## Examples
 

--- a/skills/diagram-design/references/type-line.md
+++ b/skills/diagram-design/references/type-line.md
@@ -41,6 +41,7 @@
 
 - **Slopegraph:** exactly two states, several series, read as slope and rank change. Full spec below.
 - **Ridgeline:** one distribution per series, stacked with deliberate overlap on one shared amplitude. Full spec below.
+- **Bump chart:** rank movement across 3–6 ordered snapshots, position only. Full spec below.
 
 ### Slopegraph
 
@@ -203,6 +204,48 @@ The binding contract is the slopegraph's, applied to areas: the outline declares
 - Fewer than 3 ridges (that is a histogram or a pair of small multiples) or more than 12.
 - Reading traffic off ridge height, or shipping a figure whose source line lets a reader do so.
 
+### Bump chart
+
+**Best for:** rank movement across **3–6 ordered snapshots** when position, not magnitude, is the story — package popularity by quarter, team standings by sprint, top queries by month. The slopegraph above shows two moments and keeps magnitude; a bump chart trades magnitude away entirely to show *several* moments of pure position. That trade is the type: the vertical axis is rank, every row is one rank apart, and a flat line means "nothing displaced it", not "nothing changed".
+
+Not for: exactly two snapshots (that is the **slopegraph** above); magnitude stories — a series whose downloads doubled while its rank held draws a flat line, and if that surprise matters the reader needed a **line chart**; fewer than 4 series (a sentence is shorter) or more than 8 (spaghetti with a legend).
+
+#### Layout conventions
+
+- **One vertical axis rule per snapshot**, evenly pitched inside the plot, with the label gutters of the slopegraph: names right-aligned ending at `x=272` and first ranks at `x=304` on the left, mirrored from `x=696` (ranks) and `x=728` (names) on the right. The shipped example runs four axes at `x` 320/440/560/680 — the same 360px run as the slopegraph, spent in three segments instead of one.
+- **Rank rows on a fixed pitch.** The shipped grid is `y = 88 + 56 × (rank − 1)`. Rank is ordinal, so — unlike the slopegraph, whose endpoint `y` values are data-scaled and grid-exempt — **every vertex lands exactly on the 4px grid**, and `scripts/verify-bump.py` enforces the row placement with no tolerance at all. There is no honest reason for a vertex to sit off its row.
+- **Straight segments between adjacent snapshots, dots at every vertex** (`r=3`, focal `r=4`). Never splines: a curve between two quarterly snapshots draws a trajectory nobody measured. The draft this variant came from calls them subway curves and bans them outright.
+- **Labels at first and last appearance** — name and rank (`#1`…`#6`, the sigil keeps a rank from reading as a magnitude) at both ends, each on its own series' row.
+- **Snapshot captions** in Geist Mono 9px, centred under each axis, bound with `data-axis` / `data-state` exactly as the slopegraph binds its two.
+- **Series count 4–8, snapshots 3–6.** Two snapshots are a slopegraph; past six the columns compress until rank changes cannot be followed.
+- **No gridlines.** The dots are the readable positions and the axis rules are the columns.
+
+#### Colour
+
+Everything the slopegraph's colour section says holds here unchanged: one accent on the editorially focal series, an `ink` opacity ramp (`0.80 → 0.62`, floor 0.53) for the rest — ordered by first-snapshot rank, so the legend can say "strongest tone was highest-ranked", skin-neutrally — focus carried by stroke weight (2.4px against 1.2px) and dot size rather than tone, and labels in `ink`/`muted` on every series including the focal one. The accent marks the series the story is about, never the winner: the shipped example spends it on the package that *fell*.
+
+#### Honest-data rule
+
+**State the ranking key and the tie-break in the source line.** Rank hides magnitude by design, so the footnote is where a reader learns what "first" means and why no two series ever share a row. `scripts/verify-bump.py` gates the geometry half: every snapshot's ranks must be a permutation of 1..N — a duplicated rank is a tie the stated tie-break cannot produce, and a skipped rank is an empty row the reader fills with a series that is not there.
+
+- **If the ranking measure changed definition between snapshots, the chart is invalid** — ranks under different measures are not comparable, and no drawing convention repairs that.
+- **A series that enters late or leaves early starts or stops.** A real gap is drawn as absence, never interpolated across.
+- **Never smooth a tie into a crossing.** The tie-break decides the order; drawing anything else invents a rank.
+- **Never nudge a vertex off its row** to dodge a label collision — it reads as a rank between two ranks, and the checker treats it as the lie it is.
+
+#### Declaring the values
+
+The binding contract is the slopegraph's, one level up: the path declares its ranks, and every visible string is bound to what it describes.
+
+```svg
+<path data-series="legacy-http" data-ranks="1,2,4,6" d="M320,88 L440,144 L560,256 L680,368" fill="none" stroke="#eb6c36" stroke-width="2.4"/>
+<text data-series="legacy-http" data-end="first" data-role="name" x="272" y="91.5" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="end">legacy-http</text>
+<text data-series="legacy-http" data-end="first" data-role="rank" x="304" y="91.5" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" text-anchor="end">#1</text>
+<text data-axis="0" data-state="Q1" x="320" y="416" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace" letter-spacing="0.14em" text-anchor="middle">Q1</text>
+```
+
+`data-ranks` is the basis of every geometric check, so a series whose labels go missing stays in the verified set and the missing label is itself reported. `scripts/verify-bump.py` covers the grid, the permutations, the segments, the dots, the focus pairing, the label bindings and the captions; `scripts/test-verify-bump.py` proves each check in both polarities.
+
 ## Examples
 
 - `assets/example-line.html` — minimal light
@@ -214,3 +257,6 @@ The binding contract is the slopegraph's, applied to areas: the outline declares
 - `assets/example-ridgeline.html` — ridgeline, minimal light
 - `assets/example-ridgeline-dark.html` — ridgeline, minimal dark
 - `assets/example-ridgeline-full.html` — ridgeline, full editorial
+- `assets/example-bump.html` — bump chart, minimal light
+- `assets/example-bump-dark.html` — bump chart, minimal dark
+- `assets/example-bump-full.html` — bump chart, full editorial

--- a/skills/diagram-design/references/type-line.md
+++ b/skills/diagram-design/references/type-line.md
@@ -229,7 +229,7 @@ Everything the slopegraph's colour section says holds here unchanged: one accent
 **State the ranking key and the tie-break in the source line.** Rank hides magnitude by design, so the footnote is where a reader learns what "first" means and why no two series ever share a row. `scripts/verify-bump.py` gates the geometry half: every snapshot's ranks must be a permutation of 1..N — a duplicated rank is a tie the stated tie-break cannot produce, and a skipped rank is an empty row the reader fills with a series that is not there.
 
 - **If the ranking measure changed definition between snapshots, the chart is invalid** — ranks under different measures are not comparable, and no drawing convention repairs that.
-- **A series that enters late or leaves early starts or stops.** A real gap is drawn as absence, never interpolated across.
+- **A series that enters late or leaves early starts or stops.** A real gap is drawn as absence, never interpolated across. The shipped grammar has no way to *declare* a gap yet, so `verify-bump.py` requires every series to visit every snapshot — a series with fewer vertices than columns is a finding until a gap declaration exists, because widening the rule without one would let a truncated series pass as a deliberate exit.
 - **Never smooth a tie into a crossing.** The tie-break decides the order; drawing anything else invents a rank.
 - **Never nudge a vertex off its row** to dodge a label collision — it reads as a rank between two ranks, and the checker treats it as the lie it is.
 


### PR DESCRIPTION
Bump chart per the routing in #62 — rank movement across 3–6 snapshots, position only, as a Line variant like the slopegraph.

- Three static examples: six internal packages ranked by weekly downloads across four quarters; the focal series is the one that falls. Same gutters, legend rhythm and ink ramp as the slopegraph. Rank is ordinal, so every vertex sits exactly on the 4px grid.
- `type-line.md` gains the variant spec — layout, colour (inherits the slopegraph's section), honest-data rules (ranking key + tie-break in the footnote, no splines, gaps drawn as absence, never nudge a vertex off its row), and the data-binding contract: `data-ranks` on the path, `data-end`/`data-role` on labels, `data-axis`/`data-state` on captions.
- `verify-bump.py` derives the figure's own rank grid and enforces it exactly — vertex-on-row with zero tolerance, a permutation of 1..N per snapshot, M/L-only segments, a dot at every vertex, exactly one focal series, printed `#k` agreeing with declared ranks, bound captions, transform refusal, fail closed on unreadable figures. `test-verify-bump.py` proves each check in both polarities, with synthetic figures for the budget rules.
- One edit outside the new files: `verify-slopegraph.py`'s detector claimed any file containing `data-series` and rejected the bump examples for lacking `<line>` elements. It now requires `data-series` on a `<line>` — its fail-closed case is preserved, and the scope treaty is pinned in both suites.
- Gallery tab added beside the slopegraph's (both eyebrows now read 20, the parent Line's number). Patch bump to 2.6.2.

Note: the `fix/line-dark-skin` PR also bumps to 2.6.2 — whichever lands second gets a rebase and re-bump.
