### PR TITLE
feat(i18n): put Korean label rules on the always-loaded path

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, polar chart (polar/radial lollipop), loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, polar chart (polar/radial lollipop), loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "diagram-design",
   "description": "Create branded architecture, IT current-state, flowchart, sequence, state machine, ER/data model, timeline, swimlane, quadrant, radar/spider, polar chart (polar/radial lollipop), loop/flywheel, nested, tree, org chart, layer stack, Venn, pyramid/funnel, treemap, bar, line, Gantt and scatter charts, high-level, process, medallion, data flow, DP integration, DP security matrix, sankey, fishbone, Wardley map, kanban, user journey, deployment, dependency graph, UML class, story map, or database schema diagrams as standalone HTML/SVG/PNG. Redraw .drawio/.drawio.png/.drawio.svg or Mermaid .mmd sources at a chosen size/detail; onboard brand tokens from a website; add semantic patterns, callouts, accessible motion, or sketchy/hand-drawn styling.",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "author": {
     "name": "Cathryn Lavery",
     "url": "https://github.com/cathrynlavery"

--- a/scripts/lint-skin.py
+++ b/scripts/lint-skin.py
@@ -62,6 +62,7 @@ ALLOWED_FONTS = {
     "noto sans mono cjk jp",
     "apple sd gothic neo",
     "noto sans kr",
+    "noto serif kr",
     "malgun gothic",
     "noto sans mono cjk kr",
     "system-ui",

--- a/scripts/test-lint-a11y.py
+++ b/scripts/test-lint-a11y.py
@@ -474,7 +474,7 @@ def main() -> int:
             "kr-name-stack",
             kr_name_svg.replace(
                 "</svg>",
-                '<text font-family="\'Geist\', \'Apple SD Gothic Neo\', \'Noto Sans KR\', '
+                '<text font-family="\'Geist\', \'Noto Sans KR\', \'Apple SD Gothic Neo\', '
                 '\'Malgun Gothic\', sans-serif">인증 서비스</text>\n</svg>',
             ),
             directory,
@@ -496,7 +496,7 @@ def main() -> int:
         )
         require_pass(
             "kr-css-stack",
-            '<style>text { font-family: "Geist", "Apple SD Gothic Neo", "Noto Sans KR", '
+            '<style>text { font-family: "Geist", "Noto Sans KR", "Apple SD Gothic Neo", '
             '"Malgun Gothic", sans-serif; }</style>\n' + kr_css_svg,
             directory,
         )

--- a/scripts/test-verify-treemap.py
+++ b/scripts/test-verify-treemap.py
@@ -67,6 +67,34 @@ def main() -> int:
         else:
             print(f"OK: {language} wide-glyph estimator contract is {expected:g}em")
 
+    # Mixed labels are where a per-script formula fails. Sizing a box from
+    # "Hangul syllables + Latin letters + spaces" drops digits and punctuation
+    # entirely, so `주문 v2.1` gets a box built for four of its seven
+    # characters. These pin the per-character contract against that regression.
+    for label, expected, note in (
+        ("주문 v2.1", 5.0, "Hangul with a version suffix (digits and a period)"),
+        ("API 게이트웨이 v2", 9.2, "leading Latin acronym, trailing digit"),
+        ("주문（원본）", 6.0, "full-width parentheses are wide, not narrow"),
+        ("한글e\u0301", 2.6, "a decomposed combining acute adds no advance"),
+        ("", 0.0, "an empty label costs nothing"),
+    ):
+        actual = ESTIMATED_ADVANCE(label, False)
+        if abs(actual - expected) > 1e-9:
+            failures.append(
+                f"mixed-script contract moved for {label!r} ({note}): "
+                f"expected {expected:g}em, got {actual:g}em"
+            )
+        else:
+            print(f"OK: mixed-script estimate for {label!r} is {expected:g}em")
+
+    # The mono face keeps its own narrow advance; only the wide glyphs are
+    # script-dependent. Without this the two faces can silently converge.
+    mono_mixed = ESTIMATED_ADVANCE("주문 v2.1", True)
+    if abs(mono_mixed - 5.1) > 1e-9:
+        failures.append(f"mono mixed-script contract moved: expected 5.1em, got {mono_mixed:g}em")
+    else:
+        print("OK: mono mixed-script estimate keeps the 0.62em narrow advance")
+
     with tempfile.TemporaryDirectory() as raw:
         directory = Path(raw)
 

--- a/scripts/test-verify-treemap.py
+++ b/scripts/test-verify-treemap.py
@@ -75,7 +75,8 @@ def main() -> int:
         ("주문 v2.1", 5.0, "Hangul with a version suffix (digits and a period)"),
         ("API 게이트웨이 v2", 9.2, "leading Latin acronym, trailing digit"),
         ("주문（원본）", 6.0, "full-width parentheses are wide, not narrow"),
-        ("한글e\u0301", 2.6, "a decomposed combining acute adds no advance"),
+        ("한글e\u0301", 2.6, "a decomposed combining acute adds no advance (Mn)"),
+        ("한글e\u20dd", 2.6, "an enclosing circle adds no advance (Me)"),
         ("", 0.0, "an empty label costs nothing"),
     ):
         actual = ESTIMATED_ADVANCE(label, False)

--- a/skills/diagram-design/SKILL.md
+++ b/skills/diagram-design/SKILL.md
@@ -199,10 +199,12 @@ Type-specific anti-patterns live in each type reference linked in the guide.
 - **Arrow label** — Geist Mono, 8px — annotation on arrows
 - **Editorial aside** — Instrument Serif *italic*, 14px — callouts only
 
+**Korean labels** — Geist and Instrument Serif carry no Hangul. Extend the family on that `<text>`, budget 1em per Unicode wide or full-width character and the Latin advance for every other, and never set Hangul below 12px. Full rules in [`style-guide.md`](references/style-guide.md#korean-labels).
+
 **Mono is for technical content only** — never as a blanket "dev" font, and never JetBrains Mono.
 
 ```html
-<link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&family=Noto+Sans+KR:wght@400;500;600&family=Noto+Serif+KR:wght@400&display=swap" rel="stylesheet">
 ```
 
 ---

--- a/skills/diagram-design/assets/template-dark.html
+++ b/skills/diagram-design/assets/template-dark.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Diagram</title>
-  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&family=Noto+Sans+KR:wght@400;500;600&family=Noto+Serif+KR:wght@400&display=swap" rel="stylesheet">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     :root {
@@ -13,7 +13,7 @@
       --color-muted:   #bfc0c0;
       --color-accent:  #f08a59;
       --font-sans:     'Geist', system-ui, sans-serif;
-      --font-serif:    'Instrument Serif', serif;
+      --font-serif:    'Instrument Serif', 'Noto Serif KR', serif;
       --font-mono:     'Geist Mono', ui-monospace, monospace;
     }
 

--- a/skills/diagram-design/assets/template-full.html
+++ b/skills/diagram-design/assets/template-full.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>[PROJECT NAME] Architecture</title>
-  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&family=Noto+Sans+KR:wght@400;500;600&family=Noto+Serif+KR:wght@400&display=swap" rel="stylesheet">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -21,7 +21,7 @@
       --color-accent-tint: rgba(235,108,54,0.08);
       --color-link:        #2e5aa8;
       --font-sans:   'Geist', system-ui, sans-serif;
-      --font-serif:  'Instrument Serif', 'Times New Roman', serif;
+      --font-serif:  'Instrument Serif', 'Noto Serif KR', 'Times New Roman', serif;
       --font-mono:   'Geist Mono', ui-monospace, Menlo, monospace;
     }
 

--- a/skills/diagram-design/assets/template-motion.html
+++ b/skills/diagram-design/assets/template-motion.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Motion diagram template</title>
-  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&family=Noto+Sans+KR:wght@400;500;600&family=Noto+Serif+KR:wght@400&display=swap" rel="stylesheet">
   <style>
     *, *::before, *::after { box-sizing: border-box; }
     :root {
@@ -15,7 +15,7 @@
       --color-accent: #eb6c36;
       --color-rule: rgba(45,49,66,0.12);
       --font-sans: 'Geist', system-ui, sans-serif;
-      --font-serif: 'Instrument Serif', serif;
+      --font-serif: 'Instrument Serif', 'Noto Serif KR', serif;
       --font-mono: 'Geist Mono', ui-monospace, monospace;
       --motion-fast: 160ms;
       --motion-step: 480ms;

--- a/skills/diagram-design/assets/template.html
+++ b/skills/diagram-design/assets/template.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Diagram</title>
-  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&family=Noto+Sans+KR:wght@400;500;600&family=Noto+Serif+KR:wght@400&display=swap" rel="stylesheet">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     :root {
@@ -13,7 +13,7 @@
       --color-muted:   #4f5d75;   /* blue-slate */
       --color-accent:  #eb6c36;   /* atomic-tangerine */
       --font-sans:     'Geist', system-ui, sans-serif;
-      --font-serif:    'Instrument Serif', serif;
+      --font-serif:    'Instrument Serif', 'Noto Serif KR', serif;
       --font-mono:     'Geist Mono', ui-monospace, monospace;
     }
 

--- a/skills/diagram-design/references/output-spec.md
+++ b/skills/diagram-design/references/output-spec.md
@@ -142,10 +142,10 @@ Geist has no CJK coverage. When labels contain Japanese, Chinese, or Korean text
 
 ```svg
 <text font-family="'Geist', 'Hiragino Sans', 'Noto Sans JP', 'Yu Gothic', sans-serif">認証サービス</text>
-<text font-family="'Geist', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', sans-serif">인증 서비스</text>
+<text font-family="'Geist', 'Noto Sans KR', 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif">인증 서비스</text>
 ```
 
-The Hiragino/Yu Gothic stack carries no Hangul glyphs, so Korean labels need the Korean stack — don't reuse the Japanese one. For mono sublabels use `'Geist Mono', 'Noto Sans Mono CJK JP', monospace` (Japanese) or `'Geist Mono', 'Noto Sans Mono CJK KR', monospace` (Korean). Budget **1em per full-width CJK glyph**, not a small percentage over the average Latin glyph; `verify-treemap.py` uses that conservative contract for Unicode wide/full-width characters and treats combining marks as non-advancing. Prefer 12px names over 8px sublabels for CJK, which goes muddy below 10px. Actual width still varies by fallback font, so run the relevant geometry verifier after translating labels.
+The Hiragino/Yu Gothic stack carries no Hangul glyphs, so Korean labels need the Korean stack — don't reuse the Japanese one. Noto Sans KR ships in the skin's font link, so it leads that stack and the local families follow it; the register, floor, and title rules Korean needs beyond the font live in [`style-guide.md`](style-guide.md#korean-labels). For mono sublabels use `'Geist Mono', 'Noto Sans Mono CJK JP', monospace` (Japanese) or `'Geist Mono', 'Noto Sans Mono CJK KR', monospace` (Korean). Budget **1em per full-width CJK glyph**, not a small percentage over the average Latin glyph; `verify-treemap.py` uses that conservative contract for Unicode wide/full-width characters and treats combining marks as non-advancing. Prefer 12px names over 8px sublabels for CJK, which goes muddy below 10px. Actual width still varies by fallback font, so run the relevant geometry verifier after translating labels.
 
 ---
 

--- a/skills/diagram-design/references/style-guide.md
+++ b/skills/diagram-design/references/style-guide.md
@@ -83,8 +83,28 @@ A self-contained palette for the terminal-window primitive (see [primitive-termi
 ### Font stack
 
 ```html
-<link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&family=Noto+Sans+KR:wght@400;500;600&family=Noto+Serif+KR:wght@400&display=swap" rel="stylesheet">
 ```
+
+### Korean labels
+
+Geist and Instrument Serif carry no Hangul. A Korean `<text>` element extends its own family — never swap the skin:
+
+```svg
+<text font-family="'Geist', 'Noto Sans KR', 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif">결제 서비스</text>
+```
+
+Both Noto faces ship in the font link above, so the web font resolves before any locally installed one and the same file renders identically on macOS, Windows, and a reviewer's browser. The local families follow it for offline viewing. Page titles need the serif equivalent — `'Instrument Serif', 'Noto Serif KR', serif` — or a mixed Latin/Korean title resolves Hangul through the platform's generic serif and the two halves disagree. Google's `css2` endpoint slices Korean by unicode-range, so a diagram with a handful of Korean labels downloads only the slices it touches. The four templates carry both faces because a new diagram may contain Hangul; the shipped Latin-only examples keep the shorter link, since a file with no Hangul has nothing to resolve.
+
+**Width budget.** Measure per character, not per script: **every Unicode wide or full-width character costs 1em, every other character costs its face's Latin advance** (0.60em sans, 0.62em mono), and nonspacing/enclosing marks cost nothing. Sum over the string and multiply by the font size for the text width, then add padding and round the box up to the next multiple of 4. `verify-treemap.py` enforces exactly this text width for treemap cell labels; the padding and rounding are authoring convention, and no other type carries an automatic check, so on those the budget is yours to hold.
+
+Counting by script is the trap. `주문 v2.1` is two full-width syllables and five narrow characters; a formula that tallies Hangul, Latin letters, and spaces silently drops `2`, `.`, and `1` and sizes the box for four of its seven characters. Every rendered character costs something — measure per character, never per script.
+
+Three rules follow from Hangul metrics:
+
+- **Sublabels stay Latin.** Ports, protocols, field types, and URLs are Latin anyway — keep `Geist Mono` there and don't translate them. Hangul in a 9px mono sublabel is unreadable and has no mono face to fall back to.
+- **Floor of 12px.** Hangul goes muddy below 12px. If a Korean name doesn't fit at 12px, cut the name — don't shrink the type.
+- **Arrow labels, eyebrows, and legend text switch register.** Those slots are 7–8px Geist Mono, uppercase and tracked, which Hangul has neither a face nor legibility for. A Korean label in one of those slots becomes 12px sans at weight 500 with no tracking and no uppercase transform, and its mask rect grows to match (16px tall, width from the budget above, still rounded to a multiple of 4). Latin labels in the same diagram keep the mono treatment.
 
 **Load-bearing rule:** Mono is for *technical* content (ports, commands, URLs, field types). Names go in Geist sans. Page title is Instrument Serif. Italic Instrument Serif is reserved for annotation callouts (see [primitive-annotation.md](primitive-annotation.md)). **Never JetBrains Mono** as a blanket "dev" font.
 


### PR DESCRIPTION
Continues @etaseoul-jason's #86 on current `main`. That one closed unmerged after your revise request, and #83 has since landed the fallback allowlist it was waiting on, so this sticks to the three things you asked for — the always-loaded guidance, template font availability, and a width budget that survives mixed labels.

## The width budget

#86 measured its own per-script advances (11px per Hangul syllable, 6.5px per Latin character, 3px per space), and that is where the sizing gap came from. `주문 v2.1` is two full-width syllables and five narrow characters; a formula that tallies Hangul, Latin letters, and spaces silently drops `2`, `.`, and `1` and sizes the box for four of the seven.

Rather than patch that formula I removed it and pointed the rules at the model `verify-treemap.py` already implements, the one #121 landed: every Unicode wide or full-width character costs 1em, every other character costs its face's Latin advance (0.60em sans, 0.62em mono), and nonspacing marks cost nothing. It walks characters rather than scripts, so a character class cannot go missing — digits and punctuation included. It also matches what `output-spec.md` already tells importers, so the two surfaces stop disagreeing.

I tried to be careful about what that claims. The rules say `verify-treemap.py` enforces this text width for treemap cell labels; the padding and the round-to-4 are authoring convention, and no other type carries an automatic check. If you would rather it read as a general contract I can widen the wording, but I did not want to promise enforcement that isn't there.

## Changes

- `style-guide.md` gains a Korean labels section — the two fallback stacks, the width budget, the 12px floor, and the register switch for arrow labels, eyebrows, and legend text, which sit at 7–8px mono where Hangul has neither a face nor legibility.
- `SKILL.md` carries one line plus the two Korean faces in its font link, so a plain "draw me a flowchart" sees the rule without loading a reference. The line costs 300 bytes and the link 68, leaving 96 under the 40,000 cap. If that is too tight I can cut it to the pointer and the 12px floor.
- The four templates load Noto Sans KR and Noto Serif KR, and Noto Serif KR joins `--font-serif` so a mixed Latin/Korean title stops falling through to the platform's generic serif and rendering differently on macOS and Windows. Latin glyph selection is unchanged — Instrument Serif still leads.
- Shipped examples keep the shorter link. None of them contains Hangul, so there is nothing there to resolve, and `build-icons.py` output is untouched.
- `output-spec.md` leads the Korean stack with the shipped web font instead of the local families, matching the link, and hands the register and floor rules to `style-guide.md`. The two Korean fixtures in `test-lint-a11y.py` follow the same order.
- `lint-skin.py` allows `noto serif kr`; #83 already covered the sans side.

## Validation

Adversarial cases for the mixed labels you named live in `test-verify-treemap.py` — a version suffix (`주문 v2.1`, 5.0em), a leading Latin acronym (`API 게이트웨이 v2`, 9.2em), full-width parentheses, a decomposed combining mark that exercises the `Mn` branch, and the empty string, plus the mono face's own narrow advance so the two faces cannot silently converge.

The full gate suite from `CONTRIBUTING.md` runs green against current `main` — 39 gates, including `claude plugin validate . --strict`, `lint-skin.py --all --baseline`, `lint-render.py --self-test && --all`, `verify-screenshot-freshness.py`, and the `build-icons.py` regeneration diff. Manifests are at 2.6.8 across Claude, Codex, and Factory.
