### PR TITLE
feat(export): unify SVG extraction and PowerPoint-safe normalization

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, polar chart (polar/radial lollipop), loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.6.5",
+  "version": "2.6.9",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, polar chart (polar/radial lollipop), loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.6.5",
+  "version": "2.6.9",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, polar chart (polar/radial lollipop), loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.6.5",
+  "version": "2.6.9",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,11 @@ jobs:
         id: mermaid
         run: python scripts/verify-mermaid-import.py
 
+      - name: Verify Figma export tooling
+        if: always()
+        id: figma
+        run: python scripts/verify-figma-export.py
+
       - name: Verify optional motion contract
         if: always()
         id: motion
@@ -329,6 +334,7 @@ jobs:
           echo "| Sequence Diagram Grammar | ${{ steps.oauth.outcome == 'success' && '✅ Passed' || (steps.oauth.outcome == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Draw.io Import Extractor | ${{ steps.drawio.outcome == 'success' && '✅ Passed' || (steps.drawio.outcome == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Mermaid Import Extractor | ${{ steps.mermaid.outcome == 'success' && '✅ Passed' || (steps.mermaid.outcome == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Figma Export Tooling | ${{ steps.figma.outcome == 'success' && '✅ Passed' || (steps.figma.outcome == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Optional Motion Contract | ${{ steps.motion.outcome == 'success' && '✅ Passed' || (steps.motion.outcome == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Doctor Diagnostics Contract | ${{ steps.doctor.outcome == 'success' && '✅ Passed' || (steps.doctor.outcome == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Doctor Diagnostics Tests | ${{ steps.doctor_tests.outcome == 'success' && '✅ Passed' || (steps.doctor_tests.outcome == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -105,7 +105,7 @@
       "slug": "polar",
       "source": "skills/diagram-design/assets/example-polar.html",
       "screenshot": "docs/screenshots/polar.png",
-      "source_sha256": "596e2042f18044ef1fa2c2eb849f39fa5c7767b2a17e272617ebd27e10bc86b1",
+      "source_sha256": "4e4fb12761b8f2854716e8fd81f4a5069a16bcc94eebe1953c6bd49ced044396",
       "screenshot_sha256": "a1dd1d4cb38db2217759c5d256cc56d832acc4f3077f090cc8691d6e4f82ef31",
       "width": 2400,
       "height": 1202
@@ -222,7 +222,7 @@
       "slug": "high-level",
       "source": "skills/diagram-design/assets/example-high-level.html",
       "screenshot": "docs/screenshots/high-level.png",
-      "source_sha256": "33789942cb06be5228ffa6e450602d1f7c9344b7d263fa2674b7ba5e6dd7e788",
+      "source_sha256": "502cbc68c56fdb83c6cf5f4b90dd7483af16f56acfdcc67e540067e45140dbbd",
       "screenshot_sha256": "afe822249fbbb601657edc468d5572d2c4a6acc8cbef4ea41771d42d13e3b75e",
       "width": 2400,
       "height": 1298

--- a/scripts/fixtures/sample-nested-svg.html
+++ b/scripts/fixtures/sample-nested-svg.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Open data lake · Nested SVG fixture</title>
+</head>
+<body>
+  <svg viewBox="0 0 480 180" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="nested-datalake-title nested-datalake-desc">
+    <title id="nested-datalake-title">Open data lake · End-to-end stack</title>
+    <desc id="nested-datalake-desc">A trimmed data lake architecture with app server, database, and Apache NiFi icon SVGs nested inside the diagram SVG.</desc>
+    <defs>
+      <pattern id="fixture-dots" width="16" height="16" patternUnits="userSpaceOnUse">
+        <circle cx="1" cy="1" r="0.8" fill="#d5d7de"/>
+      </pattern>
+    </defs>
+    <rect width="480" height="180" rx="12" fill="url(#fixture-dots)"/>
+
+    <g transform="translate(24 40)">
+      <rect width="120" height="96" rx="8" fill="white" stroke="#2d3142"/>
+      <svg x="48" y="16" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#2d3142" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M3 7a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v2a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3"/>
+        <path d="M3 15a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v2a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3l0 -2"/>
+        <path d="M7 8l0 .01"/><path d="M7 16l0 .01"/>
+      </svg>
+      <text x="60" y="64" text-anchor="middle" font-family="sans-serif" font-size="12">App servers</text>
+    </g>
+
+    <g transform="translate(180 40)">
+      <rect width="120" height="96" rx="8" fill="white" stroke="#2d3142"/>
+      <svg x="48" y="16" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#2d3142" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M4 6a8 3 0 1 0 16 0a8 3 0 1 0 -16 0"/>
+        <path d="M4 6v6a8 3 0 0 0 16 0v-6"/>
+        <path d="M4 12v6a8 3 0 0 0 16 0v-6"/>
+      </svg>
+      <text x="60" y="64" text-anchor="middle" font-family="sans-serif" font-size="12">Databases</text>
+    </g>
+
+    <g transform="translate(336 40)">
+      <rect width="120" height="96" rx="8" fill="white" stroke="#eb6c36"/>
+      <svg x="48" y="16" width="24" height="24" viewBox="0 0 24 24" fill="#eb6c36" aria-hidden="true">
+        <path d="M11.648 0a.093.093 0 0 0-.084.053A30.71 30.71 0 0 1 8.592 4.73c-2.09 2.728-5.145 6.466-5.145 10.364a8.201 8.201 0 0 0 8.201 8.2v-5.003c0-.106.087-.193.194-.193h2.81v-2.813c0-.106.087-.191.194-.191h5.004c0-3.9-3.056-7.636-5.145-10.364A30.712 30.712 0 0 1 11.732.053.094.094 0 0 0 11.648 0z"/>
+      </svg>
+      <text x="60" y="64" text-anchor="middle" font-family="sans-serif" font-size="12">Apache NiFi</text>
+    </g>
+  </svg>
+</body>
+</html>

--- a/scripts/test-self-check.py
+++ b/scripts/test-self-check.py
@@ -109,8 +109,8 @@ def main() -> int:
     check_fail(
         "hidden motion item",
         animated.replace(
-            '<g data-motion-item data-step="1"',
-            '<g style="opacity:0" data-motion-item data-step="1"',
+            '<g data-motion-item="true" data-step="1"',
+            '<g style="opacity:0" data-motion-item="true" data-step="1"',
             1,
         ),
         "hidden in source",

--- a/scripts/verify-figma-export.py
+++ b/scripts/verify-figma-export.py
@@ -1,0 +1,585 @@
+#!/usr/bin/env python3
+"""Cross-platform verification gate for the shipped Figma SVG tooling."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from html.parser import HTMLParser
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+sys.dont_write_bytecode = True
+
+ROOT = Path(__file__).resolve().parent.parent
+CAPTURE = ROOT / "skills/diagram-design/scripts/figma_capture.py"
+EXPORT_REF = ROOT / "skills/diagram-design/references/export.md"
+REFERENCES = ROOT / "skills/diagram-design/references"
+COMMANDS = ROOT / "commands"
+FIXTURE = ROOT / "scripts/fixtures/sample-nested-svg.html"
+GALLERY = ROOT / "skills/diagram-design/assets/index.html"
+MEDALLION = ROOT / "skills/diagram-design/assets/example-medallion.html"
+SVG_NAMESPACE = "http://www.w3.org/2000/svg"
+XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8"?>\n'
+VARIANTS = (
+    ("light", ROOT / "skills/diagram-design/assets/example-architecture.html"),
+    ("dark", ROOT / "skills/diagram-design/assets/example-architecture-dark.html"),
+    ("full", ROOT / "skills/diagram-design/assets/example-architecture-full.html"),
+    ("terminal", ROOT / "skills/diagram-design/assets/example-loop-terminal.html"),
+)
+SECRET_RE = re.compile(r"(?i)(api[_-]?key|token|secret)\s*[:=]")
+WINDOWS_HOME_RE = re.compile(r"[A-Za-z]:\\Users\\", re.IGNORECASE)
+
+
+class VerificationError(Exception):
+    """A verification assertion failed."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise VerificationError(message)
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class SvgIsolationParser(HTMLParser):
+    """Find top-level SVG spans without confusing nested icon SVGs for siblings."""
+
+    def __init__(self, source: str) -> None:
+        super().__init__(convert_charrefs=True)
+        self.source = source
+        self.line_starts = [0]
+        self.line_starts.extend(match.end() for match in re.finditer("\n", source))
+        self.depth = 0
+        self.start: int | None = None
+        self.spans: list[tuple[int, int]] = []
+
+    def _offset(self) -> int:
+        line, column = self.getpos()
+        return self.line_starts[line - 1] + column
+
+    def _token_end(self, start: int) -> int:
+        end = self.source.find(">", start)
+        if end < 0:
+            raise VerificationError("unterminated SVG tag in verification input")
+        return end + 1
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        del attrs
+        if tag.lower() != "svg":
+            return
+        if self.depth == 0:
+            self.start = self._offset()
+        self.depth += 1
+
+    def handle_startendtag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        del attrs
+        if tag.lower() == "svg" and self.depth == 0:
+            start = self._offset()
+            self.spans.append((start, self._token_end(start)))
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() != "svg" or self.depth == 0:
+            return
+        self.depth -= 1
+        if self.depth == 0:
+            require(self.start is not None, "inconsistent SVG nesting in source")
+            self.spans.append((self.start, self._token_end(self._offset())))
+            self.start = None
+
+
+class RootAttributesParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.attrs: dict[str, str | None] | None = None
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        if self.attrs is None and tag.lower() == "svg":
+            self.attrs = {name.lower(): value for name, value in attrs}
+
+
+def isolate_svg(path: Path) -> str:
+    source = path.read_text(encoding="utf-8")
+    parser = SvgIsolationParser(source)
+    parser.feed(source)
+    parser.close()
+    require(parser.depth == 0, f"{path.name}: unterminated source SVG")
+    require(len(parser.spans) == 1, f"{path.name}: expected one top-level source SVG")
+    start, end = parser.spans[0]
+    return source[start:end]
+
+
+def root_attributes(svg: str) -> dict[str, str | None]:
+    parser = RootAttributesParser()
+    parser.feed(svg)
+    parser.close()
+    require(parser.attrs is not None, "could not read outer SVG attributes")
+    return parser.attrs
+
+
+def audit_generated_svg(svg: str) -> None:
+    for marker in ("/Users/", "/home/"):
+        require(marker not in svg, f"generated SVG leaks absolute home path {marker!r}")
+    require(
+        WINDOWS_HOME_RE.search(svg) is None,
+        "generated SVG leaks an absolute Windows user-home path",
+    )
+    require(
+        SECRET_RE.search(svg) is None,
+        "generated SVG contains an obvious secret-token assignment pattern",
+    )
+
+
+class CaptureRunner:
+    """Drive the real CLI while centrally enforcing source and output invariants."""
+
+    def __init__(self) -> None:
+        self.integrity_checks = 0
+        self.integrity_failures: list[str] = []
+        self.hygiene_checks = 0
+        self.hygiene_failures: list[str] = []
+
+    def run(self, command: str, source: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+        before = sha256(source)
+        proc = subprocess.run(
+            [sys.executable, "-B", str(CAPTURE), command, str(source), *extra],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            shell=False,
+        )
+        after = sha256(source)
+        self.integrity_checks += 1
+        if before != after:
+            message = f"{command} modified source {source}"
+            self.integrity_failures.append(message)
+            raise VerificationError(message)
+
+        if command == "extract" and proc.returncode == 0:
+            if "--stdout" in extra:
+                generated = proc.stdout
+            else:
+                if "--out" in extra:
+                    out_arg = extra[extra.index("--out") + 1]
+                    output = Path(out_arg)
+                    if not output.is_absolute():
+                        output = ROOT / output
+                else:
+                    output = source.with_suffix(".svg")
+                require(output.is_file(), f"extract succeeded without writing {output}")
+                generated = output.read_text(encoding="utf-8")
+            self.hygiene_checks += 1
+            try:
+                audit_generated_svg(generated)
+            except VerificationError as exc:
+                self.hygiene_failures.append(str(exc))
+                raise
+        return proc
+
+
+def require_success(proc: subprocess.CompletedProcess[str], context: str) -> None:
+    require(
+        proc.returncode == 0,
+        f"{context} exited {proc.returncode}: {proc.stderr.strip()}",
+    )
+
+
+def case_happy_paths(runner: CaptureRunner, tmp: Path) -> None:
+    del tmp
+    for variant, source in VARIANTS:
+        checked = runner.run("check", source)
+        require_success(checked, f"{variant} check")
+        digest = re.fullmatch(
+            r'ok source=(.+) viewBox="([^"]+)" dimensions=([^\s]+) '
+            r"sha256=([0-9a-f]{64})\n?",
+            checked.stdout,
+        )
+        require(digest is not None, f"{variant} check digest has the wrong shape")
+
+        extracted = runner.run("extract", source, "--stdout")
+        require_success(extracted, f"{variant} extract")
+        svg = extracted.stdout
+        require(svg.startswith(XML_DECLARATION), f"{variant} XML declaration is wrong")
+        try:
+            root = ET.fromstring(svg)
+        except ET.ParseError as exc:
+            raise VerificationError(f"{variant} extract is not well-formed XML: {exc}") from exc
+        source_viewbox = root_attributes(isolate_svg(source)).get("viewbox")
+        require(digest.group(1) == str(source), f"{variant} check reported wrong source")
+        require(digest.group(2) == source_viewbox, f"{variant} check reported wrong viewBox")
+        viewbox_numbers = [float(part) for part in str(source_viewbox).replace(",", " ").split()]
+        expected_dimensions = f"{viewbox_numbers[2]:g}x{viewbox_numbers[3]:g}"
+        require(
+            digest.group(3) == expected_dimensions,
+            f"{variant} check reported wrong dimensions",
+        )
+        require(digest.group(4) == sha256(source), f"{variant} check reported wrong SHA-256")
+        require(root.tag == f"{{{SVG_NAMESPACE}}}svg", f"{variant} root lacks SVG xmlns")
+        require(
+            root.attrib.get("viewBox") == source_viewbox,
+            f"{variant} extract changed viewBox",
+        )
+
+
+def case_verbatim_source(runner: CaptureRunner, tmp: Path) -> None:
+    del tmp
+    source = VARIANTS[0][1]
+    source_svg = isolate_svg(source)
+    text_match = re.search(r"<text\b[^>]*>[^<]{4,}</text>", source_svg, re.IGNORECASE)
+    path_match = re.search(r'<path\b[^>]*\bd="([^"]{24,})"', source_svg, re.IGNORECASE)
+    require(text_match is not None, "could not select a source text label")
+    require(path_match is not None, "could not select a source path fragment")
+    snippets = (text_match.group(0), f'd="{path_match.group(1)[:80]}')
+
+    proc = runner.run("extract", source, "--stdout")
+    require_success(proc, "verbatim-source extract")
+    for snippet in snippets:
+        require(snippet in proc.stdout, f"source SVG content was rewritten: {snippet!r}")
+
+
+def export_font_import() -> str:
+    spec = EXPORT_REF.read_text(encoding="utf-8")
+    require("## SVG export procedure" in spec, "export.md lacks SVG export procedure")
+    section = spec.split("## SVG export procedure", 1)[1].split("## PNG export procedure", 1)[0]
+    block = re.search(r"```svg\s*(.*?)\s*```", section, re.DOTALL)
+    require(block is not None, "export.md SVG procedure lacks its SVG snippet")
+    font_import = re.search(
+        r"(@import url\('https://fonts\.googleapis\.com/[^'\n]+'\);)",
+        block.group(1),
+    )
+    require(font_import is not None, "export.md SVG snippet lacks Google Fonts @import")
+    return font_import.group(1)
+
+
+def case_export_spec_parity(runner: CaptureRunner, tmp: Path) -> None:
+    source = VARIANTS[0][1]
+    source_svg = isolate_svg(source)
+    require(
+        len(re.findall(r"<defs(?=[\s>])", source_svg, re.IGNORECASE)) == 1,
+        "parity source must begin with exactly one existing defs block",
+    )
+    proc = runner.run("extract", source, "--stdout")
+    require_success(proc, "export-spec parity extract")
+    output = proc.stdout
+    font_import = export_font_import()
+    require(font_import in output, "extract output drifted from export.md font import")
+    require(
+        output.count(f"<style>{font_import}</style>") == 1,
+        "font import was not merged exactly once",
+    )
+    require(
+        len(re.findall(r"<defs(?=[\s>])", output, re.IGNORECASE)) == 1,
+        "extract added a duplicate defs block",
+    )
+    require(output.startswith(XML_DECLARATION), "export.md XML declaration is not honored")
+    opening = re.match(r"<svg\b[^>]*>", output[len(XML_DECLARATION) :], re.DOTALL)
+    require(opening is not None, "standalone output lacks an SVG opening tag")
+    require(
+        f'xmlns="{SVG_NAMESPACE}"' in opening.group(0),
+        "export.md xmlns requirement is not honored",
+    )
+
+    bare = tmp / "no-defs-or-xmlns.html"
+    bare.write_text(
+        '<svg viewBox="0 0 20 10" role="img" aria-labelledby="bare-title bare-desc">'
+        '<title id="bare-title">Bare diagram</title>'
+        '<desc id="bare-desc">No namespace or definitions block.</desc>'
+        '<rect width="20" height="10"/></svg>',
+        encoding="utf-8",
+    )
+    bare_proc = runner.run("extract", bare, "--stdout")
+    require_success(bare_proc, "missing-defs/missing-xmlns extract")
+    bare_output = bare_proc.stdout
+    bare_opening = re.match(
+        r"<svg\b[^>]*>", bare_output[len(XML_DECLARATION) :], re.DOTALL
+    )
+    require(bare_opening is not None, "normalized SVG lacks an opening tag")
+    require(
+        f'xmlns="{SVG_NAMESPACE}"' in bare_opening.group(0),
+        "extract did not add a missing SVG namespace",
+    )
+    require(bare_output.count(f"<style>{font_import}</style>") == 1, "new defs lost font style")
+    require(
+        bare_output.index("</desc>") < bare_output.index("<defs>") < bare_output.index("<rect"),
+        "new defs block was not inserted after title/desc",
+    )
+
+
+def case_nested_svg(runner: CaptureRunner, tmp: Path) -> None:
+    del tmp
+    source_svg = isolate_svg(FIXTURE)
+    proc = runner.run("extract", FIXTURE, "--stdout")
+    require_success(proc, "nested-SVG extract")
+    pattern = re.compile(r"<svg(?=[\s>/])", re.IGNORECASE)
+    require(
+        len(pattern.findall(source_svg)) == len(pattern.findall(proc.stdout)),
+        "nested SVG count changed during extraction",
+    )
+    require(len(pattern.findall(source_svg)) >= 4, "fixture lacks three nested icon SVGs")
+    try:
+        ET.fromstring(proc.stdout)
+    except ET.ParseError as exc:
+        raise VerificationError(f"nested-SVG extract is not well-formed XML: {exc}") from exc
+
+
+def raw_element(svg: str, tag: str) -> bytes:
+    match = re.search(
+        rf"<{tag}\b[^>]*>.*?</{tag}\s*>", svg, re.IGNORECASE | re.DOTALL
+    )
+    require(match is not None, f"SVG lacks <{tag}> element")
+    return match.group(0).encode("utf-8")
+
+
+def case_accessibility(runner: CaptureRunner, tmp: Path) -> None:
+    del tmp
+    for source in (FIXTURE, VARIANTS[0][1]):
+        source_svg = isolate_svg(source)
+        proc = runner.run("extract", source, "--stdout")
+        require_success(proc, f"{source.name} accessibility extract")
+        source_attrs = root_attributes(source_svg)
+        output_attrs = root_attributes(proc.stdout[len(XML_DECLARATION) :])
+        require(source_attrs.get("role") == "img", f"{source.name} lacks role=img")
+        require(
+            output_attrs.get("role") == source_attrs.get("role"),
+            f"{source.name} role changed during extract",
+        )
+        require(
+            output_attrs.get("aria-labelledby") == source_attrs.get("aria-labelledby"),
+            f"{source.name} aria-labelledby changed during extract",
+        )
+        for tag in ("title", "desc"):
+            require(
+                raw_element(proc.stdout, tag) == raw_element(source_svg, tag),
+                f"{source.name} {tag} element was not byte-identical",
+            )
+
+
+def case_path_edge(runner: CaptureRunner, tmp: Path) -> None:
+    folder = tmp / "über diagramm"
+    folder.mkdir()
+    source = folder / "mein plan.html"
+    shutil.copyfile(VARIANTS[0][1], source)
+    expected_output = source.with_suffix(".svg")
+    proc = runner.run("extract", source)
+    require_success(proc, "spaces/non-ASCII default extract")
+    require(expected_output.is_file(), "default extract did not write next to source")
+    require(f"source: {source}" in proc.stdout, "file digest omitted source")
+    require(f"output: {expected_output}" in proc.stdout, "file digest omitted output")
+    require("viewBox: " in proc.stdout, "file digest omitted viewBox")
+    require(f"source_sha256: {sha256(source)}" in proc.stdout, "file digest omitted SHA-256")
+
+    explicit_output = folder / "maßgeschneidert.svg"
+    explicit = runner.run("extract", source, "--out", str(explicit_output))
+    require_success(explicit, "explicit --out extract")
+    require(explicit_output.is_file(), "explicit --out path was not written")
+    require(f"output: {explicit_output}" in explicit.stdout, "explicit output digest is wrong")
+
+
+def write_svg_case(path: Path, body: str, viewbox: str | None = "0 0 20 10") -> None:
+    viewbox_attr = "" if viewbox is None else f' viewBox="{viewbox}"'
+    path.write_text(
+        f'<svg{viewbox_attr} xmlns="{SVG_NAMESPACE}">{body}</svg>',
+        encoding="utf-8",
+    )
+
+
+def case_errors(runner: CaptureRunner, tmp: Path) -> None:
+    errors = tmp / "errors"
+    errors.mkdir()
+    missing_svg = errors / "missing-svg.html"
+    missing_svg.write_text("<!doctype html><p>not a diagram</p>", encoding="utf-8")
+    siblings = errors / "two-siblings.html"
+    siblings.write_text(
+        '<svg viewBox="0 0 10 10"></svg><svg viewBox="0 0 10 10"></svg>',
+        encoding="utf-8",
+    )
+    missing_viewbox = errors / "missing-viewbox.html"
+    write_svg_case(missing_viewbox, "<rect width=\"10\" height=\"10\"/>", None)
+    malformed_viewbox = errors / "malformed-viewbox.html"
+    write_svg_case(malformed_viewbox, "<rect/>", "0 0 x 10")
+    nonpositive_viewbox = errors / "nonpositive-viewbox.html"
+    write_svg_case(nonpositive_viewbox, "<rect/>", "0 0 0 10")
+    script = errors / "script.html"
+    write_svg_case(script, "<script>alert(1)</script>")
+    handler = errors / "handler.html"
+    write_svg_case(handler, '<rect onclick="alert(1)"/>')
+    javascript_url = errors / "javascript-url.html"
+    write_svg_case(javascript_url, '<a href="javascript:alert(1)"><rect/></a>')
+    xml_unclean = errors / "xml-unclean.html"
+    write_svg_case(xml_unclean, "<text>A & B</text>")
+
+    cases = (
+        ("missing-svg", missing_svg, "no <svg>"),
+        ("gallery", GALLERY, "gallery source"),
+        ("siblings", siblings, "2 top-level <svg>"),
+        ("missing-viewbox", missing_viewbox, "missing a viewBox"),
+        ("malformed-viewbox", malformed_viewbox, "malformed viewBox"),
+        ("nonpositive-viewbox", nonpositive_viewbox, "positive width and height"),
+        ("script", script, "<script>"),
+        ("handler", handler, "event-handler"),
+        ("javascript-url", javascript_url, "javascript:"),
+        ("xml-unclean", xml_unclean, "not XML-clean"),
+    )
+    for name, source, cause in cases:
+        output = errors / f"{name}-must-not-exist.svg"
+        proc = runner.run("extract", source, "--out", str(output))
+        require(proc.returncode == 2, f"{name} exited {proc.returncode}, expected 2")
+        require(proc.stderr.startswith("figma_capture: "), f"{name} lacks error prefix")
+        require(cause.lower() in proc.stderr.lower(), f"{name} stderr does not name {cause}")
+        require(not output.exists(), f"{name} wrote an output file on failure")
+
+
+def case_external_references(runner: CaptureRunner, tmp: Path) -> None:
+    refs = tmp / "external-references"
+    refs.mkdir()
+    google = refs / "google-fonts.html"
+    write_svg_case(
+        google,
+        "<style>@import url('https://fonts.googleapis.com/css2?family=Geist');</style>"
+        '<rect width="20" height="10"/>',
+    )
+    other_font = refs / "other-font.html"
+    write_svg_case(
+        other_font,
+        "<style>@import url('https://other.example/css2?family=Geist');</style>",
+    )
+    other_image = refs / "other-image.html"
+    write_svg_case(other_image, '<image href="https://other.example/x.png"/>')
+    other_css_url = refs / "other-css-url.html"
+    write_svg_case(
+        other_css_url,
+        "<style>.remote { fill: url('https://other.example/fill.svg'); }</style>",
+    )
+    local_refs = refs / "local-refs.html"
+    write_svg_case(
+        local_refs,
+        '<defs><linearGradient id="grad"><stop offset="1"/></linearGradient>'
+        '<path id="shape" d="M0 0h1v1z"/></defs>'
+        '<use href="#shape"/><rect width="20" height="10" fill="url(#grad)"/>'
+        '<image href="data:image/png;base64,iVBORw0KGgo="/>',
+    )
+
+    for name, source in (("Google Fonts", google), ("fragment references", local_refs)):
+        proc = runner.run("check", source)
+        require_success(proc, f"{name} policy check")
+    for name, source, cause in (
+        ("other font host", other_font, "external @import host"),
+        ("other image host", other_image, "external href host"),
+        ("other CSS URL host", other_css_url, "external url() host"),
+    ):
+        proc = runner.run("check", source)
+        require(proc.returncode == 2, f"{name} unexpectedly passed")
+        require(cause in proc.stderr, f"{name} failure did not identify {cause}")
+
+
+def case_foreign_object(runner: CaptureRunner, tmp: Path) -> None:
+    proc = runner.run("check", MEDALLION)
+    require_success(proc, "medallion foreignObject check")
+    require("warning:" in proc.stderr, "medallion check omitted warning")
+    require("foreignObject" in proc.stderr, "medallion warning omitted foreignObject")
+
+    unsafe = tmp / "foreign-object-script.html"
+    write_svg_case(unsafe, "<foreignObject><script>alert(1)</script></foreignObject>")
+    proc = runner.run("check", unsafe)
+    require(proc.returncode == 2, "foreignObject with script unexpectedly passed")
+    require("<script>" in proc.stderr, "foreignObject script failure omitted cause")
+
+
+def case_source_integrity(runner: CaptureRunner, tmp: Path) -> None:
+    del tmp
+    require(runner.integrity_checks > 0, "no subprocess source hashes were checked")
+    require(
+        not runner.integrity_failures,
+        "source integrity failures: " + "; ".join(runner.integrity_failures),
+    )
+
+
+def case_hygiene(runner: CaptureRunner, tmp: Path) -> None:
+    del tmp
+    require(runner.hygiene_checks > 0, "no generated SVG outputs were audited")
+    require(
+        not runner.hygiene_failures,
+        "output hygiene failures: " + "; ".join(runner.hygiene_failures),
+    )
+
+
+def case_doc_pointers(runner: CaptureRunner, tmp: Path) -> None:
+    del runner, tmp
+    references: list[tuple[Path, str]] = []
+    target_re = re.compile(
+        r"^(?:\.\./)*commands/([A-Za-z0-9._-]+\.md)(?:#[^\s]*)?$"
+    )
+    for document in sorted(REFERENCES.glob("*.md")):
+        text = document.read_text(encoding="utf-8")
+        targets = re.findall(r"`([^`\n]+)`", text)
+        targets.extend(re.findall(r"\[[^\]]*\]\(([^)\s]+)\)", text))
+        for target in targets:
+            match = target_re.fullmatch(target.strip("<>"))
+            if match:
+                references.append((document, match.group(1)))
+    require(references, "no commands/<name>.md references were discovered")
+    missing = [
+        f"{document.name}: commands/{name}"
+        for document, name in references
+        if not (COMMANDS / name).is_file()
+    ]
+    require(not missing, "stale command pointers: " + ", ".join(missing))
+
+
+def main() -> int:
+    required = (CAPTURE, EXPORT_REF, FIXTURE, GALLERY, MEDALLION, *(path for _, path in VARIANTS))
+    missing = [str(path.relative_to(ROOT)) for path in required if not path.is_file()]
+    if missing:
+        print("FAIL: missing required artifacts: " + ", ".join(missing), file=sys.stderr)
+        return 1
+
+    cases = (
+        ("happy path across light/dark/full/terminal variants", case_happy_paths),
+        ("extract preserves distinctive source SVG content verbatim", case_verbatim_source),
+        ("extract stays in parity with export.md", case_export_spec_parity),
+        ("nested SVG fixture survives complete and well-formed", case_nested_svg),
+        ("accessibility metadata and title/desc survive byte-identically", case_accessibility),
+        ("spaces and non-ASCII paths support default output", case_path_edge),
+        ("invalid and active-content inputs fail without output", case_errors),
+        ("external-reference allowlist accepts and rejects correctly", case_external_references),
+        ("foreignObject warns while active content still fails", case_foreign_object),
+        ("every subprocess leaves its source byte-identical", case_source_integrity),
+        ("all generated SVGs pass path and secret hygiene", case_hygiene),
+        ("reference command pointers resolve at the repository root", case_doc_pointers),
+    )
+    runner = CaptureRunner()
+    failures = 0
+    with tempfile.TemporaryDirectory(prefix="diagram-design-figma-") as tmp_dir:
+        tmp = Path(tmp_dir)
+        for number, (label, check) in enumerate(cases, start=1):
+            try:
+                check(runner, tmp)
+            except VerificationError as exc:
+                failures += 1
+                print(f"FAIL {number}: {label}: {exc}", file=sys.stderr)
+            else:
+                print(f"PASS {number}: {label}")
+
+    if failures:
+        print(f"\n{failures} of {len(cases)} Figma export tooling cases failed.", file=sys.stderr)
+        return 1
+    print(f"\nAll {len(cases)} Figma export tooling cases passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-figma-export.py
+++ b/scripts/verify-figma-export.py
@@ -243,7 +243,10 @@ def case_verbatim_source(runner: CaptureRunner, tmp: Path) -> None:
     path_match = re.search(r'<path\b[^>]*\bd="([^"]{24,})"', source_svg, re.IGNORECASE)
     require(text_match is not None, "could not select a source text label")
     require(path_match is not None, "could not select a source path fragment")
-    snippets = (text_match.group(0), f'd="{path_match.group(1)[:80]}')
+    snippets = (
+        f">{text_match.group(0).split('>', 1)[1]}",
+        f'd="{path_match.group(1)[:80]}',
+    )
 
     proc = runner.run("extract", source, "--stdout")
     require_success(proc, "verbatim-source extract")
@@ -319,6 +322,123 @@ def case_export_spec_parity(runner: CaptureRunner, tmp: Path) -> None:
     )
 
 
+def case_color_normalization(runner: CaptureRunner, tmp: Path) -> None:
+    colors = tmp / "colors"
+    colors.mkdir()
+    source = colors / "positive.html"
+    write_svg_case(
+        source,
+        '<rect id="fill" fill = " RGBA(45, 49, 66, .03) "/>'
+        "<path id='stroke' stroke='rgba(255,0,16,0.5)' stroke-opacity = '.4'/>"
+        '<circle id="transparent" fill="TrAnSpArEnT" stroke=" transparent "/>'
+        '<rect id="zero" fill="rgba(0,0,0,1)" fill-opacity="0"/>'
+        "<style>/* rgba(1,2,3,.5) and transparent in comments are inert */</style>",
+    )
+    proc = runner.run("extract", source, "--stdout")
+    require_success(proc, "presentation-color normalization")
+    output = proc.stdout
+    try:
+        root = ET.fromstring(output)
+    except ET.ParseError as exc:
+        raise VerificationError(f"normalized colors are not XML-clean: {exc}") from exc
+    elements = {
+        element.attrib["id"]: element
+        for element in root.iter()
+        if "id" in element.attrib
+    }
+    require(
+        elements["fill"].attrib.get("fill") == "#2d3142"
+        and elements["fill"].attrib.get("fill-opacity") == "0.03",
+        "rgba fill did not become lowercase hex plus alpha opacity",
+    )
+    require(
+        elements["stroke"].attrib.get("stroke") == "#ff0010"
+        and elements["stroke"].attrib.get("stroke-opacity") == "0.2",
+        "rgba stroke did not compose with existing stroke-opacity",
+    )
+    require(
+        elements["transparent"].attrib.get("fill") == "none"
+        and elements["transparent"].attrib.get("stroke") == "none",
+        "case-insensitive transparent did not become none",
+    )
+    require(
+        elements["zero"].attrib.get("fill-opacity") == "0",
+        "zero existing opacity did not compose correctly",
+    )
+    for element in root.iter():
+        for attribute in ("fill", "stroke"):
+            value = element.attrib.get(attribute, "")
+            require(
+                re.search(r"(?i)rgba\s*\(|\btransparent\b", value) is None,
+                f"unsupported {attribute} color survived normalization: {value!r}",
+            )
+
+    normalized = colors / "normalized.svg"
+    normalized.write_text(output, encoding="utf-8")
+    repeated = runner.run("extract", normalized, "--stdout")
+    require_success(repeated, "idempotent normalized extract")
+    require(repeated.stdout == output, "normalization changed an already-normalized SVG")
+
+    invalid_cases = (
+        ("negative-rgb", '<rect fill="rgba(-1,0,0,.5)"/>', "RGB channels"),
+        ("high-rgb", '<rect stroke="rgba(0,256,0,.5)"/>', "RGB channels"),
+        ("high-alpha", '<rect fill="rgba(0,0,0,1.1)"/>', "between 0 and 1"),
+        (
+            "nonfinite-alpha",
+            '<rect fill="rgba(0,0,0,NaN)"/>',
+            "unsupported fill color",
+        ),
+        (
+            "duplicate-fill",
+            '<rect fill="rgba(0,0,0,.5)" fill="transparent"/>',
+            "duplicate fill",
+        ),
+        (
+            "duplicate-opacity",
+            '<rect fill="rgba(0,0,0,.5)" fill-opacity=".5" fill-opacity=".4"/>',
+            "duplicate fill-opacity",
+        ),
+        (
+            "nonnumeric-opacity",
+            '<rect fill="#000" fill-opacity="opaque"/>',
+            "numeric value",
+        ),
+        (
+            "nonfinite-opacity",
+            '<rect fill="#000" fill-opacity="inf"/>',
+            "must be finite",
+        ),
+        (
+            "negative-opacity",
+            '<rect fill="#000" fill-opacity="-.1"/>',
+            "between 0 and 1",
+        ),
+        (
+            "unsupported-rgba",
+            '<rect fill="rgba(0 0 0 / .5)"/>',
+            "unsupported fill color",
+        ),
+        (
+            "inline-css",
+            '<rect style="fill: rgba(0,0,0,.5)"/>',
+            "unsupported rgba() color in style attribute",
+        ),
+        (
+            "style-block",
+            '<style>.hidden { stroke: transparent; }</style><path class="hidden"/>',
+            "unsupported transparent color in <style>",
+        ),
+    )
+    for name, body, cause in invalid_cases:
+        invalid = colors / f"{name}.html"
+        output_path = colors / f"{name}.svg"
+        write_svg_case(invalid, body)
+        failed = runner.run("extract", invalid, "--out", str(output_path))
+        require(failed.returncode == 2, f"{name} unexpectedly passed")
+        require(cause in failed.stderr, f"{name} did not identify {cause!r}")
+        require(not output_path.exists(), f"{name} wrote output before validation")
+
+
 def case_nested_svg(runner: CaptureRunner, tmp: Path) -> None:
     del tmp
     source_svg = isolate_svg(FIXTURE)
@@ -334,6 +454,26 @@ def case_nested_svg(runner: CaptureRunner, tmp: Path) -> None:
         ET.fromstring(proc.stdout)
     except ET.ParseError as exc:
         raise VerificationError(f"nested-SVG extract is not well-formed XML: {exc}") from exc
+
+
+def case_example_corpus(runner: CaptureRunner, tmp: Path) -> None:
+    del tmp
+    sources = sorted((ROOT / "skills/diagram-design/assets").glob("example-*.html"))
+    require(len(sources) >= 100, "example corpus discovery is unexpectedly incomplete")
+    for source in sources:
+        proc = runner.run("extract", source, "--stdout")
+        require_success(proc, f"{source.name} corpus extract")
+        try:
+            root = ET.fromstring(proc.stdout)
+        except ET.ParseError as exc:
+            raise VerificationError(f"{source.name} is not XML-clean: {exc}") from exc
+        for element in root.iter():
+            for attribute in ("fill", "stroke"):
+                value = element.attrib.get(attribute, "")
+                require(
+                    re.search(r"(?i)rgba\s*\(|\btransparent\b", value) is None,
+                    f"{source.name} retained unsupported {attribute}={value!r}",
+                )
 
 
 def raw_element(svg: str, tag: str) -> bytes:
@@ -551,7 +691,12 @@ def main() -> int:
         ("happy path across light/dark/full/terminal variants", case_happy_paths),
         ("extract preserves distinctive source SVG content verbatim", case_verbatim_source),
         ("extract stays in parity with export.md", case_export_spec_parity),
+        (
+            "PowerPoint-safe color normalization is strict and idempotent",
+            case_color_normalization,
+        ),
         ("nested SVG fixture survives complete and well-formed", case_nested_svg),
+        ("every shipped example extracts as normalized XML", case_example_corpus),
         ("accessibility metadata and title/desc survive byte-identically", case_accessibility),
         ("spaces and non-ASCII paths support default output", case_path_edge),
         ("invalid and active-content inputs fail without output", case_errors),

--- a/skills/diagram-design/assets/example-high-level.html
+++ b/skills/diagram-design/assets/example-high-level.html
@@ -234,7 +234,7 @@
       <text x="452" y="252" fill="#eb6c36" font-size="12" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">MinIO / S3</text>
       <text x="452" y="268" fill="#eb6c36" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle" opacity="0.75">Object store · S3-API</text>
 
-      <!-- ── Data Modeling & Analysis ── -->
+      <!-- ── Data Modeling &amp; Analysis ── -->
       <rect x="600" y="144" width="164" height="80" rx="6" fill="#f5f5f5"/>
       <rect x="600" y="144" width="164" height="80" rx="6" fill="white" stroke="rgba(45,49,66,0.25)" stroke-width="1"/>
       <rect x="608" y="150" width="32" height="12" rx="2" fill="transparent" stroke="rgba(45,49,66,0.28)" stroke-width="0.8"/>
@@ -245,7 +245,7 @@
       <text x="682" y="186" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">Data Modeling</text>
       <text x="682" y="198" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">Notebook · Python · R</text>
 
-      <!-- ── Dashboards & Report ── -->
+      <!-- ── Dashboards &amp; Report ── -->
       <rect x="820" y="144" width="152" height="80" rx="6" fill="#f5f5f5"/>
       <rect x="820" y="144" width="152" height="80" rx="6" fill="white" stroke="rgba(45,49,66,0.25)" stroke-width="1"/>
       <rect x="828" y="150" width="28" height="12" rx="2" fill="transparent" stroke="rgba(45,49,66,0.28)" stroke-width="0.8"/>

--- a/skills/diagram-design/assets/example-paved-road-animated.html
+++ b/skills/diagram-design/assets/example-paved-road-animated.html
@@ -216,7 +216,7 @@
         <text x="76" y="357" fill="#eb6c36" font-family="'Geist', sans-serif" font-size="14" font-weight="600">Unauthorized Attacker</text>
         <text x="76" y="377" fill="#eb6c36" font-family="'Geist Mono', monospace" font-size="11">Bypass Attempt (No Key)</text>
 
-        <!-- Base Layout: Trust Zone 2 - Corporate CI/CD & Governance -->
+        <!-- Base Layout: Trust Zone 2 - Corporate CI/CD &amp; Governance -->
         <rect x="330" y="40" width="380" height="490" rx="8" fill="#ececec" stroke="rgba(45,49,66,0.12)" stroke-width="1" />
         <text x="350" y="72" fill="#4f5d75" font-family="'Geist Mono', monospace" font-size="11" letter-spacing="1.6">CORPORATE GOVERNANCE ZONE</text>
 
@@ -230,7 +230,7 @@
         <text x="370" y="238" fill="#2d3142" font-family="'Geist', sans-serif" font-size="14" font-weight="600">Privileged Security Gate</text>
         <text x="370" y="258" fill="#4f5d75" font-family="'Geist Mono', monospace" font-size="11">Policy: OPA Signature &amp; Vulnerability Scan</text>
 
-        <!-- Node: Boundary Firewall & WAF (Left side x=350..560) -->
+        <!-- Node: Boundary Firewall &amp; WAF (Left side x=350..560) -->
         <rect x="350" y="325" width="210" height="72" rx="6" fill="rgba(235,108,54,0.08)" stroke="#eb6c36" stroke-width="1.5" />
         <text x="366" y="355" fill="#eb6c36" font-family="'Geist', sans-serif" font-size="13" font-weight="600">Boundary Firewall &amp; WAF</text>
         <text x="366" y="375" fill="#eb6c36" font-family="'Geist Mono', monospace" font-size="10.5" font-weight="600">Status: × BLOCKED</text>
@@ -260,21 +260,21 @@
         <text x="800" y="485" fill="#4f5d75" font-family="'Geist Mono', monospace" font-size="11">Monitoring: Real-time Alerting Active</text>
 
         <!-- STEP 1: Authorized Developer Code Ingress -->
-        <g data-motion-item data-step="1" aria-label="Step 1: Developer workstation pushes signed code commit into CI/CD Paved Road pipeline">
+        <g data-motion-item="true" data-step="1" aria-label="Step 1: Developer workstation pushes signed code commit into CI/CD Paved Road pipeline">
           <path d="M 260 132 L 350 132" fill="none" stroke="#2d3142" stroke-width="2" marker-end="url(#arrow-ink)" />
           <rect x="275" y="104" width="60" height="18" rx="3" fill="#ffffff" stroke="#2d3142" stroke-width="1" />
           <text x="305" y="117" text-anchor="middle" fill="#2d3142" font-family="'Geist Mono', monospace" font-size="9" font-weight="600">GIT PUSH</text>
         </g>
 
-        <!-- STEP 2: CI/CD Build & Cryptographic Signing -->
-        <g data-motion-item data-step="2" aria-label="Step 2: CI/CD pipeline builds binary and generates cryptographic provenance signature">
+        <!-- STEP 2: CI/CD Build &amp; Cryptographic Signing -->
+        <g data-motion-item="true" data-step="2" aria-label="Step 2: CI/CD pipeline builds binary and generates cryptographic provenance signature">
           <path d="M 520 168 L 520 210" fill="none" stroke="#2d3142" stroke-width="2" marker-end="url(#arrow-ink)" />
           <rect x="440" y="178" width="160" height="20" rx="4" fill="#ffffff" stroke="#2d3142" stroke-width="1" />
           <text x="520" y="192" text-anchor="middle" fill="#2d3142" font-family="'Geist Mono', monospace" font-size="9" font-weight="600">PROVENANCE [SIGNED]</text>
         </g>
 
         <!-- STEP 3: Security Gate Approval → Production Gateway → Database Deployment -->
-        <g data-motion-item data-step="3" aria-label="Step 3: Security gate verifies OPA policy, approves artifact, and deploys via Production API Gateway to Isolated Core Database">
+        <g data-motion-item="true" data-step="3" aria-label="Step 3: Security gate verifies OPA policy, approves artifact, and deploys via Production API Gateway to Isolated Core Database">
           <!-- Gate ✓ PASS → Production API Gateway (diagonal: gate right edge to gateway left edge) -->
           <path d="M 690 230 L 780 132" fill="none" stroke="#2d3142" stroke-width="2" marker-end="url(#arrow-ink)" />
           <rect x="700" y="166" width="65" height="18" rx="3" fill="#ffffff" stroke="#2d3142" stroke-width="1" />
@@ -284,14 +284,14 @@
         </g>
 
         <!-- STEP 4: Unauthorized Bypass Attempt Blocked at Boundary Firewall -->
-        <g data-motion-item data-step="4" aria-label="Step 4: Unauthorized attacker connection attempt is blocked at trust boundary firewall">
+        <g data-motion-item="true" data-step="4" aria-label="Step 4: Unauthorized attacker connection attempt is blocked at trust boundary firewall">
           <path d="M 260 361 L 350 361" fill="none" stroke="#eb6c36" stroke-width="2" stroke-dasharray="4 4" marker-end="url(#arrow-accent)" />
           <rect x="272" y="345" width="65" height="18" rx="3" fill="#ffffff" stroke="#eb6c36" stroke-width="1" />
           <text x="304" y="358" text-anchor="middle" fill="#eb6c36" font-family="'Geist Mono', monospace" font-size="8.5" font-weight="600">BYPASS</text>
         </g>
 
-        <!-- STEP 5: Audit Log & SIEM Security Monitoring Record -->
-        <g data-motion-item data-step="5" aria-label="Step 5: Immutable SIEM audit log records both authorized deployment and blocked attack attempt">
+        <!-- STEP 5: Audit Log &amp; SIEM Security Monitoring Record -->
+        <g data-motion-item="true" data-step="5" aria-label="Step 5: Immutable SIEM audit log records both authorized deployment and blocked attack attempt">
           <!-- Gate Audit Trail (Runs cleanly down the right side x=620, clear of Firewall node x=350..560!) -->
           <path d="M 620 286 L 620 435" fill="none" stroke="#2d3142" stroke-width="2" marker-end="url(#arrow-ink)" />
           <!-- WAF Audit Trail (Runs directly down x=455 into Audit Log) -->
@@ -304,7 +304,7 @@
         </g>
 
         <!-- Precision SVG Legend Footer (Exact visual mini-arrows and mini-rects) -->
-        <g data-motion-decorative aria-hidden="true">
+        <g data-motion-decorative="true" aria-hidden="true">
           <!-- Flow Line 1: Authorized Paved Road -->
           <line x1="40" y1="584" x2="65" y2="584" stroke="#2d3142" stroke-width="2" marker-end="url(#arrow-ink)" />
           <text x="73" y="588" fill="#2d3142" font-family="'Geist Mono', monospace" font-size="9.5">Authorized Paved Road</text>

--- a/skills/diagram-design/assets/example-polar-dark.html
+++ b/skills/diagram-design/assets/example-polar-dark.html
@@ -28,30 +28,30 @@
 
     <svg viewBox="0 0 1000 520" xmlns="http://www.w3.org/2000/svg"
          role="img" aria-labelledby="polar-dark-title polar-dark-desc"
-         data-polar-chart data-polar-cx="500" data-polar-cy="230"
+         data-polar-chart="true" data-polar-cx="500" data-polar-cy="230"
          data-polar-radius="160" data-polar-min="0" data-polar-max="100"
          data-polar-start-angle="-90" data-polar-clockwise="true"
          data-polar-radius-encoding="linear" data-polar-inner-radius="0">
       <title id="polar-dark-title">Request demand by UTC window</title>
       <desc id="polar-dark-desc">Polar chart on a 0–100% scale identifying 12–15 UTC as the 100% peak, with the other seven UTC windows proceeding clockwise.</desc>
 
-      <rect data-polar-background width="100%" height="100%" fill="#2d3142"/>
+      <rect data-polar-background="true" width="100%" height="100%" fill="#2d3142"/>
       <text x="40" y="28" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.14em">% OF DAILY PEAK · 0–100</text>
 
-      <circle data-polar-ring cx="500" cy="230" r="32" fill="none" stroke="rgba(245,245,245,0.10)" stroke-width="0.8"/>
-      <circle data-polar-ring cx="500" cy="230" r="64" fill="none" stroke="rgba(245,245,245,0.10)" stroke-width="0.8"/>
-      <circle data-polar-ring cx="500" cy="230" r="96" fill="none" stroke="rgba(245,245,245,0.10)" stroke-width="0.8"/>
-      <circle data-polar-ring cx="500" cy="230" r="128" fill="none" stroke="rgba(245,245,245,0.10)" stroke-width="0.8"/>
-      <circle data-polar-ring cx="500" cy="230" r="160" fill="none" stroke="rgba(245,245,245,0.20)" stroke-width="0.8"/>
+      <circle data-polar-ring="true" cx="500" cy="230" r="32" fill="none" stroke="rgba(245,245,245,0.10)" stroke-width="0.8"/>
+      <circle data-polar-ring="true" cx="500" cy="230" r="64" fill="none" stroke="rgba(245,245,245,0.10)" stroke-width="0.8"/>
+      <circle data-polar-ring="true" cx="500" cy="230" r="96" fill="none" stroke="rgba(245,245,245,0.10)" stroke-width="0.8"/>
+      <circle data-polar-ring="true" cx="500" cy="230" r="128" fill="none" stroke="rgba(245,245,245,0.10)" stroke-width="0.8"/>
+      <circle data-polar-ring="true" cx="500" cy="230" r="160" fill="none" stroke="rgba(245,245,245,0.20)" stroke-width="0.8"/>
 
-      <line data-polar-spoke data-polar-index="0" x1="500" y1="230" x2="500" y2="70" stroke="rgba(245,245,245,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="1" x1="500" y1="230" x2="613.137" y2="116.863" stroke="rgba(245,245,245,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="2" x1="500" y1="230" x2="660" y2="230" stroke="rgba(245,245,245,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="3" x1="500" y1="230" x2="613.137" y2="343.137" stroke="rgba(245,245,245,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="4" x1="500" y1="230" x2="500" y2="390" stroke="rgba(245,245,245,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="5" x1="500" y1="230" x2="386.863" y2="343.137" stroke="rgba(245,245,245,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="6" x1="500" y1="230" x2="340" y2="230" stroke="rgba(245,245,245,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="7" x1="500" y1="230" x2="386.863" y2="116.863" stroke="rgba(245,245,245,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="0" x1="500" y1="230" x2="500" y2="70" stroke="rgba(245,245,245,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="1" x1="500" y1="230" x2="613.137" y2="116.863" stroke="rgba(245,245,245,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="2" x1="500" y1="230" x2="660" y2="230" stroke="rgba(245,245,245,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="3" x1="500" y1="230" x2="613.137" y2="343.137" stroke="rgba(245,245,245,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="4" x1="500" y1="230" x2="500" y2="390" stroke="rgba(245,245,245,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="5" x1="500" y1="230" x2="386.863" y2="343.137" stroke="rgba(245,245,245,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="6" x1="500" y1="230" x2="340" y2="230" stroke="rgba(245,245,245,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="7" x1="500" y1="230" x2="386.863" y2="116.863" stroke="rgba(245,245,245,0.16)" stroke-width="0.8"/>
 
       <text x="492" y="201" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end">20</text>
       <text x="492" y="169" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end">40</text>
@@ -61,54 +61,54 @@
       <text x="508" y="233" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace">0</text>
 
       <g data-polar-category="00–03" data-polar-index="0" data-polar-value="32">
-        <line data-polar-ray x1="500" y1="230" x2="500" y2="178.8" stroke="#bfc0c0" stroke-width="2"/>
-        <circle data-polar-marker cx="500" cy="178.8" r="4" fill="#2d3142" stroke="#bfc0c0" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="500" y2="178.8" stroke="#bfc0c0" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="500" cy="178.8" r="4" fill="#2d3142" stroke="#bfc0c0" stroke-width="1.2"/>
         <text x="500" y="42" fill="#f5f5f5" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">00–03</text>
-        <text data-polar-value-label x="500" y="26" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">32</text>
+        <text data-polar-value-label="true" x="500" y="26" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">32</text>
       </g>
       <g data-polar-category="03–06" data-polar-index="1" data-polar-value="18">
-        <line data-polar-ray x1="500" y1="230" x2="520.365" y2="209.635" stroke="#bfc0c0" stroke-width="2"/>
-        <circle data-polar-marker cx="520.365" cy="209.635" r="4" fill="#2d3142" stroke="#bfc0c0" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="520.365" y2="209.635" stroke="#bfc0c0" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="520.365" cy="209.635" r="4" fill="#2d3142" stroke="#bfc0c0" stroke-width="1.2"/>
         <text x="632.936" y="97.064" fill="#f5f5f5" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="start">03–06</text>
-        <text data-polar-value-label x="644.25" y="85.75" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" text-anchor="start">18</text>
+        <text data-polar-value-label="true" x="644.25" y="85.75" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" text-anchor="start">18</text>
       </g>
       <g data-polar-category="06–09" data-polar-index="2" data-polar-value="24">
-        <line data-polar-ray x1="500" y1="230" x2="538.4" y2="230" stroke="#bfc0c0" stroke-width="2"/>
-        <circle data-polar-marker cx="538.4" cy="230" r="4" fill="#2d3142" stroke="#bfc0c0" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="538.4" y2="230" stroke="#bfc0c0" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="538.4" cy="230" r="4" fill="#2d3142" stroke="#bfc0c0" stroke-width="1.2"/>
         <text x="688" y="230" fill="#f5f5f5" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="start">06–09</text>
-        <text data-polar-value-label x="704" y="230" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" text-anchor="start" dy="16">24</text>
+        <text data-polar-value-label="true" x="704" y="230" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" text-anchor="start" dy="16">24</text>
       </g>
       <g data-polar-category="09–12" data-polar-index="3" data-polar-value="58">
-        <line data-polar-ray x1="500" y1="230" x2="565.62" y2="295.62" stroke="#bfc0c0" stroke-width="2"/>
-        <circle data-polar-marker cx="565.62" cy="295.62" r="4" fill="#2d3142" stroke="#bfc0c0" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="565.62" y2="295.62" stroke="#bfc0c0" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="565.62" cy="295.62" r="4" fill="#2d3142" stroke="#bfc0c0" stroke-width="1.2"/>
         <text x="632.936" y="362.936" fill="#f5f5f5" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="start">09–12</text>
-        <text data-polar-value-label x="644.25" y="374.25" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" text-anchor="start" dy="12">58</text>
+        <text data-polar-value-label="true" x="644.25" y="374.25" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" text-anchor="start" dy="12">58</text>
       </g>
       <g data-polar-category="12–15" data-polar-index="4" data-polar-value="100" data-polar-focal="true">
-        <line data-polar-ray x1="500" y1="230" x2="500" y2="390" stroke="#f08a59" stroke-width="2.4"/>
-        <circle data-polar-marker cx="500" cy="390" r="5" fill="#2d3142" stroke="#f08a59" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="500" y2="390" stroke="#f08a59" stroke-width="2.4"/>
+        <circle data-polar-marker="true" cx="500" cy="390" r="5" fill="#2d3142" stroke="#f08a59" stroke-width="1.2"/>
         <text x="500" y="418" fill="#f5f5f5" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">12–15</text>
-        <text data-polar-value-label x="500" y="434" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">100</text>
+        <text data-polar-value-label="true" x="500" y="434" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">100</text>
       </g>
       <g data-polar-category="15–18" data-polar-index="5" data-polar-value="82">
-        <line data-polar-ray x1="500" y1="230" x2="407.227" y2="322.773" stroke="#bfc0c0" stroke-width="2"/>
-        <circle data-polar-marker cx="407.227" cy="322.773" r="4" fill="#2d3142" stroke="#bfc0c0" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="407.227" y2="322.773" stroke="#bfc0c0" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="407.227" cy="322.773" r="4" fill="#2d3142" stroke="#bfc0c0" stroke-width="1.2"/>
         <text x="367.064" y="362.936" fill="#f5f5f5" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="end">15–18</text>
-        <text data-polar-value-label x="355.75" y="374.25" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end" dy="12">82</text>
+        <text data-polar-value-label="true" x="355.75" y="374.25" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end" dy="12">82</text>
       </g>
       <g data-polar-category="18–21" data-polar-index="6" data-polar-value="76">
-        <line data-polar-ray x1="500" y1="230" x2="378.4" y2="230" stroke="#bfc0c0" stroke-width="2"/>
-        <circle data-polar-marker cx="378.4" cy="230" r="4" fill="#2d3142" stroke="#bfc0c0" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="378.4" y2="230" stroke="#bfc0c0" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="378.4" cy="230" r="4" fill="#2d3142" stroke="#bfc0c0" stroke-width="1.2"/>
         <text x="312" y="230" fill="#f5f5f5" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="end">18–21</text>
-        <text data-polar-value-label x="296" y="230" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end" dy="16">76</text>
+        <text data-polar-value-label="true" x="296" y="230" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end" dy="16">76</text>
       </g>
       <g data-polar-category="21–24" data-polar-index="7" data-polar-value="45">
-        <line data-polar-ray x1="500" y1="230" x2="449.088" y2="179.088" stroke="#bfc0c0" stroke-width="2"/>
-        <circle data-polar-marker cx="449.088" cy="179.088" r="4" fill="#2d3142" stroke="#bfc0c0" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="449.088" y2="179.088" stroke="#bfc0c0" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="449.088" cy="179.088" r="4" fill="#2d3142" stroke="#bfc0c0" stroke-width="1.2"/>
         <text x="367.064" y="97.064" fill="#f5f5f5" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="end">21–24</text>
-        <text data-polar-value-label x="355.75" y="85.75" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end">45</text>
+        <text data-polar-value-label="true" x="355.75" y="85.75" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end">45</text>
       </g>
-      <line data-polar-rule x1="40" y1="468" x2="960" y2="468" stroke="rgba(245,245,245,0.10)" stroke-width="0.8"/>
+      <line data-polar-rule="true" x1="40" y1="468" x2="960" y2="468" stroke="rgba(245,245,245,0.10)" stroke-width="0.8"/>
       <text x="40" y="488" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.08em">Illustrative normalized workload profile</text>
     </svg>
   </div>

--- a/skills/diagram-design/assets/example-polar-full.html
+++ b/skills/diagram-design/assets/example-polar-full.html
@@ -38,30 +38,30 @@
     <div class="diagram-container">
       <svg viewBox="0 0 1000 520" xmlns="http://www.w3.org/2000/svg"
          role="img" aria-labelledby="polar-full-title polar-full-desc"
-         data-polar-chart data-polar-cx="500" data-polar-cy="230"
+         data-polar-chart="true" data-polar-cx="500" data-polar-cy="230"
          data-polar-radius="160" data-polar-min="0" data-polar-max="100"
          data-polar-start-angle="-90" data-polar-clockwise="true"
          data-polar-radius-encoding="linear" data-polar-inner-radius="0">
       <title id="polar-full-title">Request demand by UTC window</title>
       <desc id="polar-full-desc">Polar chart on a 0–100% scale identifying 12–15 UTC as the 100% peak, with the other seven UTC windows proceeding clockwise.</desc>
 
-      <rect data-polar-background width="100%" height="100%" fill="#f5f5f5"/>
+      <rect data-polar-background="true" width="100%" height="100%" fill="#f5f5f5"/>
       <text x="40" y="28" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.14em">% OF DAILY PEAK · 0–100</text>
 
-      <circle data-polar-ring cx="500" cy="230" r="32" fill="none" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
-      <circle data-polar-ring cx="500" cy="230" r="64" fill="none" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
-      <circle data-polar-ring cx="500" cy="230" r="96" fill="none" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
-      <circle data-polar-ring cx="500" cy="230" r="128" fill="none" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
-      <circle data-polar-ring cx="500" cy="230" r="160" fill="none" stroke="rgba(45,49,66,0.20)" stroke-width="0.8"/>
+      <circle data-polar-ring="true" cx="500" cy="230" r="32" fill="none" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
+      <circle data-polar-ring="true" cx="500" cy="230" r="64" fill="none" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
+      <circle data-polar-ring="true" cx="500" cy="230" r="96" fill="none" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
+      <circle data-polar-ring="true" cx="500" cy="230" r="128" fill="none" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
+      <circle data-polar-ring="true" cx="500" cy="230" r="160" fill="none" stroke="rgba(45,49,66,0.20)" stroke-width="0.8"/>
 
-      <line data-polar-spoke data-polar-index="0" x1="500" y1="230" x2="500" y2="70" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="1" x1="500" y1="230" x2="613.137" y2="116.863" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="2" x1="500" y1="230" x2="660" y2="230" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="3" x1="500" y1="230" x2="613.137" y2="343.137" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="4" x1="500" y1="230" x2="500" y2="390" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="5" x1="500" y1="230" x2="386.863" y2="343.137" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="6" x1="500" y1="230" x2="340" y2="230" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="7" x1="500" y1="230" x2="386.863" y2="116.863" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="0" x1="500" y1="230" x2="500" y2="70" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="1" x1="500" y1="230" x2="613.137" y2="116.863" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="2" x1="500" y1="230" x2="660" y2="230" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="3" x1="500" y1="230" x2="613.137" y2="343.137" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="4" x1="500" y1="230" x2="500" y2="390" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="5" x1="500" y1="230" x2="386.863" y2="343.137" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="6" x1="500" y1="230" x2="340" y2="230" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="7" x1="500" y1="230" x2="386.863" y2="116.863" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
 
       <text x="492" y="201" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end">20</text>
       <text x="492" y="169" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end">40</text>
@@ -71,54 +71,54 @@
       <text x="508" y="233" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace">0</text>
 
       <g data-polar-category="00–03" data-polar-index="0" data-polar-value="32">
-        <line data-polar-ray x1="500" y1="230" x2="500" y2="178.8" stroke="#4f5d75" stroke-width="2"/>
-        <circle data-polar-marker cx="500" cy="178.8" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="500" y2="178.8" stroke="#4f5d75" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="500" cy="178.8" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
         <text x="500" y="42" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">00–03</text>
-        <text data-polar-value-label x="500" y="26" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">32</text>
+        <text data-polar-value-label="true" x="500" y="26" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">32</text>
       </g>
       <g data-polar-category="03–06" data-polar-index="1" data-polar-value="18">
-        <line data-polar-ray x1="500" y1="230" x2="520.365" y2="209.635" stroke="#4f5d75" stroke-width="2"/>
-        <circle data-polar-marker cx="520.365" cy="209.635" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="520.365" y2="209.635" stroke="#4f5d75" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="520.365" cy="209.635" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
         <text x="632.936" y="97.064" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="start">03–06</text>
-        <text data-polar-value-label x="644.25" y="85.75" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="start">18</text>
+        <text data-polar-value-label="true" x="644.25" y="85.75" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="start">18</text>
       </g>
       <g data-polar-category="06–09" data-polar-index="2" data-polar-value="24">
-        <line data-polar-ray x1="500" y1="230" x2="538.4" y2="230" stroke="#4f5d75" stroke-width="2"/>
-        <circle data-polar-marker cx="538.4" cy="230" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="538.4" y2="230" stroke="#4f5d75" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="538.4" cy="230" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
         <text x="688" y="230" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="start">06–09</text>
-        <text data-polar-value-label x="704" y="230" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="start" dy="16">24</text>
+        <text data-polar-value-label="true" x="704" y="230" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="start" dy="16">24</text>
       </g>
       <g data-polar-category="09–12" data-polar-index="3" data-polar-value="58">
-        <line data-polar-ray x1="500" y1="230" x2="565.62" y2="295.62" stroke="#4f5d75" stroke-width="2"/>
-        <circle data-polar-marker cx="565.62" cy="295.62" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="565.62" y2="295.62" stroke="#4f5d75" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="565.62" cy="295.62" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
         <text x="632.936" y="362.936" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="start">09–12</text>
-        <text data-polar-value-label x="644.25" y="374.25" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="start" dy="12">58</text>
+        <text data-polar-value-label="true" x="644.25" y="374.25" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="start" dy="12">58</text>
       </g>
       <g data-polar-category="12–15" data-polar-index="4" data-polar-value="100" data-polar-focal="true">
-        <line data-polar-ray x1="500" y1="230" x2="500" y2="390" stroke="#eb6c36" stroke-width="2.4"/>
-        <circle data-polar-marker cx="500" cy="390" r="5" fill="#f5f5f5" stroke="#eb6c36" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="500" y2="390" stroke="#eb6c36" stroke-width="2.4"/>
+        <circle data-polar-marker="true" cx="500" cy="390" r="5" fill="#f5f5f5" stroke="#eb6c36" stroke-width="1.2"/>
         <text x="500" y="418" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">12–15</text>
-        <text data-polar-value-label x="500" y="434" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">100</text>
+        <text data-polar-value-label="true" x="500" y="434" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">100</text>
       </g>
       <g data-polar-category="15–18" data-polar-index="5" data-polar-value="82">
-        <line data-polar-ray x1="500" y1="230" x2="407.227" y2="322.773" stroke="#4f5d75" stroke-width="2"/>
-        <circle data-polar-marker cx="407.227" cy="322.773" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="407.227" y2="322.773" stroke="#4f5d75" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="407.227" cy="322.773" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
         <text x="367.064" y="362.936" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="end">15–18</text>
-        <text data-polar-value-label x="355.75" y="374.25" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end" dy="12">82</text>
+        <text data-polar-value-label="true" x="355.75" y="374.25" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end" dy="12">82</text>
       </g>
       <g data-polar-category="18–21" data-polar-index="6" data-polar-value="76">
-        <line data-polar-ray x1="500" y1="230" x2="378.4" y2="230" stroke="#4f5d75" stroke-width="2"/>
-        <circle data-polar-marker cx="378.4" cy="230" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="378.4" y2="230" stroke="#4f5d75" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="378.4" cy="230" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
         <text x="312" y="230" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="end">18–21</text>
-        <text data-polar-value-label x="296" y="230" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end" dy="16">76</text>
+        <text data-polar-value-label="true" x="296" y="230" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end" dy="16">76</text>
       </g>
       <g data-polar-category="21–24" data-polar-index="7" data-polar-value="45">
-        <line data-polar-ray x1="500" y1="230" x2="449.088" y2="179.088" stroke="#4f5d75" stroke-width="2"/>
-        <circle data-polar-marker cx="449.088" cy="179.088" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="449.088" y2="179.088" stroke="#4f5d75" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="449.088" cy="179.088" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
         <text x="367.064" y="97.064" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="end">21–24</text>
-        <text data-polar-value-label x="355.75" y="85.75" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end">45</text>
+        <text data-polar-value-label="true" x="355.75" y="85.75" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end">45</text>
       </g>
-      <line data-polar-rule x1="40" y1="468" x2="960" y2="468" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
+      <line data-polar-rule="true" x1="40" y1="468" x2="960" y2="468" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
       <text x="40" y="488" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.08em">Illustrative normalized workload profile</text>
       </svg>
     </div>

--- a/skills/diagram-design/assets/example-polar.html
+++ b/skills/diagram-design/assets/example-polar.html
@@ -28,30 +28,30 @@
 
     <svg viewBox="0 0 1000 520" xmlns="http://www.w3.org/2000/svg"
          role="img" aria-labelledby="polar-title polar-desc"
-         data-polar-chart data-polar-cx="500" data-polar-cy="230"
+         data-polar-chart="true" data-polar-cx="500" data-polar-cy="230"
          data-polar-radius="160" data-polar-min="0" data-polar-max="100"
          data-polar-start-angle="-90" data-polar-clockwise="true"
          data-polar-radius-encoding="linear" data-polar-inner-radius="0">
       <title id="polar-title">Request demand by UTC window</title>
       <desc id="polar-desc">Polar chart on a 0–100% scale identifying 12–15 UTC as the 100% peak, with the other seven UTC windows proceeding clockwise.</desc>
 
-      <rect data-polar-background width="100%" height="100%" fill="#f5f5f5"/>
+      <rect data-polar-background="true" width="100%" height="100%" fill="#f5f5f5"/>
       <text x="40" y="28" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.14em">% OF DAILY PEAK · 0–100</text>
 
-      <circle data-polar-ring cx="500" cy="230" r="32" fill="none" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
-      <circle data-polar-ring cx="500" cy="230" r="64" fill="none" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
-      <circle data-polar-ring cx="500" cy="230" r="96" fill="none" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
-      <circle data-polar-ring cx="500" cy="230" r="128" fill="none" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
-      <circle data-polar-ring cx="500" cy="230" r="160" fill="none" stroke="rgba(45,49,66,0.20)" stroke-width="0.8"/>
+      <circle data-polar-ring="true" cx="500" cy="230" r="32" fill="none" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
+      <circle data-polar-ring="true" cx="500" cy="230" r="64" fill="none" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
+      <circle data-polar-ring="true" cx="500" cy="230" r="96" fill="none" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
+      <circle data-polar-ring="true" cx="500" cy="230" r="128" fill="none" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
+      <circle data-polar-ring="true" cx="500" cy="230" r="160" fill="none" stroke="rgba(45,49,66,0.20)" stroke-width="0.8"/>
 
-      <line data-polar-spoke data-polar-index="0" x1="500" y1="230" x2="500" y2="70" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="1" x1="500" y1="230" x2="613.137" y2="116.863" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="2" x1="500" y1="230" x2="660" y2="230" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="3" x1="500" y1="230" x2="613.137" y2="343.137" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="4" x1="500" y1="230" x2="500" y2="390" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="5" x1="500" y1="230" x2="386.863" y2="343.137" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="6" x1="500" y1="230" x2="340" y2="230" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
-      <line data-polar-spoke data-polar-index="7" x1="500" y1="230" x2="386.863" y2="116.863" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="0" x1="500" y1="230" x2="500" y2="70" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="1" x1="500" y1="230" x2="613.137" y2="116.863" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="2" x1="500" y1="230" x2="660" y2="230" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="3" x1="500" y1="230" x2="613.137" y2="343.137" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="4" x1="500" y1="230" x2="500" y2="390" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="5" x1="500" y1="230" x2="386.863" y2="343.137" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="6" x1="500" y1="230" x2="340" y2="230" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
+      <line data-polar-spoke="true" data-polar-index="7" x1="500" y1="230" x2="386.863" y2="116.863" stroke="rgba(45,49,66,0.16)" stroke-width="0.8"/>
 
       <text x="492" y="201" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end">20</text>
       <text x="492" y="169" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end">40</text>
@@ -61,54 +61,54 @@
       <text x="508" y="233" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace">0</text>
 
       <g data-polar-category="00–03" data-polar-index="0" data-polar-value="32">
-        <line data-polar-ray x1="500" y1="230" x2="500" y2="178.8" stroke="#4f5d75" stroke-width="2"/>
-        <circle data-polar-marker cx="500" cy="178.8" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="500" y2="178.8" stroke="#4f5d75" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="500" cy="178.8" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
         <text x="500" y="42" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">00–03</text>
-        <text data-polar-value-label x="500" y="26" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">32</text>
+        <text data-polar-value-label="true" x="500" y="26" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">32</text>
       </g>
       <g data-polar-category="03–06" data-polar-index="1" data-polar-value="18">
-        <line data-polar-ray x1="500" y1="230" x2="520.365" y2="209.635" stroke="#4f5d75" stroke-width="2"/>
-        <circle data-polar-marker cx="520.365" cy="209.635" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="520.365" y2="209.635" stroke="#4f5d75" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="520.365" cy="209.635" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
         <text x="632.936" y="97.064" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="start">03–06</text>
-        <text data-polar-value-label x="644.25" y="85.75" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="start">18</text>
+        <text data-polar-value-label="true" x="644.25" y="85.75" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="start">18</text>
       </g>
       <g data-polar-category="06–09" data-polar-index="2" data-polar-value="24">
-        <line data-polar-ray x1="500" y1="230" x2="538.4" y2="230" stroke="#4f5d75" stroke-width="2"/>
-        <circle data-polar-marker cx="538.4" cy="230" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="538.4" y2="230" stroke="#4f5d75" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="538.4" cy="230" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
         <text x="688" y="230" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="start">06–09</text>
-        <text data-polar-value-label x="704" y="230" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="start" dy="16">24</text>
+        <text data-polar-value-label="true" x="704" y="230" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="start" dy="16">24</text>
       </g>
       <g data-polar-category="09–12" data-polar-index="3" data-polar-value="58">
-        <line data-polar-ray x1="500" y1="230" x2="565.62" y2="295.62" stroke="#4f5d75" stroke-width="2"/>
-        <circle data-polar-marker cx="565.62" cy="295.62" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="565.62" y2="295.62" stroke="#4f5d75" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="565.62" cy="295.62" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
         <text x="632.936" y="362.936" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="start">09–12</text>
-        <text data-polar-value-label x="644.25" y="374.25" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="start" dy="12">58</text>
+        <text data-polar-value-label="true" x="644.25" y="374.25" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="start" dy="12">58</text>
       </g>
       <g data-polar-category="12–15" data-polar-index="4" data-polar-value="100" data-polar-focal="true">
-        <line data-polar-ray x1="500" y1="230" x2="500" y2="390" stroke="#eb6c36" stroke-width="2.4"/>
-        <circle data-polar-marker cx="500" cy="390" r="5" fill="#f5f5f5" stroke="#eb6c36" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="500" y2="390" stroke="#eb6c36" stroke-width="2.4"/>
+        <circle data-polar-marker="true" cx="500" cy="390" r="5" fill="#f5f5f5" stroke="#eb6c36" stroke-width="1.2"/>
         <text x="500" y="418" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="middle">12–15</text>
-        <text data-polar-value-label x="500" y="434" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">100</text>
+        <text data-polar-value-label="true" x="500" y="434" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="middle">100</text>
       </g>
       <g data-polar-category="15–18" data-polar-index="5" data-polar-value="82">
-        <line data-polar-ray x1="500" y1="230" x2="407.227" y2="322.773" stroke="#4f5d75" stroke-width="2"/>
-        <circle data-polar-marker cx="407.227" cy="322.773" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="407.227" y2="322.773" stroke="#4f5d75" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="407.227" cy="322.773" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
         <text x="367.064" y="362.936" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="end">15–18</text>
-        <text data-polar-value-label x="355.75" y="374.25" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end" dy="12">82</text>
+        <text data-polar-value-label="true" x="355.75" y="374.25" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end" dy="12">82</text>
       </g>
       <g data-polar-category="18–21" data-polar-index="6" data-polar-value="76">
-        <line data-polar-ray x1="500" y1="230" x2="378.4" y2="230" stroke="#4f5d75" stroke-width="2"/>
-        <circle data-polar-marker cx="378.4" cy="230" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="378.4" y2="230" stroke="#4f5d75" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="378.4" cy="230" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
         <text x="312" y="230" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="end">18–21</text>
-        <text data-polar-value-label x="296" y="230" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end" dy="16">76</text>
+        <text data-polar-value-label="true" x="296" y="230" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end" dy="16">76</text>
       </g>
       <g data-polar-category="21–24" data-polar-index="7" data-polar-value="45">
-        <line data-polar-ray x1="500" y1="230" x2="449.088" y2="179.088" stroke="#4f5d75" stroke-width="2"/>
-        <circle data-polar-marker cx="449.088" cy="179.088" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
+        <line data-polar-ray="true" x1="500" y1="230" x2="449.088" y2="179.088" stroke="#4f5d75" stroke-width="2"/>
+        <circle data-polar-marker="true" cx="449.088" cy="179.088" r="4" fill="#f5f5f5" stroke="#4f5d75" stroke-width="1.2"/>
         <text x="367.064" y="97.064" fill="#2d3142" font-size="11" font-weight="600" font-family="'Geist', sans-serif" text-anchor="end">21–24</text>
-        <text data-polar-value-label x="355.75" y="85.75" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end">45</text>
+        <text data-polar-value-label="true" x="355.75" y="85.75" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" text-anchor="end">45</text>
       </g>
-      <line data-polar-rule x1="40" y1="468" x2="960" y2="468" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
+      <line data-polar-rule="true" x1="40" y1="468" x2="960" y2="468" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
       <text x="40" y="488" fill="#4f5d75" font-size="8" font-family="'Geist Mono', monospace" letter-spacing="0.08em">Illustrative normalized workload profile</text>
     </svg>
   </div>

--- a/skills/diagram-design/assets/example-policy-trace-animated.html
+++ b/skills/diagram-design/assets/example-policy-trace-animated.html
@@ -209,7 +209,7 @@
         <text x="936" y="72" text-anchor="middle" fill="#2d3142" font-family="'Geist', sans-serif" font-size="12" font-weight="600">Trace B · sensitive write</text>
         <text x="936" y="92" text-anchor="middle" fill="#4f5d75" font-family="'Geist Mono', monospace" font-size="12">restricted records request</text>
 
-        <g data-motion-item data-step="1" aria-label="Rule 1: Identity bound passes for both traces">
+        <g data-motion-item="true" data-step="1" aria-label="Rule 1: Identity bound passes for both traces">
           <rect class="row-focus" x="48" y="124" width="1080" height="68" rx="4"/>
           <text x="72" y="152" fill="#2d3142" font-family="'Geist', sans-serif" font-size="12" font-weight="600">1 · Identity bound</text>
           <text x="72" y="172" fill="#4f5d75" font-family="'Geist Mono', monospace" font-size="12">named principal required</text>
@@ -219,7 +219,7 @@
           <text x="936" y="164" text-anchor="middle" fill="#2d3142" font-family="'Geist Mono', monospace" font-size="10" font-weight="600">✓ PASS</text>
         </g>
 
-        <g data-motion-item data-step="2" aria-label="Rule 2: Internal audience passes for both traces">
+        <g data-motion-item="true" data-step="2" aria-label="Rule 2: Internal audience passes for both traces">
           <rect class="row-focus" x="48" y="200" width="1080" height="68" rx="4"/>
           <text x="72" y="228" fill="#2d3142" font-family="'Geist', sans-serif" font-size="12" font-weight="600">2 · Internal audience</text>
           <text x="72" y="248" fill="#4f5d75" font-family="'Geist Mono', monospace" font-size="12">employees only</text>
@@ -229,7 +229,7 @@
           <text x="936" y="240" text-anchor="middle" fill="#2d3142" font-family="'Geist Mono', monospace" font-size="10" font-weight="600">✓ PASS</text>
         </g>
 
-        <g data-motion-item data-step="3" aria-label="Rule 3 is the first divergence: Trace A passes and Trace B fails">
+        <g data-motion-item="true" data-step="3" aria-label="Rule 3 is the first divergence: Trace A passes and Trace B fails">
           <rect class="row-focus" x="48" y="276" width="1080" height="80" rx="4"/>
           <text x="72" y="304" fill="#2d3142" font-family="'Geist', sans-serif" font-size="12" font-weight="600">3 · Data class</text>
           <text x="72" y="324" fill="#4f5d75" font-family="'Geist Mono', monospace" font-size="12">restricted writes denied</text>
@@ -242,7 +242,7 @@
           <text x="778" y="351" text-anchor="middle" fill="#eb6c36" font-family="'Geist Mono', monospace" font-size="12" font-weight="600" letter-spacing=".8">FIRST DIVERGENCE</text>
         </g>
 
-        <g data-motion-item data-step="4" aria-label="Rule 4 is skipped for Trace A and not reached for Trace B">
+        <g data-motion-item="true" data-step="4" aria-label="Rule 4 is skipped for Trace A and not reached for Trace B">
           <rect class="row-focus" x="48" y="364" width="1080" height="68" rx="4"/>
           <text x="72" y="392" fill="#2d3142" font-family="'Geist', sans-serif" font-size="12" font-weight="600">4 · Human approval</text>
           <text x="72" y="412" fill="#4f5d75" font-family="'Geist Mono', monospace" font-size="12">required only for writes</text>
@@ -252,7 +252,7 @@
           <text x="936" y="404" text-anchor="middle" fill="#7a8399" font-family="'Geist Mono', monospace" font-size="10" font-weight="600">○ NOT REACHED</text>
         </g>
 
-        <g data-motion-item data-step="5" aria-label="Rule 5 passes for Trace A and is not reached for Trace B; outcomes are permitted and denied">
+        <g data-motion-item="true" data-step="5" aria-label="Rule 5 passes for Trace A and is not reached for Trace B; outcomes are permitted and denied">
           <rect class="row-focus" x="48" y="440" width="1080" height="152" rx="4"/>
           <text x="72" y="468" fill="#2d3142" font-family="'Geist', sans-serif" font-size="12" font-weight="600">5 · Deploy gate</text>
           <text x="72" y="488" fill="#4f5d75" font-family="'Geist Mono', monospace" font-size="12">all reached rules must pass</text>

--- a/skills/diagram-design/assets/example-queue-animated.html
+++ b/skills/diagram-design/assets/example-queue-animated.html
@@ -244,9 +244,9 @@
         <text x="360" y="182" fill="#2d3142" font-family="'Geist', sans-serif" font-size="14" font-weight="600">Central Ingress Queue Buffer</text>
         <text x="360" y="200" fill="#4f5d75" font-family="'Geist Mono', monospace" font-size="11">Capacity: 5 slots (Bounded FIFO)</text>
 
-        <!-- STEP 1: Ingress Traffic Arrives (Slots 1 & 2 + Initial 2/5 Queue Depth Badge) -->
-        <g data-motion-item data-step="1" aria-label="Step 1: Web App and Mobile API send steady ingress traffic (7 req/sec total) into queue slots 1 and 2">
-          <!-- Ingress Flow Arrows 1 & 2 -->
+        <!-- STEP 1: Ingress Traffic Arrives (Slots 1 &amp; 2 + Initial 2/5 Queue Depth Badge) -->
+        <g data-motion-item="true" data-step="1" aria-label="Step 1: Web App and Mobile API send steady ingress traffic (7 req/sec total) into queue slots 1 and 2">
+          <!-- Ingress Flow Arrows 1 &amp; 2 -->
           <path d="M 260 132 L 340 234" fill="none" stroke="#2d3142" stroke-width="2" marker-end="url(#arrow-ink)" />
           <path d="M 260 232 L 340 282" fill="none" stroke="#2d3142" stroke-width="2" marker-end="url(#arrow-ink)" />
 
@@ -267,8 +267,8 @@
         </g>
 
         <!-- STEP 2: Ingress Spike Fills Queue (Slots 3, 4, 5 + Updated 5/5 Full Warn Queue Depth Badge) -->
-        <g data-motion-item data-step="2" aria-label="Step 2: Payment and ERP traffic spike (20 req/sec total) fills queue to 5/5 slots capacity">
-          <!-- Ingress Flow Arrows 3 & 4 -->
+        <g data-motion-item="true" data-step="2" aria-label="Step 2: Payment and ERP traffic spike (20 req/sec total) fills queue to 5/5 slots capacity">
+          <!-- Ingress Flow Arrows 3 &amp; 4 -->
           <path d="M 260 332 L 340 322" fill="none" stroke="#eb6c36" stroke-width="2" marker-end="url(#arrow-accent)" />
           <path d="M 260 432 L 340 370" fill="none" stroke="#eb6c36" stroke-width="2" marker-end="url(#arrow-accent)" />
 
@@ -292,7 +292,7 @@
         </g>
 
         <!-- STEP 3: Rate Limiter Diverts Excess Traffic (429 Dropped Sink) -->
-        <g data-motion-item data-step="3" aria-label="Step 3: Overflow backpressure activates, shedding excess 19 req/sec to 429 Rate Limiter sink">
+        <g data-motion-item="true" data-step="3" aria-label="Step 3: Overflow backpressure activates, shedding excess 19 req/sec to 429 Rate Limiter sink">
           <!-- Overflow Diverter Connector -->
           <path d="M 525 150 L 525 92 L 760 92" fill="none" stroke="#eb6c36" stroke-width="2" stroke-dasharray="4 4" marker-end="url(#arrow-accent)" />
           
@@ -302,8 +302,8 @@
           <text x="780" y="104" fill="#4f5d75" font-family="'Geist Mono', monospace" font-size="11">Status: 429 Backpressure (19 req/sec Shed)</text>
         </g>
 
-        <!-- STEP 4: Worker Service Processing & Downstream Output -->
-        <g data-motion-item data-step="4" aria-label="Step 4: Constrained worker node processes queue at 8 req/sec max emitting 200 OK downstream responses">
+        <!-- STEP 4: Worker Service Processing &amp; Downstream Output -->
+        <g data-motion-item="true" data-step="4" aria-label="Step 4: Constrained worker node processes queue at 8 req/sec max emitting 200 OK downstream responses">
           <!-- Worker Processing Connector -->
           <path d="M 710 310 L 760 280" fill="none" stroke="#2d3142" stroke-width="2" marker-end="url(#arrow-ink)" />
 
@@ -323,15 +323,15 @@
           <text x="780" y="464" fill="#4f5d75" font-family="'Geist Mono', monospace" font-size="11">Result: 200 OK Admitted Traffic Stream (8 req/sec)</text>
         </g>
 
-        <!-- STEP 5: Equilibrium State & Performance Metrics Summary -->
-        <g data-motion-item data-step="5" aria-label="Step 5: System reaches controlled equilibrium protecting worker from overload while shedding excess traffic">
+        <!-- STEP 5: Equilibrium State &amp; Performance Metrics Summary -->
+        <g data-motion-item="true" data-step="5" aria-label="Step 5: System reaches controlled equilibrium protecting worker from overload while shedding excess traffic">
           <rect x="340" y="490" width="370" height="64" rx="6" fill="#ffffff" stroke="#2d3142" stroke-width="1.5" />
           <text x="360" y="516" fill="#2d3142" font-family="'Geist', sans-serif" font-size="13" font-weight="600">System State: Controlled Equilibrium</text>
           <text x="360" y="536" fill="#4f5d75" font-family="'Geist Mono', monospace" font-size="11">Worker Protected · Backpressure Active</text>
         </g>
 
         <!-- Precision SVG Legend Footer (Exact visual mini-arrows and mini-rects) -->
-        <g data-motion-decorative aria-hidden="true">
+        <g data-motion-decorative="true" aria-hidden="true">
           <!-- Flow Line 1: Admitted Flow -->
           <line x1="40" y1="584" x2="65" y2="584" stroke="#2d3142" stroke-width="2" marker-end="url(#arrow-ink)" />
           <text x="73" y="588" fill="#2d3142" font-family="'Geist Mono', monospace" font-size="9.5">Admitted Flow</text>

--- a/skills/diagram-design/assets/example-slopegraph-dark.html
+++ b/skills/diagram-design/assets/example-slopegraph-dark.html
@@ -85,13 +85,13 @@
       <text data-series="Auth" data-end="to" x="696" y="405.8" fill="#bfc0c0" font-size="9" font-family="'Geist Mono', monospace">121</text>
       <text data-series="Auth" data-end="to" data-role="name" x="728" y="405.8" fill="#f5f5f5" font-size="11" font-weight="500" font-family="'Geist', sans-serif">Auth</text>
 
-      <!-- Recommender FOCAL -- and it is the series that got WORSE. The accent marks
+      <!-- Recommender FOCAL — and it is the series that got WORSE. The accent marks
            the editorially focal line, never the winner. Focus is carried by STROKE
            WEIGHT, not tone: the accent measures 2.86:1 on light paper, so on tone
            alone the focal line would read fainter than the ink ramp it is meant to
-           dominate. Its labels stay ink/muted for the same reason -- accent text
+           dominate. Its labels stay ink/muted for the same reason — accent text
            misses AA at this size. Being the only ascending line it crosses three of
-           the other four -- not Auth, which starts and ends below it, because moving
+           the other four — not Auth, which starts and ends below it, because moving
            the opposite way does not guarantee meeting. The crossings are left
            unannotated: two endpoints say nothing about WHEN the regression started. -->
       <line data-series="Recommender" data-from="238" data-to="431" x1="320" y1="303.5" x2="680" y2="140.5" stroke="#f08a59" stroke-width="2.4"/>

--- a/skills/diagram-design/assets/example-slopegraph-full.html
+++ b/skills/diagram-design/assets/example-slopegraph-full.html
@@ -95,13 +95,13 @@
         <text data-series="Auth" data-end="to" x="696" y="405.8" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace">121</text>
         <text data-series="Auth" data-end="to" data-role="name" x="728" y="405.8" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif">Auth</text>
 
-        <!-- Recommender FOCAL -- and it is the series that got WORSE. The accent marks
+        <!-- Recommender FOCAL — and it is the series that got WORSE. The accent marks
              the editorially focal line, never the winner. Focus is carried by STROKE
              WEIGHT, not tone: the accent measures 2.86:1 on light paper, so on tone
              alone the focal line would read fainter than the ink ramp it is meant to
-             dominate. Its labels stay ink/muted for the same reason -- accent text
+             dominate. Its labels stay ink/muted for the same reason — accent text
              misses AA at this size. Being the only ascending line it crosses three of
-             the other four -- not Auth, which starts and ends below it, because moving
+             the other four — not Auth, which starts and ends below it, because moving
              the opposite way does not guarantee meeting. The crossings are left
              unannotated: two endpoints say nothing about WHEN the regression started. -->
         <line data-series="Recommender" data-from="238" data-to="431" x1="320" y1="303.5" x2="680" y2="140.5" stroke="#eb6c36" stroke-width="2.4"/>

--- a/skills/diagram-design/assets/example-slopegraph.html
+++ b/skills/diagram-design/assets/example-slopegraph.html
@@ -85,13 +85,13 @@
       <text data-series="Auth" data-end="to" x="696" y="405.8" fill="#4f5d75" font-size="9" font-family="'Geist Mono', monospace">121</text>
       <text data-series="Auth" data-end="to" data-role="name" x="728" y="405.8" fill="#2d3142" font-size="11" font-weight="500" font-family="'Geist', sans-serif">Auth</text>
 
-      <!-- Recommender FOCAL -- and it is the series that got WORSE. The accent marks
+      <!-- Recommender FOCAL — and it is the series that got WORSE. The accent marks
            the editorially focal line, never the winner. Focus is carried by STROKE
            WEIGHT, not tone: the accent measures 2.86:1 on light paper, so on tone
            alone the focal line would read fainter than the ink ramp it is meant to
-           dominate. Its labels stay ink/muted for the same reason -- accent text
+           dominate. Its labels stay ink/muted for the same reason — accent text
            misses AA at this size. Being the only ascending line it crosses three of
-           the other four -- not Auth, which starts and ends below it, because moving
+           the other four — not Auth, which starts and ends below it, because moving
            the opposite way does not guarantee meeting. The crossings are left
            unannotated: two endpoints say nothing about WHEN the regression started. -->
       <line data-series="Recommender" data-from="238" data-to="431" x1="320" y1="303.5" x2="680" y2="140.5" stroke="#eb6c36" stroke-width="2.4"/>

--- a/skills/diagram-design/references/export.md
+++ b/skills/diagram-design/references/export.md
@@ -26,8 +26,18 @@ If the user explicitly asks for "a screenshot of the whole page including the ca
 
 ## SVG export procedure
 
+Run the shared extraction implementation:
+
+```
+python3 skills/diagram-design/scripts/figma_capture.py extract <src> [--stdout | --out PATH]
+```
+
+Without an output option, it validates the source and writes `<basename>.svg` next to it. Use `--out PATH` for an explicit destination or `--stdout` to emit the standalone SVG without writing a file.
+
+When running scripts isn't possible, use this manual fallback:
+
 1. Read the source HTML file.
-2. Extract the **first** `<svg ...>...</svg>` block. Use a multiline regex anchored on `<svg` and `</svg>`. Most generated diagrams have only one SVG; if there are multiple, the first is the diagram (gallery files are an exception — see *Edge cases*).
+2. Isolate the **first** complete `<svg ...>...</svg>` block with balanced, nested-aware tag parsing. Don't stop at the first `</svg>` — that truncates diagrams with nested SVGs, such as `example-datalake.html`. Most generated diagrams have only one SVG; if there are multiple, the first is the diagram (gallery files are an exception — see *Edge cases*).
 3. Make it standalone:
    - Ensure the opening tag has `xmlns="http://www.w3.org/2000/svg"`. Add it if missing.
    - Ensure a `viewBox` is present. The skill's templates always include one; warn the user if absent rather than guessing.
@@ -38,6 +48,7 @@ If the user explicitly asks for "a screenshot of the whole page including the ca
        <style>@import url('https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&amp;family=Geist:wght@400;500;600&amp;family=Geist+Mono:wght@400;500;600&amp;display=swap');</style>
      </defs>
      ```
+     Escaping the ampersands as `&amp;` is required for the standalone file to be well-formed XML.
      If the SVG already contains a `<defs>` block, **merge** the `<style>` into it (don't add a second `<defs>`).
 4. Prepend `<?xml version="1.0" encoding="UTF-8"?>\n` so the file is well-formed XML.
 5. Write to `<basename>.svg` next to the source (e.g. `example-architecture.html` → `example-architecture.svg`). Honour an explicit output path if the user provides one.
@@ -125,6 +136,7 @@ If the target aspect ratio doesn't match the `viewBox` aspect ratio, say so and 
 
 - **Source is `assets/index.html`** (the gallery, multiple SVGs in one file): refuse the export and ask the user which specific diagram file they meant. Don't guess.
 - **No `<svg>` block found**: the source isn't a diagram file. Tell the user; don't write anything.
+- **Diagram contains `<foreignObject>`** (including the medallion examples): SVG export succeeds, but warn that import targets may render it with reduced fidelity.
 - **Surrounding HTML matters to the user**: they want cards/header in the image. Tell them this skill exports diagrams only, and recommend a browser-based full-page screenshot (or a separate PDF print).
 - **Source is missing fonts at runtime**: Playwright will substitute, the screenshot will look off. Check that the source HTML has the `<link href="...fonts.googleapis.com...">` tag in `<head>`. If absent, the file isn't from a current template — fix the source rather than working around it in export.
 

--- a/skills/diagram-design/references/export.md
+++ b/skills/diagram-design/references/export.md
@@ -32,7 +32,7 @@ Run the shared extraction implementation:
 python3 skills/diagram-design/scripts/figma_capture.py extract <src> [--stdout | --out PATH]
 ```
 
-Without an output option, it validates the source and writes `<basename>.svg` next to it. Use `--out PATH` for an explicit destination or `--stdout` to emit the standalone SVG without writing a file.
+Without an output option, it validates the source and writes `<basename>.svg` next to it. Use `--out PATH` for an explicit destination or `--stdout` to emit the standalone SVG without writing a file. The extractor also normalizes `rgba()` and `transparent` presentation attributes for PowerPoint and other strict SVG 1.1 importers before it XML-verifies the result.
 
 When running scripts isn't possible, use this manual fallback:
 
@@ -50,8 +50,14 @@ When running scripts isn't possible, use this manual fallback:
      ```
      Escaping the ampersands as `&amp;` is required for the standalone file to be well-formed XML.
      If the SVG already contains a `<defs>` block, **merge** the `<style>` into it (don't add a second `<defs>`).
-4. Prepend `<?xml version="1.0" encoding="UTF-8"?>\n` so the file is well-formed XML.
-5. Write to `<basename>.svg` next to the source (e.g. `example-architecture.html` → `example-architecture.svg`). Honour an explicit output path if the user provides one.
+4. Normalize only `fill` and `stroke` presentation attributes for strict SVG 1.1 consumers:
+   - Convert `transparent` to `none`, case-insensitively.
+   - Convert `rgba(r,g,b,a)` to lowercase `#rrggbb` plus the matching `fill-opacity` or `stroke-opacity`. Accept optional whitespace and alpha forms such as `.03`.
+   - If the matching opacity attribute already exists, multiply it by the alpha value. Reject duplicate attributes and any nonnumeric, non-finite, or out-of-range channel/opacity instead of guessing.
+   - Do not rewrite CSS. If `rgba()` or `transparent` remains in a `style="..."` attribute or `<style>` block, fail and move that color to a `fill`/`stroke` presentation attribute first.
+   - The transform must be idempotent: normalizing an already-normalized SVG produces the same attributes.
+5. Prepend `<?xml version="1.0" encoding="UTF-8"?>\n`, then parse the complete result as XML before writing anything. A parse failure is an export failure, not a warning.
+6. Write to `<basename>.svg` next to the source (e.g. `example-architecture.html` → `example-architecture.svg`). Honour an explicit output path if the user provides one.
 
 ### Caveat to surface to the user
 

--- a/skills/diagram-design/scripts/figma_capture.py
+++ b/skills/diagram-design/scripts/figma_capture.py
@@ -1,0 +1,693 @@
+#!/usr/bin/env python3
+"""Validate diagram HTML and extract its SVG for Figma-oriented workflows.
+
+This branch-independent core isolates SVG markup with balanced-tag parsing,
+checks that it is safe and self-contained, and can write a standalone SVG
+without modifying the source HTML.  Future capture commands can be added as
+additional subcommands.
+
+Usage:
+    python3 figma_capture.py extract <src> [--stdout | --out PATH]
+    python3 figma_capture.py check <src>
+
+Exit codes: 0 ok, 2 unreadable / invalid input.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import math
+import re
+import sys
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import NoReturn
+from urllib.parse import urlsplit
+from xml.etree import ElementTree as ET
+
+# --------------------------------------------------------------------------
+# constants + errors
+# --------------------------------------------------------------------------
+
+MAX_INPUT_BYTES = 32 * 1024 * 1024
+SVG_NAMESPACE = "http://www.w3.org/2000/svg"
+FONT_IMPORT = (
+    "@import url('https://fonts.googleapis.com/css2?"
+    "family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&"
+    "family=Geist+Mono:wght@400;500;600&display=swap');"
+)
+FONT_IMPORT_XML = html.escape(FONT_IMPORT, quote=False)
+FONT_STYLE = f"<style>{FONT_IMPORT_XML}</style>"
+FONT_DEFS = f"<defs>{FONT_STYLE}</defs>"
+ALLOWED_EXTERNAL_HOSTS = frozenset(
+    {"fonts.googleapis.com", "fonts.gstatic.com"}
+)
+
+CSS_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+CSS_URL_RE = re.compile(
+    r"url\(\s*(?:\"(?P<double>[^\"]*)\"|'(?P<single>[^']*)'|"
+    r"(?P<bare>[^)]*?))\s*\)",
+    re.IGNORECASE | re.DOTALL,
+)
+CSS_IMPORT_RE = re.compile(
+    r"@import\s+(?P<target>"
+    r"url\(\s*(?:\"[^\"]*\"|'[^']*'|[^)]*?)\s*\)"
+    r"|\"[^\"]*\"|'[^']*'|[^\s;]+)",
+    re.IGNORECASE | re.DOTALL,
+)
+CSS_ESCAPE_RE = re.compile(r"\\(?:([0-9a-fA-F]{1,6})[ \t\r\n\f]?|([^\r\n\f]))")
+XMLNS_RE = re.compile(
+    r"(?P<prefix>\sxmlns\s*=\s*)"
+    r"(?P<value>\"[^\"]*\"|'[^']*'|[^\s>]+)"
+)
+
+
+def _fail(msg: str) -> NoReturn:
+    print(f"figma_capture: {msg}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def _warn(msg: str) -> None:
+    print(f"figma_capture: warning: {msg}", file=sys.stderr)
+
+
+@dataclass(frozen=True)
+class ViewBox:
+    raw: str
+    min_x: float
+    min_y: float
+    width: float
+    height: float
+
+
+@dataclass(frozen=True)
+class CheckedDiagram:
+    source: Path
+    source_sha256: str
+    svg: str
+    viewbox: ViewBox
+
+
+# --------------------------------------------------------------------------
+# balanced SVG isolation
+# --------------------------------------------------------------------------
+
+
+class SvgIsolationParser(HTMLParser):
+    """Locate top-level SVG spans while retaining source-text offsets."""
+
+    def __init__(self, source: str) -> None:
+        super().__init__(convert_charrefs=True)
+        self.source = source
+        self.line_starts = [0]
+        self.line_starts.extend(match.end() for match in re.finditer("\n", source))
+        self.svg_depth = 0
+        self.current_start: int | None = None
+        self.spans: list[tuple[int, int]] = []
+
+    def _offset(self) -> int:
+        line, column = self.getpos()
+        return self.line_starts[line - 1] + column
+
+    def _token_end(self, start: int) -> int:
+        end = self.source.find(">", start)
+        if end < 0:
+            raise ValueError("unterminated SVG tag")
+        return end + 1
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        del attrs
+        if tag.lower() != "svg":
+            return
+        if self.svg_depth == 0:
+            self.current_start = self._offset()
+        self.svg_depth += 1
+
+    def handle_startendtag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        del attrs
+        if tag.lower() == "svg" and self.svg_depth == 0:
+            start = self._offset()
+            self.spans.append((start, self._token_end(start)))
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() != "svg" or self.svg_depth == 0:
+            return
+        self.svg_depth -= 1
+        if self.svg_depth == 0:
+            if self.current_start is None:
+                raise ValueError("SVG nesting is inconsistent")
+            self.spans.append(
+                (self.current_start, self._token_end(self._offset()))
+            )
+            self.current_start = None
+
+
+def _is_gallery_path(path: Path) -> bool:
+    return path.name.lower() == "index.html" and path.parent.name.lower() == "assets"
+
+
+def _read_source(path: Path) -> tuple[bytes, str]:
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        _fail(f"{path}: cannot read source: {exc.strerror or exc}")
+    if not path.is_file():
+        _fail(f"{path}: not a regular file")
+    if size > MAX_INPUT_BYTES:
+        _fail(
+            f"{path.name}: input is {size} bytes; maximum is "
+            f"{MAX_INPUT_BYTES // (1024 * 1024)} MiB"
+        )
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        _fail(f"{path}: cannot read source: {exc.strerror or exc}")
+    try:
+        return data, data.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        _fail(f"{path}: source is not valid UTF-8: {exc}")
+
+
+def _isolate_svg(path: Path, source: str) -> str:
+    if _is_gallery_path(path):
+        _fail(f"{path}: gallery source is not a single diagram")
+
+    parser = SvgIsolationParser(source)
+    try:
+        parser.feed(source)
+        parser.close()
+    except (ValueError, AssertionError) as exc:
+        _fail(f"{path}: cannot parse HTML: {exc}")
+
+    if parser.svg_depth:
+        _fail(f"{path}: unterminated <svg> element")
+    if not parser.spans:
+        _fail(f"{path}: no <svg> element found")
+    if len(parser.spans) > 1:
+        _fail(
+            f"{path}: gallery source contains {len(parser.spans)} "
+            "top-level <svg> elements"
+        )
+    start, end = parser.spans[0]
+    return source[start:end]
+
+
+# --------------------------------------------------------------------------
+# SVG validation
+# --------------------------------------------------------------------------
+
+
+def _css_unescape(value: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        if match.group(1) is not None:
+            codepoint = int(match.group(1), 16)
+            if codepoint == 0 or codepoint > 0x10FFFF:
+                return "\ufffd"
+            return chr(codepoint)
+        return match.group(2) or ""
+
+    return CSS_ESCAPE_RE.sub(replace, value)
+
+
+def _compact_for_scheme(value: str) -> str:
+    decoded = html.unescape(_css_unescape(value)).strip()
+    return re.sub(r"[\x00-\x20\x7f]+", "", decoded)
+
+
+def _reference_error(
+    value: str, *, context: str, allow_data_image: bool
+) -> str | None:
+    reference = html.unescape(_css_unescape(value)).strip()
+    compact = _compact_for_scheme(reference)
+    lowered = compact.lower()
+
+    if lowered.startswith("javascript:"):
+        return f"active javascript: URL in {context}"
+    if reference.startswith("#"):
+        return None
+    if lowered.startswith("data:"):
+        if allow_data_image and lowered.startswith("data:image/"):
+            return None
+        return f"non-image data: URI in {context} is not allowed"
+
+    parsed = urlsplit(f"https:{reference}" if reference.startswith("//") else reference)
+    if parsed.scheme.lower() in {"http", "https"} and parsed.hostname:
+        host = parsed.hostname.lower().rstrip(".")
+        if host in ALLOWED_EXTERNAL_HOSTS:
+            return None
+        return f"external {context} host {host!r} is not allowed"
+    if parsed.scheme:
+        return f"external {context} scheme {parsed.scheme!r} is not allowed"
+    return f"external {context} reference {reference!r} is not allowed"
+
+
+def _css_url_value(match: re.Match[str]) -> str:
+    for name in ("double", "single", "bare"):
+        value = match.group(name)
+        if value is not None:
+            return value.strip()
+    return ""
+
+
+def _import_value(target: str) -> str:
+    target = target.strip()
+    if target.lower().startswith("url"):
+        match = CSS_URL_RE.fullmatch(target)
+        return _css_url_value(match) if match else target
+    if len(target) >= 2 and target[0] == target[-1] and target[0] in "\"'":
+        return target[1:-1]
+    return target
+
+
+def _audit_css(css: str, context: str) -> str | None:
+    css = _css_unescape(html.unescape(CSS_COMMENT_RE.sub("", css)))
+    compact = _compact_for_scheme(css).lower()
+    if "javascript:" in compact:
+        return f"active javascript: URL in {context}"
+
+    for match in CSS_IMPORT_RE.finditer(css):
+        error = _reference_error(
+            _import_value(match.group("target")),
+            context="@import",
+            allow_data_image=False,
+        )
+        if error:
+            return error
+    for match in CSS_URL_RE.finditer(css):
+        error = _reference_error(
+            _css_url_value(match), context="url()", allow_data_image=True
+        )
+        if error:
+            return error
+    return None
+
+
+class SvgAuditParser(HTMLParser):
+    """Collect the outer attributes and the first unsafe SVG construct."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.outer_attrs: list[tuple[str, str | None]] | None = None
+        self.error: str | None = None
+        self.has_foreign_object = False
+        self.style_depth = 0
+        self.style_parts: list[str] = []
+
+    def _record(self, message: str) -> None:
+        if self.error is None:
+            self.error = message
+
+    def _audit_tag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        lowered_tag = tag.lower()
+        if self.outer_attrs is None:
+            if lowered_tag != "svg":
+                self._record("extracted markup does not begin with <svg>")
+                return
+            self.outer_attrs = attrs
+
+        if lowered_tag == "script":
+            self._record("active <script> element is not allowed")
+        elif lowered_tag == "foreignobject":
+            self.has_foreign_object = True
+
+        for name, value in attrs:
+            lowered_name = name.lower()
+            if lowered_name.startswith("on"):
+                self._record(f"event-handler attribute {name!r} is not allowed")
+            if value is None:
+                continue
+            decoded_value = _css_unescape(html.unescape(value))
+            if _compact_for_scheme(value).lower().startswith("javascript:"):
+                self._record(f"active javascript: URL in attribute {name!r}")
+            if lowered_name in {"href", "xlink:href"}:
+                error = _reference_error(
+                    value,
+                    context=lowered_name,
+                    allow_data_image=lowered_tag in {"image", "feimage"},
+                )
+                if error:
+                    self._record(error)
+            attribute_css = CSS_COMMENT_RE.sub("", decoded_value)
+            for match in CSS_URL_RE.finditer(attribute_css):
+                error = _reference_error(
+                    _css_url_value(match), context="url()", allow_data_image=True
+                )
+                if error:
+                    self._record(error)
+            if lowered_name == "style":
+                error = _audit_css(value, "style attribute")
+                if error:
+                    self._record(error)
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        self._audit_tag(tag, attrs)
+        if tag.lower() == "style":
+            self.style_depth += 1
+
+    def handle_startendtag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        self._audit_tag(tag, attrs)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() == "style" and self.style_depth:
+            self.style_depth -= 1
+            if self.style_depth == 0:
+                error = _audit_css("".join(self.style_parts), "<style>")
+                if error:
+                    self._record(error)
+                self.style_parts.clear()
+
+    def handle_data(self, data: str) -> None:
+        if self.style_depth:
+            self.style_parts.append(data)
+
+    def finish(self) -> None:
+        if self.style_parts:
+            error = _audit_css("".join(self.style_parts), "<style>")
+            if error:
+                self._record(error)
+            self.style_parts.clear()
+
+
+def _parse_viewbox(attrs: list[tuple[str, str | None]]) -> ViewBox:
+    values = [value for name, value in attrs if name.lower() == "viewbox"]
+    if not values or values[0] is None:
+        _fail("diagram <svg> is missing a viewBox")
+    if len(values) > 1:
+        _fail("diagram <svg> has duplicate viewBox attributes")
+
+    raw = values[0]
+    assert raw is not None
+    parts = re.split(r"\s*,\s*|\s+", raw.strip())
+    if len(parts) != 4:
+        _fail(f"diagram <svg> has malformed viewBox {raw!r}; expected 4 numbers")
+    try:
+        numbers = tuple(float(part) for part in parts)
+    except ValueError:
+        _fail(f"diagram <svg> has malformed viewBox {raw!r}; expected 4 numbers")
+    if not all(math.isfinite(number) for number in numbers):
+        _fail(f"diagram <svg> has non-finite viewBox {raw!r}")
+    min_x, min_y, width, height = numbers
+    if width <= 0 or height <= 0:
+        _fail(
+            f"diagram <svg> viewBox must have positive width and height; got {raw!r}"
+        )
+    return ViewBox(raw, min_x, min_y, width, height)
+
+
+def _check_source(path: Path) -> CheckedDiagram:
+    data, source = _read_source(path)
+    svg = _isolate_svg(path, source)
+    parser = SvgAuditParser()
+    try:
+        parser.feed(svg)
+        parser.close()
+        parser.finish()
+    except (ValueError, AssertionError) as exc:
+        _fail(f"{path}: cannot parse extracted SVG: {exc}")
+    if parser.error:
+        _fail(f"{path}: {parser.error}")
+    if parser.outer_attrs is None:
+        _fail(f"{path}: no usable <svg> element found")
+    viewbox = _parse_viewbox(parser.outer_attrs)
+    if parser.has_foreign_object:
+        _warn(
+            f"{path}: <foreignObject> present — "
+            "Figma/import fidelity is not guaranteed"
+        )
+    return CheckedDiagram(path, hashlib.sha256(data).hexdigest(), svg, viewbox)
+
+
+# --------------------------------------------------------------------------
+# standalone SVG construction
+# --------------------------------------------------------------------------
+
+
+class SvgLayoutParser(HTMLParser):
+    """Find insertion points without re-serializing any source markup."""
+
+    def __init__(self, svg: str) -> None:
+        super().__init__(convert_charrefs=True)
+        self.svg = svg
+        self.line_starts = [0]
+        self.line_starts.extend(match.end() for match in re.finditer("\n", svg))
+        self.stack: list[str] = []
+        self.root_seen = False
+        self.root_self_closing = False
+        self.opening_end: int | None = None
+        self.first_defs: tuple[int, int, bool] | None = None
+        self.preamble_open = True
+        self.preamble_end: int | None = None
+
+    def _offset(self) -> int:
+        line, column = self.getpos()
+        return self.line_starts[line - 1] + column
+
+    def _raw_end(self) -> int:
+        raw = self.get_starttag_text()
+        if raw is None:
+            raise ValueError("cannot locate start tag")
+        return self._offset() + len(raw)
+
+    def _endtag_end(self) -> int:
+        end = self.svg.find(">", self._offset())
+        if end < 0:
+            raise ValueError("unterminated end tag")
+        return end + 1
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        del attrs
+        lowered = tag.lower()
+        start = self._offset()
+        end = self._raw_end()
+        if not self.root_seen:
+            self.root_seen = True
+            self.opening_end = end
+            self.stack.append(lowered)
+            return
+
+        direct_child = len(self.stack) == 1
+        if lowered == "defs" and self.first_defs is None:
+            self.first_defs = (start, end, False)
+        if direct_child and self.preamble_open and lowered not in {"title", "desc"}:
+            self.preamble_open = False
+        self.stack.append(lowered)
+
+    def handle_startendtag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        del attrs
+        lowered = tag.lower()
+        start = self._offset()
+        end = self._raw_end()
+        if not self.root_seen:
+            self.root_seen = True
+            self.root_self_closing = True
+            self.opening_end = end
+            return
+
+        direct_child = len(self.stack) == 1
+        if lowered == "defs" and self.first_defs is None:
+            self.first_defs = (start, end, True)
+        if direct_child and self.preamble_open:
+            if lowered in {"title", "desc"}:
+                self.preamble_end = end
+            else:
+                self.preamble_open = False
+
+    def handle_endtag(self, tag: str) -> None:
+        lowered = tag.lower()
+        if lowered in self.stack:
+            matching_index = len(self.stack) - 1 - self.stack[::-1].index(lowered)
+            direct_child = matching_index == 1
+            self.stack = self.stack[:matching_index]
+            if (
+                direct_child
+                and self.preamble_open
+                and lowered in {"title", "desc"}
+            ):
+                self.preamble_end = self._endtag_end()
+
+    def handle_data(self, data: str) -> None:
+        if self.root_seen and len(self.stack) == 1 and data.strip():
+            self.preamble_open = False
+
+
+def _ensure_xmlns(opening: str) -> str:
+    match = XMLNS_RE.search(opening)
+    if match:
+        value = match.group("value")
+        unquoted = value[1:-1] if value[:1] in {"\"", "'"} else value
+        if unquoted == SVG_NAMESPACE:
+            return opening
+        return opening[: match.start("value")] + f'"{SVG_NAMESPACE}"' + opening[match.end("value") :]
+
+    insert_at = len(opening) - 1
+    cursor = insert_at - 1
+    while cursor >= 0 and opening[cursor].isspace():
+        cursor -= 1
+    if cursor >= 0 and opening[cursor] == "/":
+        insert_at = cursor
+    return opening[:insert_at] + f' xmlns="{SVG_NAMESPACE}"' + opening[insert_at:]
+
+
+def _expand_self_closing(opening: str) -> str:
+    close = re.search(r"/\s*>$", opening)
+    if close is None:
+        return opening
+    return opening[: close.start()] + opening[close.start() + 1 :]
+
+
+def _standalone_svg(svg: str) -> str:
+    layout = SvgLayoutParser(svg)
+    try:
+        layout.feed(svg)
+        layout.close()
+    except (ValueError, AssertionError) as exc:
+        _fail(f"cannot prepare standalone SVG: {exc}")
+    if layout.opening_end is None:
+        _fail("cannot locate the diagram <svg> opening tag")
+
+    opening = _ensure_xmlns(svg[: layout.opening_end])
+    if layout.root_self_closing:
+        body = _expand_self_closing(opening) + FONT_DEFS + "</svg>"
+        return '<?xml version="1.0" encoding="UTF-8"?>\n' + body
+
+    body = opening + svg[layout.opening_end :]
+    opening_delta = len(opening) - layout.opening_end
+    if layout.first_defs is not None:
+        defs_start, defs_end, self_closing = layout.first_defs
+        defs_start += opening_delta
+        defs_end += opening_delta
+        if self_closing:
+            defs_open = _expand_self_closing(body[defs_start:defs_end])
+            body = (
+                body[:defs_start]
+                + defs_open
+                + FONT_STYLE
+                + "</defs>"
+                + body[defs_end:]
+            )
+        else:
+            body = body[:defs_end] + FONT_STYLE + body[defs_end:]
+    else:
+        insert_at = (
+            layout.preamble_end
+            if layout.preamble_end is not None
+            else layout.opening_end
+        )
+        insert_at += opening_delta
+        body = body[:insert_at] + FONT_DEFS + body[insert_at:]
+    return '<?xml version="1.0" encoding="UTF-8"?>\n' + body
+
+
+def _verify_xml_clean(svg: str, source: Path) -> None:
+    try:
+        ET.fromstring(svg)
+    except ET.ParseError as exc:
+        _fail(f"{source}: source SVG is not XML-clean: {exc}")
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def _format_number(number: float) -> str:
+    return f"{number:.15g}"
+
+
+def _run_check(args: argparse.Namespace) -> int:
+    diagram = _check_source(Path(args.src))
+    dimensions = (
+        f"{_format_number(diagram.viewbox.width)}x"
+        f"{_format_number(diagram.viewbox.height)}"
+    )
+    print(
+        f'ok source={diagram.source} viewBox="{diagram.viewbox.raw}" '
+        f"dimensions={dimensions} sha256={diagram.source_sha256}"
+    )
+    return 0
+
+
+def _write_stdout_bytes(data: bytes) -> None:
+    buffer = getattr(sys.stdout, "buffer", None)
+    if buffer is not None:
+        buffer.write(data)
+        buffer.flush()
+    else:  # Useful for callers that replace stdout with io.StringIO.
+        sys.stdout.write(data.decode("utf-8"))
+
+
+def _run_extract(args: argparse.Namespace) -> int:
+    diagram = _check_source(Path(args.src))
+    standalone = _standalone_svg(diagram.svg)
+    _verify_xml_clean(standalone, diagram.source)
+    output = standalone.encode("utf-8")
+    if args.stdout:
+        _write_stdout_bytes(output)
+        return 0
+
+    out_path = Path(args.out) if args.out else diagram.source.with_suffix(".svg")
+    same_file = out_path.resolve() == diagram.source.resolve()
+    try:
+        same_file = same_file or (out_path.exists() and out_path.samefile(diagram.source))
+    except OSError:
+        pass
+    if same_file:
+        _fail(f"output path {out_path} would overwrite the source HTML")
+    try:
+        out_path.write_bytes(output)
+    except OSError as exc:
+        _fail(f"{out_path}: cannot write output: {exc.strerror or exc}")
+    print(f"source: {diagram.source}")
+    print(f"output: {out_path}")
+    print(f"viewBox: {diagram.viewbox.raw}")
+    print(f"source_sha256: {diagram.source_sha256}")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    extract_parser = subparsers.add_parser(
+        "extract", help="validate diagram HTML and emit a standalone SVG"
+    )
+    extract_parser.add_argument("src", help="source diagram HTML file")
+    output_group = extract_parser.add_mutually_exclusive_group()
+    output_group.add_argument(
+        "--stdout", action="store_true", help="write only the SVG to stdout"
+    )
+    output_group.add_argument(
+        "--out", metavar="PATH", help="write SVG to PATH instead of next to source"
+    )
+    extract_parser.set_defaults(handler=_run_extract)
+
+    check_parser = subparsers.add_parser(
+        "check", help="validate diagram HTML without writing output"
+    )
+    check_parser.add_argument("src", help="source diagram HTML file")
+    check_parser.set_defaults(handler=_run_check)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/diagram-design/scripts/figma_capture.py
+++ b/skills/diagram-design/scripts/figma_capture.py
@@ -63,6 +63,31 @@ XMLNS_RE = re.compile(
     r"(?P<prefix>\sxmlns\s*=\s*)"
     r"(?P<value>\"[^\"]*\"|'[^']*'|[^\s>]+)"
 )
+CSS_NUMBER = r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?"
+RGBA_VALUE_RE = re.compile(
+    rf"rgba\(\s*(?P<red>[+-]?\d+)\s*,\s*"
+    rf"(?P<green>[+-]?\d+)\s*,\s*"
+    rf"(?P<blue>[+-]?\d+)\s*,\s*"
+    rf"(?P<alpha>{CSS_NUMBER})\s*\)",
+    re.IGNORECASE,
+)
+RGBA_TOKEN_RE = re.compile(r"\brgba\s*\(", re.IGNORECASE)
+TRANSPARENT_TOKEN_RE = re.compile(
+    r"(?<![A-Za-z0-9_-])transparent(?![A-Za-z0-9_-])", re.IGNORECASE
+)
+QUOTED_ATTRIBUTE_RE = re.compile(
+    r"(?P<leading>\s+)"
+    r"(?P<name>[^\s=/>]+)"
+    r"(?P<equals>\s*=\s*)"
+    r"(?P<quote>['\"])"
+    r"(?P<value>.*?)"
+    r"(?P=quote)",
+    re.DOTALL,
+)
+COLOR_ATTRIBUTES = ("fill", "stroke")
+PRESENTATION_ATTRIBUTES = frozenset(
+    {"fill", "stroke", "fill-opacity", "stroke-opacity"}
+)
 
 
 def _fail(msg: str) -> NoReturn:
@@ -271,6 +296,16 @@ def _audit_css(css: str, context: str) -> str | None:
     compact = _compact_for_scheme(css).lower()
     if "javascript:" in compact:
         return f"active javascript: URL in {context}"
+    if RGBA_TOKEN_RE.search(css):
+        return (
+            f"unsupported rgba() color in {context}; use a fill/stroke "
+            "presentation attribute"
+        )
+    if TRANSPARENT_TOKEN_RE.search(css):
+        return (
+            f"unsupported transparent color in {context}; use a fill/stroke "
+            "presentation attribute"
+        )
 
     for match in CSS_IMPORT_RE.finditer(css):
         error = _reference_error(
@@ -433,6 +468,156 @@ def _check_source(path: Path) -> CheckedDiagram:
 # --------------------------------------------------------------------------
 
 
+def _parse_opacity(value: str, attribute: str) -> float:
+    try:
+        number = float(value.strip())
+    except ValueError:
+        _fail(f"{attribute} must be a numeric value between 0 and 1; got {value!r}")
+    if not math.isfinite(number):
+        _fail(f"{attribute} must be finite; got {value!r}")
+    if not 0 <= number <= 1:
+        _fail(f"{attribute} must be between 0 and 1; got {value!r}")
+    return number
+
+
+def _normalize_start_tag(
+    opening: str, parsed_attrs: list[tuple[str, str | None]]
+) -> str:
+    attributes = list(QUOTED_ATTRIBUTE_RE.finditer(opening))
+    grouped: dict[str, list[re.Match[str]]] = {}
+    for match in attributes:
+        name = match.group("name").lower()
+        if name in PRESENTATION_ATTRIBUTES:
+            grouped.setdefault(name, []).append(match)
+
+    parsed_counts: dict[str, int] = {}
+    for name, _ in parsed_attrs:
+        lowered = name.lower()
+        if lowered in PRESENTATION_ATTRIBUTES:
+            parsed_counts[lowered] = parsed_counts.get(lowered, 0) + 1
+    for name in PRESENTATION_ATTRIBUTES:
+        if parsed_counts.get(name, 0) != len(grouped.get(name, [])):
+            _fail(
+                f"{name} presentation attributes must use single or double quotes"
+            )
+
+    edits: list[tuple[int, int, str]] = []
+    for color_name in COLOR_ATTRIBUTES:
+        color_attributes = grouped.get(color_name, [])
+        opacity_name = f"{color_name}-opacity"
+        opacity_attributes = grouped.get(opacity_name, [])
+        if len(color_attributes) > 1:
+            _fail(f"duplicate {color_name} presentation attributes are not allowed")
+        if len(opacity_attributes) > 1:
+            _fail(f"duplicate {opacity_name} presentation attributes are not allowed")
+
+        existing_opacity: float | None = None
+        if opacity_attributes:
+            existing_opacity = _parse_opacity(
+                html.unescape(opacity_attributes[0].group("value")), opacity_name
+            )
+        if not color_attributes:
+            continue
+
+        color = color_attributes[0]
+        raw_value = html.unescape(color.group("value")).strip()
+        if raw_value.casefold() == "transparent":
+            edits.append((color.start("value"), color.end("value"), "none"))
+            continue
+
+        rgba = RGBA_VALUE_RE.fullmatch(raw_value)
+        if rgba is None:
+            if RGBA_TOKEN_RE.search(raw_value) or TRANSPARENT_TOKEN_RE.search(raw_value):
+                _fail(
+                    f"unsupported {color_name} color {raw_value!r}; expected "
+                    "transparent or rgba(r,g,b,a)"
+                )
+            continue
+
+        channels = tuple(int(rgba.group(name)) for name in ("red", "green", "blue"))
+        if any(channel < 0 or channel > 255 for channel in channels):
+            _fail(
+                f"{color_name} rgba() RGB channels must be between 0 and 255; "
+                f"got {raw_value!r}"
+            )
+        alpha = _parse_opacity(rgba.group("alpha"), f"{color_name} rgba() alpha")
+        composed_opacity = alpha * (
+            existing_opacity if existing_opacity is not None else 1
+        )
+        opacity_text = _format_number(composed_opacity)
+        hex_color = "#" + "".join(f"{channel:02x}" for channel in channels)
+        edits.append((color.start("value"), color.end("value"), hex_color))
+        if opacity_attributes:
+            opacity = opacity_attributes[0]
+            edits.append(
+                (opacity.start("value"), opacity.end("value"), opacity_text)
+            )
+        else:
+            quote = color.group("quote")
+            edits.append(
+                (
+                    color.end(),
+                    color.end(),
+                    f" {opacity_name}={quote}{opacity_text}{quote}",
+                )
+            )
+
+    normalized = opening
+    for start, end, replacement in sorted(edits, reverse=True):
+        normalized = normalized[:start] + replacement + normalized[end:]
+    return normalized
+
+
+class SvgColorNormalizer(HTMLParser):
+    """Normalize presentation colors without re-serializing unrelated markup."""
+
+    def __init__(self, svg: str) -> None:
+        super().__init__(convert_charrefs=True)
+        self.svg = svg
+        self.line_starts = [0]
+        self.line_starts.extend(match.end() for match in re.finditer("\n", svg))
+        self.edits: list[tuple[int, int, str]] = []
+
+    def _offset(self) -> int:
+        line, column = self.getpos()
+        return self.line_starts[line - 1] + column
+
+    def _record(self, attrs: list[tuple[str, str | None]]) -> None:
+        opening = self.get_starttag_text()
+        if opening is None:
+            raise ValueError("cannot locate start tag")
+        normalized = _normalize_start_tag(opening, attrs)
+        if normalized != opening:
+            start = self._offset()
+            self.edits.append((start, start + len(opening), normalized))
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        del tag
+        self._record(attrs)
+
+    def handle_startendtag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        del tag
+        self._record(attrs)
+
+
+def _normalize_presentation_colors(svg: str) -> str:
+    parser = SvgColorNormalizer(svg)
+    try:
+        parser.feed(svg)
+        parser.close()
+    except (ValueError, AssertionError) as exc:
+        _fail(f"cannot normalize SVG presentation colors: {exc}")
+
+    normalized = svg
+    for start, end, replacement in reversed(parser.edits):
+        normalized = normalized[:start] + replacement + normalized[end:]
+    return normalized
+
+
 class SvgLayoutParser(HTMLParser):
     """Find insertion points without re-serializing any source markup."""
 
@@ -563,11 +748,13 @@ def _standalone_svg(svg: str) -> str:
     opening = _ensure_xmlns(svg[: layout.opening_end])
     if layout.root_self_closing:
         body = _expand_self_closing(opening) + FONT_DEFS + "</svg>"
+        body = _normalize_presentation_colors(body)
         return '<?xml version="1.0" encoding="UTF-8"?>\n' + body
 
     body = opening + svg[layout.opening_end :]
     opening_delta = len(opening) - layout.opening_end
-    if layout.first_defs is not None:
+    font_style_present = FONT_IMPORT in html.unescape(svg)
+    if not font_style_present and layout.first_defs is not None:
         defs_start, defs_end, self_closing = layout.first_defs
         defs_start += opening_delta
         defs_end += opening_delta
@@ -582,7 +769,7 @@ def _standalone_svg(svg: str) -> str:
             )
         else:
             body = body[:defs_end] + FONT_STYLE + body[defs_end:]
-    else:
+    elif not font_style_present:
         insert_at = (
             layout.preamble_end
             if layout.preamble_end is not None
@@ -590,6 +777,7 @@ def _standalone_svg(svg: str) -> str:
         )
         insert_at += opening_delta
         body = body[:insert_at] + FONT_DEFS + body[insert_at:]
+    body = _normalize_presentation_colors(body)
     return '<?xml version="1.0" encoding="UTF-8"?>\n' + body
 
 


### PR DESCRIPTION
## Summary

- port the reviewed branch-independent SVG extractor, documentation, verifier fixture, and CI gate from #39
- integrate #151's PowerPoint-safe normalization into `figma_capture.py extract`
- convert `transparent` to `none` and `rgba(r,g,b,a)` to lowercase hex plus composed fill/stroke opacity
- reject duplicate, malformed, non-finite, and out-of-range presentation values before writing output
- XML-verify every complete export and keep normalization idempotent
- publish synchronized Claude, Codex, and Factory manifests as 2.6.9

## Verification

- `python3 scripts/verify-figma-export.py` — 14/14 case families passed, including extraction and XML parsing for all 142 shipped examples
- `DIAGRAM_LINT_BROWSER_CHANNEL=chrome python3 scripts/lint-render.py --all` — 147 files rendered, 0 findings
- the full local CI command matrix passed, including package validation, accessibility, semantic, motion, geometry, docs, chart-family, screenshot-freshness, and self-check gates
- 10 XML-cleanup source pages compared before/after at desktop and mobile — all 20 screenshot pairs were byte-identical

## Draft limitations

- PowerPoint is not installed in the verification environment, so a live PowerPoint import remains **unverified**.
- The ported #39 extractor isolates the `<svg>` element. The 24 shipped examples that depend on CSS in the surrounding document `<head>` are structurally valid exports, but their standalone visual fidelity is not guaranteed until those styles are inlined or copied into the export.
- The bundled Google Font import still depends on network availability in the destination application.

Builds on #39 and #151.

Fixes #148.
