### PR TITLE
fix(factory): sync maintainer version policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Please read [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) first. All contributions ar
 
 ## What this project is
 
-Diagram Design is an agent skill (Claude Code, Codex, Pi) that produces editorial-quality diagrams as self-contained HTML files. The repo is documentation-first: `skills/diagram-design/SKILL.md` is the index, each of the 39 visual types has its own reference file, and the extractor scripts in `skills/diagram-design/scripts/` turn draw.io and Mermaid sources into a structured IR.
+Diagram Design is an agent skill (Claude Code, Codex, Factory Droid, Pi) that produces editorial-quality diagrams as self-contained HTML files. The repo is documentation-first: `skills/diagram-design/SKILL.md` is the index, each of the 39 visual types has its own reference file, and the extractor scripts in `skills/diagram-design/scripts/` turn draw.io and Mermaid sources into a structured IR.
 
 See [README.md](README.md) for the full picture, including the design system and the import/export flows.
 
@@ -131,7 +131,7 @@ python3 scripts/test-plugin-package.py \
 
 ### If a gate fails
 
-- **`verify-plugin-package.py`:** if it reports a version change, drop the manifest edits from your branch — versions are bumped on `main` after merge, never in a PR. If packaging validation fails, keep both marketplaces pointed at the repository root and keep the shared skill at `skills/diagram-design/SKILL.md`.
+- **`verify-plugin-package.py`:** if it reports a version change, drop the manifest edits from your branch — versions are bumped on `main` after merge, never in a PR. If packaging validation fails, keep all native marketplaces pointed at the repository root and keep the shared skill at `skills/diagram-design/SKILL.md`.
 - **`lint-skin.py`:** the failure message names the file, line, and category (`color`, `font-family`, `a11y`, `external-asset`, `pure-black`, `script`). Colors must come from the palette in `skills/diagram-design/references/style-guide.md`; fonts from the allowed list; diagrams must satisfy the accessible SVG contract (see below). The linter also requires the SHA-pinned controller from `template-motion.html` verbatim and rejects remote resources, CSS `@import`, non-fragment CSS `url()`, event handlers, `srcdoc`, executable URLs, and extra scripts.
 - **`verify-*.py`:** the extractor's real behavior no longer matches its fixture or the documentation, or the reference/command/prompt wiring drifted. Fix the source of truth — do not widen a test to avoid a failure.
 - **`verify-screenshot-freshness.py`:** a canonical minimal-light example or its committed PNG changed without a synchronized catalog refresh. Before the first regeneration, install the renderer with `python3 -m pip install playwright && python3 -m playwright install chromium`. Then run `python3 scripts/render-canonical-screenshots.py`, inspect all 39 renders, and commit the updated PNGs plus `docs/screenshots/manifest.json`.


### PR DESCRIPTION
## What does this PR do?

Factory Droid is already part of the native plugin package and is covered by the package verifier and version bump helper, but two maintainer-facing surfaces were still describing the older two-manifest setup.

This PR keeps those contracts in sync by:

- adding Factory Droid to the supported-host wording in `CONTRIBUTING.md`
- replacing host-count-specific wording with native-host-neutral wording
- adding `.factory-plugin/plugin.json` to the synchronized manifest list in `.maintainer-policy.json`
- bumping the three native plugin manifests together to `2.6.6` using the repository helper

No plugin runtime, install, or host behavior changes here — this just brings the contributor guidance and machine-readable maintainer policy in line with the Factory Droid support that already exists.

## Visual proof

Not applicable — no diagram or visual output changes.

## Validation gates

- [x] `python3 scripts/test-lint-a11y.py`
- [x] `python3 scripts/lint-skin.py --all --baseline`
- [x] `python3 scripts/verify-sequence-oauth.py`
- [x] `python3 scripts/verify-drawio-import.py`
- [x] `python3 scripts/verify-mermaid-import.py`
- [ ] `git diff --exit-code` green after `python3 scripts/build-icons.py` (if icons changed) — N/A, no icon changes
- [ ] Docs updated in the same PR where behavior changed — N/A, no runtime behavior change

Additional checks relevant to this change:

- [x] `python scripts/test-plugin-package.py`
- [x] `python scripts/verify-plugin-package.py upstream/main`
- [x] `claude plugin validate . --strict`
- [x] `python scripts/verify-docs-sync.py`
- [x] `python scripts/test-verify-docs-sync.py`
- [x] `git diff --check upstream/main...HEAD`

I also ran the full local validation suite from `CONTRIBUTING.md`. A few unrelated baseline/environment checks fail the same way on a clean `upstream/main` checkout:

- `verify-semantic-motion.py --markdown-only` — `SKILL.md` is currently over the 40,000-byte limit
- `lint-render.py --self-test` / `--all` — Playwright is not installed in my local Windows environment
- `verify-doctor.py` — reproduces a Windows `WinError 1312`
- `verify-screenshot-freshness.py` — existing canonical screenshots are stale against their current sources
- `test-verify-treemap.py` — reproduces a Windows CP950 `UnicodeEncodeError`

I left those unrelated failures untouched to keep this PR scoped to the Factory maintainer-policy sync.

## Checklist

- [x] No new entries added to `scripts/lint-skin-baseline.txt`
- [x] Generated and source files are consistent (extractor ↔ verifier ↔ reference ↔ command)
- [x] Accessible SVG contract satisfied for new/changed examples — N/A, no SVG examples changed
- [x] Rendered screenshots are attached for every new/changed diagram variant, or visual proof is marked not applicable
- [x] Code of Conduct respected

## Related issues

Follow-up cleanup after #120, which added the native Factory Droid packaging and closed #108.

This PR does not add new Factory functionality or close a new issue.