### PR TITLE
fix(doctor): quote argument-hint so frontmatter is valid YAML

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, polar chart (polar/radial lollipop), loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.6.11",
+  "version": "2.6.12",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, polar chart (polar/radial lollipop), loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.6.11",
+  "version": "2.6.12",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, polar chart (polar/radial lollipop), loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.6.11",
+  "version": "2.6.12",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -1,6 +1,6 @@
 ---
 description: Run one-shot environment diagnostics for Diagram Design readiness
-argument-hint: [--strict] [--json]
+argument-hint: "[--strict] [--json]"
 allowed-tools:
   - Read
   - Bash


### PR DESCRIPTION
## What does this PR do?

`commands/doctor.md` carries `argument-hint: [--strict] [--json]` unquoted. YAML reads `[--strict]` as a flow sequence and then hits a second one on the same line, so the frontmatter is invalid and strict YAML consumers drop the command. `commands/profile.md` and `prompts/doctor.md` already quote the same shape; this makes `commands/doctor.md` consistent with them.

The other three command files start with `<html-file>` / `<drawio-file>` / `<mermaid-file>`, which YAML reads as a plain scalar, so they parse fine and are left alone. `doctor` is the only file that starts with `[`.

Reproduction — installing the plugin with [apm](https://github.com/danielmeppiel/apm) (`apm install cathrynlavery/diagram-design --target claude`) integrates 4 of the 5 commands:

```
|-- 4 commands integrated -> .claude/commands/
[!] [diagram-design] Skipped command doctor.prompt.md: malformed or over-budget
    YAML frontmatter (while parsing a block mapping
      in "<unicode string>", line 2, column 1:
        description: Run one-shot enviro ...
        ^
    expected <block end>, but found '['
      in "<unicode string>", line 3, column 27:
        argument-hint: [--strict] [--json]
                                  ^)
```

Claude Code's own frontmatter parser is lenient, so `/diagram-design:doctor` works there either way — this only affects consumers that parse the frontmatter as strict YAML.

After the change, every file under `commands/` and `prompts/` round-trips through `yaml.safe_load`:

```
ok   commands/doctor.md
ok   commands/export-diagram.md
ok   commands/import-drawio.md
ok   commands/import-mermaid.md
ok   commands/profile.md
ok   prompts/doctor.md
ok   prompts/export-diagram.md
ok   prompts/import-mermaid.md
ok   prompts/profile.md
```

Rebased on `main` after 2.6.11 landed; version bumped to 2.6.12 via `scripts/bump-plugin-version.py` per CONTRIBUTING.

## Visual proof

Not applicable — no visual output changes.

## Validation gates

- [x] `python3 scripts/test-lint-a11y.py`
- [x] `python3 scripts/lint-skin.py --all --baseline` — 147 files, 0 findings
- [x] `python3 scripts/verify-sequence-oauth.py`
- [x] `python3 scripts/verify-drawio-import.py`
- [x] `python3 scripts/verify-mermaid-import.py`
- [ ] `git diff --exit-code` green after `python3 scripts/build-icons.py` (if icons changed) — not applicable, no icon changes
- [x] Docs updated in the same PR where behavior changed — no doc surface describes this quoting

The full gate chain from CONTRIBUTING was run and is green end to end (`SUITE_EXIT=0`), with `origin/main` substituted by `upstream/main` for the package gate: `test-plugin-package`, `verify-plugin-package`, `claude plugin validate . --strict`, `test-lint-a11y`, `verify-semantic-motion --markdown-only`, `verify-semantic-motion --example-only`, `verify-motion --shipped`, `lint-skin --all --baseline`, `test-verify-polar`, `verify-polar`, `verify-sequence-oauth`, `test-verify-semantic-motion`, `test-verify-sequence-oauth`, `verify-drawio-import`, `test-verify-drawio-import`, `verify-mermaid-import`, `test-verify-motion`, `verify-doctor`, `test-verify-doctor`, `verify-docs-sync`, `test-verify-docs-sync`, `verify-screenshot-freshness`, `test-self-check`, `verify-geometry --all`, `test-verify-geometry`, `verify-treemap --all`, `test-verify-treemap`, `verify-dumbbell`, `test-verify-dumbbell`, `verify-slopegraph --all`, `test-verify-slopegraph`, `verify-ridgeline --all`, `test-verify-ridgeline`, `verify-sankey --all`, `test-verify-sankey`, `verify-bubble --all`, `test-verify-bubble`.

The one gate not run locally is `scripts/lint-render.py` (`--self-test` and `--all`), which needs Playwright/Chromium that this machine does not have — it exits with `Playwright is not installed`. This change touches no rendered output, so CI covers it.

## Checklist

- [x] No new entries added to `scripts/lint-skin-baseline.txt`
- [x] Generated and source files are consistent (extractor ↔ verifier ↔ reference ↔ command)
- [x] Accessible SVG contract satisfied for new/changed examples — not applicable
- [x] Rendered screenshots are attached for every new/changed diagram variant, or visual proof is marked not applicable
- [x] Code of Conduct respected

## Related issues

None.


