### PR TITLE
docs(skill): separate the type ramp from the 4px layout grid

### DIFF
--- a/scripts/test-verify-docs-sync.py
+++ b/scripts/test-verify-docs-sync.py
@@ -44,6 +44,46 @@ effective_w        = 1000 - right_strip_w - strip_margin
 ## 8. Anti-patterns
 """
 
+GRID_SKILL = """\
+### 4px grid
+
+**Structural geometry, divisible by 4:** node origins, widths, heights, gaps, padding. Off-grid by design: type sizes (role ramp in `references/output-spec.md`), stroke widths, opacity.
+
+| Category | Allowed values |
+|---|---|
+| Node width / height | 80, 96, 120 |
+| Gap between nodes | 20, 24, 32 |
+
+### Complexity budget
+
+<text x="10" y="20" font-size="12">Ingest</text>
+<text x="10" y="34" font-size="8.5">source: s3</text>
+"""
+
+TYPE_RAMP_SPEC = """\
+### Type ramp per size class
+
+| Role | standard | presentation | print |
+|---|---|---|---|
+| Title (Instrument Serif) | 28 | 40 | 32 |
+| Node name (Geist 600) | 12 | 16 | 12 |
+| Sublabel (Geist Mono) | 9 | 12 | 9 |
+| Arrow label (Geist Mono) | 8 | 12 | 8 |
+| Eyebrow / tag (Geist Mono) | 8 | 8 | 8 |
+| Node box min height | 48 | 64 | 48 |
+| Min gap between nodes | 24 | 40 | 24 |
+
+Every `font-size` is one of the role values above for the preset in use, or one of these named exceptions:
+
+| Exception | Sizes |
+|---|---|
+| Dense annotation: legend keys, axis ticks (Geist Mono) | 7 to 11, half steps allowed |
+| Group or entity heading (Geist 600) | 14 |
+| Decorative watermark numerals at or under 0.08 opacity | any |
+
+### Safe areas
+"""
+
 
 def load_verify_module():
     sys.dont_write_bytecode = True
@@ -169,6 +209,88 @@ def main() -> int:
     )
     if errors != [expected]:
         raise AssertionError(f"light-skin regression was not reported: {errors}")
+
+    # ── type-ramp contract tests ─────────────────────────────────────────────
+    errors = []
+    verify.check_type_ramp(errors, GRID_SKILL, TYPE_RAMP_SPEC)
+    if errors:
+        raise AssertionError(f"valid type-ramp contract failed: {errors}")
+
+    errors = []
+    verify.check_type_ramp(
+        errors, GRID_SKILL.replace('font-size="12"', 'font-size="13"'), TYPE_RAMP_SPEC
+    )
+    if len(errors) != 1 or "font-size=13" not in errors[0]:
+        raise AssertionError(f"off-ramp font size was not reported: {errors}")
+
+    errors = []
+    verify.check_type_ramp(
+        errors, GRID_SKILL.replace('font-size="8.5"', 'font-size="8.25"'), TYPE_RAMP_SPEC
+    )
+    if len(errors) != 1 or "font-size=8.25" not in errors[0]:
+        raise AssertionError(f"quarter-step font size was not reported: {errors}")
+
+    errors = []
+    verify.check_type_ramp(
+        errors,
+        GRID_SKILL.replace("|---|---|\n", "|---|---|\n| Font sizes | 8, 12 |\n", 1),
+        TYPE_RAMP_SPEC,
+    )
+    if len(errors) != 1 or "'Font sizes' row" not in errors[0]:
+        raise AssertionError(f"font-size row in the grid table was not reported: {errors}")
+
+    errors = []
+    verify.check_type_ramp(
+        errors,
+        GRID_SKILL.replace(" (role ramp in `references/output-spec.md`)", ""),
+        TYPE_RAMP_SPEC,
+    )
+    if len(errors) != 1 or "does not link to references/output-spec.md" not in errors[0]:
+        raise AssertionError(f"unlinked grid section was not reported: {errors}")
+
+    errors = []
+    verify.check_type_ramp(
+        errors,
+        GRID_SKILL,
+        TYPE_RAMP_SPEC.replace("| Sublabel (Geist Mono) | 9 | 12 | 9 |\n", ""),
+    )
+    if not any("'Sublabel'" in error for error in errors):
+        raise AssertionError(f"missing ramp role was not reported: {errors}")
+
+    heading_skill = GRID_SKILL.replace('font-size="12"', 'font-size="14"')
+    errors = []
+    verify.check_type_ramp(errors, heading_skill, TYPE_RAMP_SPEC)
+    if errors:
+        raise AssertionError(f"exempt heading size 14 was rejected: {errors}")
+
+    errors = []
+    verify.check_type_ramp(
+        errors,
+        heading_skill,
+        TYPE_RAMP_SPEC.replace("| Group or entity heading (Geist 600) | 14 |\n", ""),
+    )
+    if len(errors) != 1 or "font-size=14" not in errors[0]:
+        raise AssertionError(
+            f"size 14 was accepted without its named exception: {errors}"
+        )
+
+    errors = []
+    verify.check_type_ramp(
+        errors,
+        GRID_SKILL,
+        TYPE_RAMP_SPEC[: TYPE_RAMP_SPEC.index("Every `font-size`")] + "### Safe areas\n",
+    )
+    if not any("named font-size exceptions table" in error for error in errors):
+        raise AssertionError(f"missing exceptions table was not reported: {errors}")
+
+    errors = []
+    verify.check_type_ramp(
+        errors,
+        verify.SKILL.read_text(encoding="utf-8"),
+        verify.OUTPUT_SPEC_REFERENCE.read_text(encoding="utf-8"),
+    )
+    if errors:
+        raise AssertionError(f"shipped SKILL.md and output-spec.md disagree: {errors}")
 
     with tempfile.TemporaryDirectory(prefix="verify-docs-sync-") as temp_dir:
         skill = Path(temp_dir)
@@ -686,7 +808,7 @@ diagram-design/
     print(
         "PASS: docs sync checks references, asset citations, strict-bundler packaging, "
         "routing surfaces, Factory install contract, type-count routing, High-Level invariants, "
-        "and gallery guards (parent/variant model)"
+        "the type-ramp contract, and gallery guards (parent/variant model)"
     )
     return 0
 

--- a/scripts/test-verify-docs-sync.py
+++ b/scripts/test-verify-docs-sync.py
@@ -87,7 +87,7 @@ Every `font-size` is one of the role values above for the preset in use, or one 
 
 | File | Sizes | What they are |
 |---|---|---|
-| `assets/example-legacy.html` | 13, 22 | node name and a counter |
+| `assets/example-legacy.html` | Geist 600 13, Geist 600 22 | node name and a counter |
 
 ### Safe areas
 """
@@ -381,14 +381,126 @@ def main() -> int:
         )
         errors = []
         verify.check_legacy_type_sizes(errors, TYPE_RAMP_SPEC, fake_root)
-        if len(errors) != 1 or "registers 13, 22" not in errors[0]:
+        if len(errors) != 1 or "registers Geist 600 13, Geist 600 22" not in errors[0]:
             raise AssertionError(f"a grown legacy inventory was not reported: {errors}")
 
         legacy.write_text(legacy_markup.replace('font-size="22"', 'font-size="16"'), encoding="utf-8")
         errors = []
         verify.check_legacy_type_sizes(errors, TYPE_RAMP_SPEC, fake_root)
-        if len(errors) != 1 or "registers 13, 22" not in errors[0]:
+        if len(errors) != 1 or "registers Geist 600 13, Geist 600 22" not in errors[0]:
             raise AssertionError(f"a shrunk legacy inventory was not reported: {errors}")
+
+        # An exception belongs to one font, so the same size under another font
+        # is a different use and has to be reported even though the size list is
+        # unchanged. Swap the registered 13px Geist 600 name for a serif one.
+        legacy.write_text(
+            legacy_markup.replace(
+                "font-size=\"13\" font-weight=\"600\" font-family='Geist', sans-serif",
+                "font-size=\"13\" font-family='Instrument Serif', serif",
+            ).replace(
+                '<text font-size="13" font-weight="600" font-family="\'Geist\', sans-serif">A</text>',
+                '<text font-size="13" font-family="\'Instrument Serif\', serif">A</text>',
+            ),
+            encoding="utf-8",
+        )
+        errors = []
+        verify.check_legacy_type_sizes(errors, TYPE_RAMP_SPEC, fake_root)
+        if len(errors) != 1 or "Instrument Serif 13" not in errors[0]:
+            raise AssertionError(
+                f"a legacy size moved to another font was not reported: {errors}"
+            )
+
+        legacy.write_text(legacy_markup, encoding="utf-8")
+
+        # A dense-annotation size is legal in Geist Mono and illegal in the
+        # serif, at the same size, in the same shipped file. 7 is on no role
+        # ramp, so only the exception can carry it.
+        annotation = (
+            '<svg viewBox="0 0 10 10">'
+            '<text font-size="7" font-family="\'Geist Mono\', monospace">40 ms</text>'
+            "</svg>"
+        )
+        extra = assets / "example-annotation.html"
+        extra.write_text(annotation, encoding="utf-8")
+        errors = []
+        verify.check_legacy_type_sizes(errors, TYPE_RAMP_SPEC, fake_root)
+        if errors:
+            raise AssertionError(
+                f"a Geist Mono annotation at 7 was not accepted: {errors}"
+            )
+
+        extra.write_text(
+            annotation.replace("'Geist Mono', monospace", "'Instrument Serif', serif"),
+            encoding="utf-8",
+        )
+        errors = []
+        verify.check_legacy_type_sizes(errors, TYPE_RAMP_SPEC, fake_root)
+        if not any(
+            "example-annotation" in error and "Instrument Serif 7" in error
+            for error in errors
+        ):
+            raise AssertionError(
+                f"an annotation size under the wrong font was not reported: {errors}"
+            )
+
+        # Same size, same file, set through a CSS class and a custom property:
+        # the sweep has to resolve the family before it can judge the size.
+        styled = (
+            "<style>:root{--font-mono:'Geist Mono',ui-monospace,monospace;"
+            "--font-serif:'Instrument Serif',serif}"
+            ".tick{font-family:var(--font-mono);font-size:7px}</style>"
+            '<svg viewBox="0 0 10 10"><text class="tick">40 ms</text></svg>'
+        )
+        extra.write_text(styled, encoding="utf-8")
+        errors = []
+        verify.check_legacy_type_sizes(errors, TYPE_RAMP_SPEC, fake_root)
+        if errors:
+            raise AssertionError(
+                f"a CSS-set Geist Mono annotation at 7 was not accepted: {errors}"
+            )
+
+        extra.write_text(
+            styled.replace("var(--font-mono)", "var(--font-serif)"), encoding="utf-8"
+        )
+        errors = []
+        verify.check_legacy_type_sizes(errors, TYPE_RAMP_SPEC, fake_root)
+        if not any(
+            "example-annotation" in error and "Instrument Serif 7" in error
+            for error in errors
+        ):
+            raise AssertionError(
+                f"a CSS-set annotation under the wrong font was not reported: {errors}"
+            )
+        # The heading exception is Geist 600 at 14, and the same reading applies
+        # to it: the size is not a licence the serif can pick up.
+        heading = (
+            '<svg viewBox="0 0 10 10">'
+            '<text font-size="14" font-weight="600" font-family="\'Geist\', sans-serif">'
+            "Ingest</text></svg>"
+        )
+        extra.write_text(heading, encoding="utf-8")
+        errors = []
+        verify.check_legacy_type_sizes(errors, TYPE_RAMP_SPEC, fake_root)
+        if errors:
+            raise AssertionError(f"a Geist 600 heading at 14 was not accepted: {errors}")
+
+        extra.write_text(
+            heading.replace(
+                "font-weight=\"600\" font-family=\"'Geist', sans-serif\"",
+                "font-family=\"'Instrument Serif', serif\"",
+            ),
+            encoding="utf-8",
+        )
+        errors = []
+        verify.check_legacy_type_sizes(errors, TYPE_RAMP_SPEC, fake_root)
+        if not any(
+            "example-annotation" in error and "Instrument Serif 14" in error
+            for error in errors
+        ):
+            raise AssertionError(
+                f"a heading size under the wrong font was not reported: {errors}"
+            )
+        extra.unlink()
 
         legacy.unlink()
         errors = []

--- a/scripts/test-verify-docs-sync.py
+++ b/scripts/test-verify-docs-sync.py
@@ -56,8 +56,10 @@ GRID_SKILL = """\
 
 ### Complexity budget
 
-<text x="10" y="20" font-size="12">Ingest</text>
-<text x="10" y="34" font-size="8.5">source: s3</text>
+<text x="10" y="20" font-size="12" font-weight="600" font-family="'Geist', sans-serif">Ingest</text>
+<text x="10" y="34" font-size="8.5" font-family="'Geist', sans-serif">source: s3</text>
+<text x="10" y="48" font-size="7" font-family="'Geist Mono', monospace">API</text>
+<text x="10" y="90" fill="rgba(45,49,66,0.06)" font-size="72" font-family="'Geist Mono', monospace">2026</text>
 """
 
 TYPE_RAMP_SPEC = """\
@@ -75,11 +77,17 @@ TYPE_RAMP_SPEC = """\
 
 Every `font-size` is one of the role values above for the preset in use, or one of these named exceptions:
 
-| Exception | Sizes |
-|---|---|
-| Dense annotation: legend keys, axis ticks (Geist Mono) | 7 to 11, half steps allowed |
-| Group or entity heading (Geist 600) | 14 |
-| Decorative watermark numerals at or under 0.08 opacity | any |
+| Exception | Font | Sizes |
+|---|---|---|
+| Dense annotation: legend keys, axis ticks | Geist Mono or Geist regular | 7 to 11, half steps allowed |
+| Group or entity heading | Geist 600 | 14 |
+| Decorative watermark numerals at or under 0.08 opacity | any | any |
+
+### Registered legacy sizes
+
+| File | Sizes | What they are |
+|---|---|---|
+| `assets/example-legacy.html` | 13, 22 | node name and a counter |
 
 ### Safe areas
 """
@@ -267,7 +275,7 @@ def main() -> int:
     verify.check_type_ramp(
         errors,
         heading_skill,
-        TYPE_RAMP_SPEC.replace("| Group or entity heading (Geist 600) | 14 |\n", ""),
+        TYPE_RAMP_SPEC.replace("| Group or entity heading | Geist 600 | 14 |\n", ""),
     )
     if len(errors) != 1 or "font-size=14" not in errors[0]:
         raise AssertionError(
@@ -283,6 +291,60 @@ def main() -> int:
     if not any("named font-size exceptions table" in error for error in errors):
         raise AssertionError(f"missing exceptions table was not reported: {errors}")
 
+    # Both declared syntaxes, not just the double-quoted attribute.
+    errors = []
+    verify.check_type_ramp(
+        errors,
+        GRID_SKILL.replace('font-size="12"', "font-size='13'"),
+        TYPE_RAMP_SPEC,
+    )
+    if len(errors) != 1 or "font-size=13" not in errors[0]:
+        raise AssertionError(f"single-quoted off-ramp size was not reported: {errors}")
+
+    errors = []
+    verify.check_type_ramp(
+        errors,
+        GRID_SKILL + "\n<style>.axis { font-size:13px; }</style>\n",
+        TYPE_RAMP_SPEC,
+    )
+    if len(errors) != 1 or "font-size=13" not in errors[0]:
+        raise AssertionError(f"CSS off-ramp size was not reported: {errors}")
+
+    errors = []
+    verify.check_type_ramp(
+        errors,
+        GRID_SKILL.replace("font-size=\"8.5\" font-family=\"'Geist', sans-serif\"", 'font-size="8.5"'),
+        TYPE_RAMP_SPEC,
+    )
+    if len(errors) != 1 or "declares no font" not in errors[0]:
+        raise AssertionError(f"fontless off-ramp size was not reported: {errors}")
+
+    # An exception belongs to a role, not to a number range. A node name is set
+    # in Geist 600 and cannot take a dense-annotation size just by being small.
+    errors = []
+    verify.check_type_ramp(
+        errors, GRID_SKILL.replace('font-size="12"', 'font-size="7.5"'), TYPE_RAMP_SPEC
+    )
+    if len(errors) != 1 or "font-size=7.5 on sans-600 text" not in errors[0]:
+        raise AssertionError(
+            f"node name borrowing a dense-annotation size was not reported: {errors}"
+        )
+
+    errors = []
+    verify.check_type_ramp(
+        errors, GRID_SKILL.replace('font-size="7"', 'font-size="7.5"'), TYPE_RAMP_SPEC
+    )
+    if errors:
+        raise AssertionError(f"dense annotation at 7.5 in Geist Mono was rejected: {errors}")
+
+    # The 72px watermark is legal only while its opacity keeps it decorative.
+    errors = []
+    verify.check_type_ramp(
+        errors, GRID_SKILL.replace("rgba(45,49,66,0.06)", "rgba(45,49,66,0.30)"), TYPE_RAMP_SPEC
+    )
+    if len(errors) != 1 or "font-size=72" not in errors[0]:
+        raise AssertionError(f"opaque watermark size was not reported: {errors}")
+
     errors = []
     verify.check_type_ramp(
         errors,
@@ -291,6 +353,55 @@ def main() -> int:
     )
     if errors:
         raise AssertionError(f"shipped SKILL.md and output-spec.md disagree: {errors}")
+
+    # ── registered legacy sizes ──────────────────────────────────────────────
+    legacy_markup = (
+        '<svg viewBox="0 0 10 10">'
+        '<text font-size="13" font-weight="600" font-family="\'Geist\', sans-serif">A</text>'
+        '<text font-size="22" font-weight="600" font-family="\'Geist\', sans-serif">2/5</text>'
+        "</svg>"
+    )
+    with tempfile.TemporaryDirectory(prefix="legacy-type-sizes-") as temp_dir:
+        fake_root = Path(temp_dir)
+        assets = fake_root / "skills/diagram-design/assets"
+        references = fake_root / "skills/diagram-design/references"
+        assets.mkdir(parents=True)
+        references.mkdir(parents=True)
+        legacy = assets / "example-legacy.html"
+        legacy.write_text(legacy_markup, encoding="utf-8")
+
+        errors = []
+        verify.check_legacy_type_sizes(errors, TYPE_RAMP_SPEC, fake_root)
+        if errors:
+            raise AssertionError(f"registered legacy sizes were rejected: {errors}")
+
+        legacy.write_text(
+            legacy_markup.replace("</svg>", '<text font-size="17">x</text></svg>'),
+            encoding="utf-8",
+        )
+        errors = []
+        verify.check_legacy_type_sizes(errors, TYPE_RAMP_SPEC, fake_root)
+        if len(errors) != 1 or "registers 13, 22" not in errors[0]:
+            raise AssertionError(f"a grown legacy inventory was not reported: {errors}")
+
+        legacy.write_text(legacy_markup.replace('font-size="22"', 'font-size="16"'), encoding="utf-8")
+        errors = []
+        verify.check_legacy_type_sizes(errors, TYPE_RAMP_SPEC, fake_root)
+        if len(errors) != 1 or "registers 13, 22" not in errors[0]:
+            raise AssertionError(f"a shrunk legacy inventory was not reported: {errors}")
+
+        legacy.unlink()
+        errors = []
+        verify.check_legacy_type_sizes(errors, TYPE_RAMP_SPEC, fake_root)
+        if len(errors) != 1 or "drop the row" not in errors[0]:
+            raise AssertionError(f"a stale legacy row was not reported: {errors}")
+
+    errors = []
+    verify.check_legacy_type_sizes(
+        errors, verify.OUTPUT_SPEC_REFERENCE.read_text(encoding="utf-8"), verify.ROOT
+    )
+    if errors:
+        raise AssertionError(f"shipped legacy type-size registry is stale: {errors}")
 
     with tempfile.TemporaryDirectory(prefix="verify-docs-sync-") as temp_dir:
         skill = Path(temp_dir)

--- a/scripts/verify-docs-sync.py
+++ b/scripts/verify-docs-sync.py
@@ -540,6 +540,30 @@ TYPE_SIZE_SURFACES = (
 WEIGHT_RE = re.compile(r"""font-weight\s*[:=]\s*["']?(\d{3}|bold)""")
 
 
+# The family a `{node-name}` role token stands for, and the weight that has to
+# ride alongside it because a family value cannot carry one. Then how each class
+# is written in the spec tables. All of it is the spec's own wording.
+CLASS_TOKEN_FONT = {
+    "serif": ("Instrument Serif", ""),
+    "mono": ("Geist Mono", ""),
+    "sans": ("Geist", ""),
+    "sans-600": ("Geist", 'font-weight="600"'),
+}
+CLASS_NAMES = {
+    "serif": "Instrument Serif",
+    "mono": "Geist Mono",
+    "sans": "Geist regular",
+    "sans-600": "Geist 600",
+    None: "unattributed",
+}
+
+
+def role_token_names(role: str) -> set[str]:
+    """The `{token}` spellings a reference pattern may use for a ramp role."""
+    slug = re.sub(r"[^a-z0-9]+", "-", role.lower()).strip("-")
+    return {slug, slug.split("-")[0]}
+
+
 def font_classes(text: str) -> set[str]:
     """The ramp fonts a spec cell names. A cell may name more than one."""
     named = set()
@@ -554,23 +578,53 @@ def font_classes(text: str) -> set[str]:
     return named
 
 
-def element_class(tag: str) -> str | None:
+FONT_FAMILY_RE = re.compile(
+    r"""font-family\s*[:=]\s*(?:"(?P<dq>[^"]*)"|'(?P<sq>[^']*)'|(?P<bare>[^;>\n]*))"""
+)
+
+
+def family_class(value: str) -> str | None:
+    """Which ramp family a single `font-family` value names, weight aside."""
+    if "Instrument Serif" in value:
+        return "serif"
+    if "Mono" in value or "monospace" in value:
+        return "mono"
+    if "Geist" in value or "sans-serif" in value:
+        return "sans"
+    return None
+
+
+def declared_families(context: str) -> set[str | None]:
+    """Every family named in *context*, whichever quoting each declaration uses."""
+    return {
+        family_class(
+            match.group("dq") or match.group("sq") or match.group("bare") or ""
+        )
+        for match in FONT_FAMILY_RE.finditer(context)
+    }
+
+
+def element_class(context: str) -> str | None:
     """Which ramp font an element is set in, weight included.
 
     Geist at 600 or heavier is the node-name voice; lighter Geist is annotation.
     Keeping them apart is what stops a node name borrowing an annotation size.
+    *context* may merge an element's tag with the CSS rules that style it, so two
+    declarations naming different families read as unattributed rather than as
+    whichever family happens to be tested first.
     """
-    if "Instrument Serif" in tag:
-        return "serif"
-    if "Mono" in tag or "monospace" in tag:
-        return "mono"
-    if "Geist" in tag or "sans-serif" in tag:
-        weight = WEIGHT_RE.search(tag)
-        declared = 700 if weight and weight.group(1) == "bold" else (
-            int(weight.group(1)) if weight else 400
-        )
-        return "sans-600" if declared >= 600 else "sans"
-    return None
+    families = declared_families(context)
+    families.discard(None)
+    if len(families) != 1:
+        return None
+    family = families.pop()
+    if family != "sans":
+        return family
+    # Family and weight can arrive from separate rules, and they can disagree.
+    # The heaviest wins, which is the stricter reading: it denies the dense
+    # annotation range rather than granting it.
+    weights = [700 if raw == "bold" else int(raw) for raw in WEIGHT_RE.findall(context)]
+    return "sans-600" if weights and max(weights) >= 600 else "sans"
 
 
 def enclosing_tag(markup: str, index: int) -> str:
@@ -614,6 +668,7 @@ class TypeContract:
         self.canonical: dict[str, set[float]] = {}
         self.ranges: list[tuple[str, float, float]] = []
         self.watermark_alpha: float | None = None
+        self.role_tokens: dict[str, str] = {}
 
     def allowed(self, klass: str | None) -> set[float]:
         if klass is None:
@@ -628,12 +683,14 @@ class TypeContract:
             for exception_class, low, high in self.ranges
         )
 
-    def off_ramp(self, tag: str, value: float) -> bool:
-        """Is *value* outside every role size and every exception range?
+    def off_ramp(self, tag: str, context: str, value: float) -> bool:
+        """Is *value* off the ramp and outside every exception open to it?
 
-        Size only, ignoring which role the text plays. Shipped examples set type
-        through CSS classes as well as attributes, so per-element role
-        attribution is not reliable across the asset tree; the size floor is.
+        The canonical role sizes stay one union: a size that is on the ramp for
+        any role is on contract wherever it appears. The exceptions do not. Each
+        belongs to the font beside it in the spec, so an element has to be
+        attributed to that font before it can claim one, and *context* carries
+        the CSS rules that attribution needs.
         """
         alpha = tag_alpha(tag)
         if (
@@ -644,14 +701,11 @@ class TypeContract:
             return False
         if any(value in sizes for sizes in self.canonical.values()):
             return False
-        return not any(
-            low <= value <= high and (value * 2) % 1 == 0
-            for _, low, high in self.ranges
-        )
+        return not self.excepted(element_class(context), value)
 
-    def violation(self, tag: str, value: float) -> str | None:
+    def violation(self, tag: str, context: str, value: float) -> str | None:
         """Why *value* is off contract on this tag, or None if it is fine."""
-        klass = element_class(tag)
+        klass = element_class(context)
         alpha = tag_alpha(tag)
         if (
             self.watermark_alpha is not None
@@ -674,29 +728,111 @@ class TypeContract:
         )
 
 
-def font_sizes(markup: str) -> list[tuple[float, str]]:
-    """Every declared font size in *markup* with the tag it sits on."""
-    found = []
-    for match in FONT_SIZE_RE.finditer(markup):
-        raw = match.group("attr") or match.group("css")
-        found.append((float(raw), enclosing_tag(markup, match.start())))
-    return found
-
-
 SVG_BLOCK_RE = re.compile(r"<svg\b.*?</svg>", re.DOTALL)
 CLASS_ATTR_RE = re.compile(r"""class=["']([^"']+)["']""")
 SELECTOR_CLASS_RE = re.compile(r"\.([A-Za-z0-9_-]+)")
+STYLE_BLOCK_RE = re.compile(r"<style\b[^>]*>(.*?)</style>", re.DOTALL)
+CSS_RULE_RE = re.compile(r"([^{}]*)\{([^{}]*)\}")
+CSS_VAR_DECL_RE = re.compile(r"(--[\w-]+)\s*:\s*([^;}]+)")
+CSS_VAR_USE_RE = re.compile(r"var\(\s*(--[\w-]+)\s*\)")
+ROLE_TOKEN_RE = re.compile(r"\{([a-z][a-z-]*)\}")
 
 
-def diagram_font_sizes(markup: str) -> list[tuple[float, str]]:
+class Styles:
+    """The stylesheet an element has to be read against.
+
+    Shipped examples set type through CSS classes and custom properties as often
+    as through attributes, so the font behind a size is usually not on the
+    element. This collects the rules, resolves `var(--font-mono)` back to the
+    family it names, and expands the `{node-name}` role tokens the reference
+    patterns write, so a size can be attributed to a ramp font either way.
+    """
+
+    def __init__(
+        self, markup: str, role_tokens: dict[str, tuple[str, str]] | None = None
+    ) -> None:
+        self.variables: dict[str, str] = {}
+        self.rules: list[tuple[set[str], str, int, int]] = []
+        self.role_tokens = role_tokens or {}
+        for block in STYLE_BLOCK_RE.finditer(markup):
+            body, base = block.group(1), block.start(1)
+            for name, value in CSS_VAR_DECL_RE.findall(body):
+                self.variables.setdefault(name, value.strip())
+            for rule in CSS_RULE_RE.finditer(body):
+                self.rules.append(
+                    (
+                        set(SELECTOR_CLASS_RE.findall(rule.group(1))),
+                        rule.group(2),
+                        base + rule.start(2),
+                        base + rule.end(2),
+                    )
+                )
+
+    def expand(self, text: str) -> str:
+        text = CSS_VAR_USE_RE.sub(
+            lambda match: self.variables.get(match.group(1), match.group(0)), text
+        )
+        # A role token stands where a family value goes, so the weight it implies
+        # cannot be written in its place; it is appended to the context instead.
+        weights: list[str] = []
+
+        def resolve(match: re.Match[str]) -> str:
+            font = self.role_tokens.get(match.group(1))
+            if font is None:
+                return match.group(0)
+            family, weight = font
+            if weight:
+                weights.append(weight)
+            return family
+
+        return " ".join([ROLE_TOKEN_RE.sub(resolve, text), *weights])
+
+    def declarations_for(self, classes: set[str]) -> str:
+        """Every rule body whose selector names one of *classes*."""
+        return " ".join(body for named, body, _, _ in self.rules if named & classes)
+
+    def rule_at(self, index: int) -> tuple[set[str], str]:
+        """The rule holding *index*, for a size declared in CSS rather than on a tag."""
+        for named, body, start, end in self.rules:
+            if start <= index < end:
+                return named, body
+        return set(), ""
+
+    def font_context(self, tag: str, index: int) -> str:
+        """*tag* plus every rule that could set its font, variables resolved."""
+        parts = [tag]
+        if tag:
+            for attribute in CLASS_ATTR_RE.findall(tag):
+                parts.append(self.declarations_for(set(attribute.split())))
+        else:
+            named, body = self.rule_at(index)
+            parts.extend([body, self.declarations_for(named)])
+        return self.expand(" ".join(parts))
+
+
+def font_sizes(markup: str, styles: Styles | None = None) -> list[tuple[float, str, str]]:
+    """Every declared font size in *markup*, with its tag and its font context."""
+    styles = Styles(markup) if styles is None else styles
+    found = []
+    for match in FONT_SIZE_RE.finditer(markup):
+        raw = match.group("attr") or match.group("css")
+        tag = enclosing_tag(markup, match.start())
+        found.append((float(raw), tag, styles.font_context(tag, match.start())))
+    return found
+
+
+def diagram_font_sizes(
+    markup: str, styles: Styles | None = None
+) -> list[tuple[float, str, str]]:
     """Font sizes that govern diagram type, chrome around the diagram excluded.
 
     An example page is a diagram wrapped in prose. Attributes inside the `<svg>`
     count, and so does a CSS rule whose class is worn by an element in there; a
     rule for the page's own lede or heading does not.
     """
+    styles = Styles(markup) if styles is None else styles
     if "<svg" not in markup:
-        return font_sizes(markup)
+        return font_sizes(markup, styles)
 
     spans = [match.span() for match in SVG_BLOCK_RE.finditer(markup)]
     drawn = set()
@@ -717,7 +853,8 @@ def diagram_font_sizes(markup: str) -> list[tuple[float, str]]:
             selector = markup[max(markup.rfind("}", 0, brace), 0) : brace]
             if not drawn.intersection(SELECTOR_CLASS_RE.findall(selector)):
                 continue
-        sizes.append((float(raw), enclosing_tag(markup, match.start())))
+        tag = enclosing_tag(markup, match.start())
+        sizes.append((float(raw), tag, styles.font_context(tag, match.start())))
     return sizes
 
 
@@ -751,6 +888,11 @@ def read_type_contract(errors: list[str], spec_markdown: str) -> TypeContract | 
             continue
         for klass in named:
             contract.canonical.setdefault(klass, set()).update(float(s) for s in sizes)
+        if len(named) == 1:
+            font = CLASS_TOKEN_FONT.get(next(iter(named)))
+            if font:
+                for token in role_token_names(role):
+                    contract.role_tokens[token] = font
 
     # Scope the size parsing to the exceptions table. The ramp rows above it end
     # in a bare number too, and reading those as exceptions would let any ramp
@@ -839,8 +981,9 @@ def check_type_ramp(errors: list[str], skill_markdown: str, spec_markdown: str) 
     if contract is None:
         return
 
-    for value, tag in font_sizes(skill_markdown):
-        violation = contract.violation(tag, value)
+    styles = Styles(skill_markdown, contract.role_tokens)
+    for value, tag, context in font_sizes(skill_markdown, styles):
+        violation = contract.violation(tag, context, value)
         if violation:
             errors.append(f"SKILL.md uses {violation}")
 
@@ -851,12 +994,17 @@ def check_legacy_type_sizes(errors: list[str], spec_markdown: str, root: Path) -
     if contract is None:
         return
 
-    registry: dict[str, list[float]] = {}
+    registry: dict[str, list[tuple[str | None, float]]] = {}
     for cells in table_rows(section(spec_markdown, LEGACY_SIZE_HEADING)):
         if len(cells) < 2 or not cells[0].startswith("`"):
             continue
         name = cells[0].strip("`")
-        registry[name] = sorted(float(size) for size in cells[1].split(","))
+        uses = []
+        for cell in cells[1].split(","):
+            use = read_legacy_use(errors, name, cell)
+            if use is not None:
+                uses.append(use)
+        registry[name] = sorted(uses, key=use_order)
     if not registry:
         errors.append(
             f"output-spec.md has no '{LEGACY_SIZE_HEADING}' table; the shipped "
@@ -864,7 +1012,7 @@ def check_legacy_type_sizes(errors: list[str], spec_markdown: str, root: Path) -
         )
         return
 
-    measured: dict[str, list[float]] = {}
+    measured: dict[str, list[tuple[str | None, float]]] = {}
     for directory, prefixes in TYPE_SIZE_SURFACES:
         for path in sorted((root / directory).iterdir()):
             if path.suffix.lower() not in TYPE_SIZE_SUFFIXES:
@@ -872,13 +1020,14 @@ def check_legacy_type_sizes(errors: list[str], spec_markdown: str, root: Path) -
             if not path.name.startswith(prefixes):
                 continue
             markup = path.read_text(encoding="utf-8")
+            styles = Styles(markup, contract.role_tokens)
             off = [
-                value
-                for value, tag in diagram_font_sizes(markup)
-                if contract.off_ramp(tag, value)
+                (element_class(context), value)
+                for value, tag, context in diagram_font_sizes(markup, styles)
+                if contract.off_ramp(tag, context, value)
             ]
             if off:
-                measured[f"{path.parent.name}/{path.name}"] = sorted(off)
+                measured[f"{path.parent.name}/{path.name}"] = sorted(off, key=use_order)
 
     for name in sorted(set(registry) | set(measured)):
         want = registry.get(name)
@@ -888,23 +1037,57 @@ def check_legacy_type_sizes(errors: list[str], spec_markdown: str, root: Path) -
         if want is None:
             errors.append(
                 f"{name} carries off-contract font sizes "
-                f"{format_sizes(got)} that the registered legacy list in "
+                f"{format_uses(got)} that the registered legacy list in "
                 "output-spec.md does not cover"
             )
         elif got is None:
             errors.append(
-                f"output-spec.md registers legacy font sizes {format_sizes(want)} "
+                f"output-spec.md registers legacy font sizes {format_uses(want)} "
                 f"for {name}, which no longer carries any; drop the row"
             )
         else:
             errors.append(
-                f"{name} carries off-contract font sizes {format_sizes(got)} but "
-                f"output-spec.md registers {format_sizes(want)}"
+                f"{name} carries off-contract font sizes {format_uses(got)} but "
+                f"output-spec.md registers {format_uses(want)}"
             )
 
 
-def format_sizes(values: list[float]) -> str:
-    return ", ".join(format_size(value) for value in values)
+LEGACY_USE_RE = re.compile(r"^(?P<font>.*?)\s*(?P<size>\d+(?:\.\d+)?)$")
+
+
+def read_legacy_use(
+    errors: list[str], name: str, cell: str
+) -> tuple[str | None, float] | None:
+    """One `Geist 600 13` registry entry as the font class and size it names."""
+    match = LEGACY_USE_RE.match(cell.strip())
+    if not match:
+        errors.append(
+            f"output-spec.md registers {cell.strip()!r} for {name}, which is not "
+            "a font and a size; a legacy size is registered against the font "
+            "carrying it so the two cannot be swapped"
+        )
+        return None
+    font = match.group("font")
+    named = font_classes(font)
+    if len(named) != 1:
+        if font.strip() != CLASS_NAMES[None]:
+            errors.append(
+                f"output-spec.md registers {cell.strip()!r} for {name}, naming "
+                f"font {font.strip()!r}, which is not one of the ramp fonts"
+            )
+            return None
+        return (None, float(match.group("size")))
+    return (next(iter(named)), float(match.group("size")))
+
+
+def use_order(use: tuple[str | None, float]) -> tuple[str, float]:
+    return (CLASS_NAMES[use[0]], use[1])
+
+
+def format_uses(uses: list[tuple[str | None, float]]) -> str:
+    return ", ".join(
+        f"{CLASS_NAMES[klass]} {format_size(value)}" for klass, value in uses
+    )
 
 
 MANIFEST_DESCRIPTIONS = (

--- a/scripts/verify-docs-sync.py
+++ b/scripts/verify-docs-sync.py
@@ -514,8 +514,280 @@ def check_high_level_reference(errors: list[str], markdown: str) -> None:
 
 
 TYPE_RAMP_ROLES = ("Title", "Node name", "Sublabel", "Arrow label", "Eyebrow / tag")
-FONT_SIZE_RE = re.compile(r'font-size="(\d+(?:\.\d+)?)"')
+# Both syntaxes the type-ramp contract claims: an SVG/HTML attribute in either
+# quote style, and a CSS declaration in px. Relative CSS units are page chrome,
+# not diagram type, so rem/em deliberately do not match.
+FONT_SIZE_RE = re.compile(
+    r"""font-size\s*(?:=\s*(?P<quote>["'])(?P<attr>\d+(?:\.\d+)?)(?P=quote)"""
+    r"""|:\s*(?P<css>\d+(?:\.\d+)?)px)"""
+)
 SIZE_RANGE_RE = re.compile(r"^(\d+(?:\.\d+)?)(?: to (\d+(?:\.\d+)?))?$")
+WATERMARK_OPACITY_RE = re.compile(r"at or under (\d+(?:\.\d+)?) opacity")
+ALPHA_RE = re.compile(
+    r"""(?:\bfill-)?(?<![-\w])opacity=["'](\d*\.?\d+)["']"""
+    r"""|rgba\([^)]*?,\s*(\d*\.?\d+)\s*\)"""
+)
+LEGACY_SIZE_HEADING = "### Registered legacy sizes"
+TYPE_SIZE_SUFFIXES = (".html", ".svg", ".md")
+# Where diagram type lives. The gallery pages (index.html, icons.html) are site
+# chrome, not diagrams, so the type ramp does not govern them.
+TYPE_SIZE_SURFACES = (
+    ("skills/diagram-design/assets", ("example-", "template")),
+    ("skills/diagram-design/references", ("type-",)),
+)
+
+
+WEIGHT_RE = re.compile(r"""font-weight\s*[:=]\s*["']?(\d{3}|bold)""")
+
+
+def font_classes(text: str) -> set[str]:
+    """The ramp fonts a spec cell names. A cell may name more than one."""
+    named = set()
+    if "Instrument Serif" in text:
+        named.add("serif")
+    if "Mono" in text or "monospace" in text:
+        named.add("mono")
+    if "Geist 600" in text:
+        named.add("sans-600")
+    if "Geist regular" in text or "Geist sans" in text or "sans-serif" in text:
+        named.add("sans")
+    return named
+
+
+def element_class(tag: str) -> str | None:
+    """Which ramp font an element is set in, weight included.
+
+    Geist at 600 or heavier is the node-name voice; lighter Geist is annotation.
+    Keeping them apart is what stops a node name borrowing an annotation size.
+    """
+    if "Instrument Serif" in tag:
+        return "serif"
+    if "Mono" in tag or "monospace" in tag:
+        return "mono"
+    if "Geist" in tag or "sans-serif" in tag:
+        weight = WEIGHT_RE.search(tag)
+        declared = 700 if weight and weight.group(1) == "bold" else (
+            int(weight.group(1)) if weight else 400
+        )
+        return "sans-600" if declared >= 600 else "sans"
+    return None
+
+
+def enclosing_tag(markup: str, index: int) -> str:
+    """The open tag holding the character at *index*, plus its parent `<text>`.
+
+    A `<tspan>` inherits its font from the `<text>` around it, so the parent is
+    appended and the two are classified as one string.
+    """
+    start = markup.rfind("<", 0, index)
+    if start < 0:
+        return ""
+    end = markup.find(">", index)
+    if end < 0:
+        return ""
+    tag = markup[start : end + 1]
+    # A CSS declaration inside `<style>` is not on an element. Rejecting a span
+    # that swallows another `<` keeps the stylesheet from reading as one tag.
+    if "<" in tag[1:]:
+        return ""
+    if tag.startswith("<tspan") and element_class(tag) is None:
+        parent = markup.rfind("<text", 0, start)
+        if parent >= 0:
+            parent_end = markup.find(">", parent)
+            if parent_end >= 0:
+                tag += markup[parent : parent_end + 1]
+    return tag
+
+
+def tag_alpha(tag: str) -> float | None:
+    """Smallest alpha the tag declares, whether as an attribute or in `rgba()`."""
+    alphas = [
+        float(explicit or in_rgba) for explicit, in_rgba in ALPHA_RE.findall(tag)
+    ]
+    return min(alphas) if alphas else None
+
+
+class TypeContract:
+    """The role ramp and its named exceptions, read off output-spec.md."""
+
+    def __init__(self) -> None:
+        self.canonical: dict[str, set[float]] = {}
+        self.ranges: list[tuple[str, float, float]] = []
+        self.watermark_alpha: float | None = None
+
+    def allowed(self, klass: str | None) -> set[float]:
+        if klass is None:
+            return set().union(*self.canonical.values()) if self.canonical else set()
+        return self.canonical.get(klass, set())
+
+    def excepted(self, klass: str | None, value: float) -> bool:
+        # An exception belongs to the font beside it, so text with no declared
+        # font cannot claim one.
+        return klass is not None and any(
+            klass == exception_class and low <= value <= high and (value * 2) % 1 == 0
+            for exception_class, low, high in self.ranges
+        )
+
+    def off_ramp(self, tag: str, value: float) -> bool:
+        """Is *value* outside every role size and every exception range?
+
+        Size only, ignoring which role the text plays. Shipped examples set type
+        through CSS classes as well as attributes, so per-element role
+        attribution is not reliable across the asset tree; the size floor is.
+        """
+        alpha = tag_alpha(tag)
+        if (
+            self.watermark_alpha is not None
+            and alpha is not None
+            and alpha <= self.watermark_alpha
+        ):
+            return False
+        if any(value in sizes for sizes in self.canonical.values()):
+            return False
+        return not any(
+            low <= value <= high and (value * 2) % 1 == 0
+            for _, low, high in self.ranges
+        )
+
+    def violation(self, tag: str, value: float) -> str | None:
+        """Why *value* is off contract on this tag, or None if it is fine."""
+        klass = element_class(tag)
+        alpha = tag_alpha(tag)
+        if (
+            self.watermark_alpha is not None
+            and alpha is not None
+            and alpha <= self.watermark_alpha
+        ):
+            return None
+        if value in self.allowed(klass) or self.excepted(klass, value):
+            return None
+        if klass is None:
+            return (
+                f"font-size={format_size(value)} on text that declares no font; "
+                "a size off the role ramp needs one so its exception can be checked"
+            )
+        sizes = ", ".join(format_size(size) for size in sorted(self.allowed(klass)))
+        return (
+            f"font-size={format_size(value)} on {klass} text, where the role ramp "
+            f"allows {sizes or 'nothing'} and no named exception for that font "
+            "covers it"
+        )
+
+
+def font_sizes(markup: str) -> list[tuple[float, str]]:
+    """Every declared font size in *markup* with the tag it sits on."""
+    found = []
+    for match in FONT_SIZE_RE.finditer(markup):
+        raw = match.group("attr") or match.group("css")
+        found.append((float(raw), enclosing_tag(markup, match.start())))
+    return found
+
+
+SVG_BLOCK_RE = re.compile(r"<svg\b.*?</svg>", re.DOTALL)
+CLASS_ATTR_RE = re.compile(r"""class=["']([^"']+)["']""")
+SELECTOR_CLASS_RE = re.compile(r"\.([A-Za-z0-9_-]+)")
+
+
+def diagram_font_sizes(markup: str) -> list[tuple[float, str]]:
+    """Font sizes that govern diagram type, chrome around the diagram excluded.
+
+    An example page is a diagram wrapped in prose. Attributes inside the `<svg>`
+    count, and so does a CSS rule whose class is worn by an element in there; a
+    rule for the page's own lede or heading does not.
+    """
+    if "<svg" not in markup:
+        return font_sizes(markup)
+
+    spans = [match.span() for match in SVG_BLOCK_RE.finditer(markup)]
+    drawn = set()
+    for start, end in spans:
+        for value in CLASS_ATTR_RE.findall(markup[start:end]):
+            drawn.update(value.split())
+
+    sizes = []
+    for match in FONT_SIZE_RE.finditer(markup):
+        raw = match.group("attr") or match.group("css")
+        inside = any(start <= match.start() < end for start, end in spans)
+        if not inside:
+            if match.group("attr"):
+                continue
+            brace = markup.rfind("{", 0, match.start())
+            if brace < 0:
+                continue
+            selector = markup[max(markup.rfind("}", 0, brace), 0) : brace]
+            if not drawn.intersection(SELECTOR_CLASS_RE.findall(selector)):
+                continue
+        sizes.append((float(raw), enclosing_tag(markup, match.start())))
+    return sizes
+
+
+def read_type_contract(errors: list[str], spec_markdown: str) -> TypeContract | None:
+    """Parse the role ramp and exceptions table; None if the section is missing."""
+    ramp = section(spec_markdown, "### Type ramp per size class")
+    if not ramp:
+        errors.append("output-spec.md has no '### Type ramp per size class' section")
+        return None
+
+    contract = TypeContract()
+    rows = table_rows(ramp)
+    for role in TYPE_RAMP_ROLES:
+        row = next((cells for cells in rows if cells and cells[0].startswith(role)), None)
+        if row is None:
+            errors.append(f"output-spec.md type ramp is missing the {role!r} role row")
+            continue
+        named = font_classes(row[0])
+        if not named:
+            errors.append(
+                f"output-spec.md type ramp row {role!r} does not name its font; "
+                "the role sizes cannot be bound without one"
+            )
+            continue
+        sizes = [cell for cell in row[1:] if re.fullmatch(r"\d+(?:\.\d+)?", cell)]
+        if len(sizes) != 3:
+            errors.append(
+                f"output-spec.md type ramp row {role!r} has {len(sizes)} numeric "
+                "sizes; expected three (standard, presentation, print)"
+            )
+            continue
+        for klass in named:
+            contract.canonical.setdefault(klass, set()).update(float(s) for s in sizes)
+
+    # Scope the size parsing to the exceptions table. The ramp rows above it end
+    # in a bare number too, and reading those as exceptions would let any ramp
+    # value stand in for a missing exceptions table.
+    header = re.search(r"^\|\s*Exception\s*\|", ramp, re.MULTILINE)
+    for cells in table_rows(ramp[header.start() :] if header else ""):
+        if len(cells) < 3:
+            continue
+        label, font_cell, sizes_cell = cells[0], cells[1], cells[-1]
+        if label == "Exception":
+            continue
+        if font_cell.lower() == "any":
+            opacity = WATERMARK_OPACITY_RE.search(label)
+            if opacity:
+                contract.watermark_alpha = float(opacity.group(1))
+            continue
+        named = font_classes(font_cell)
+        if not named:
+            errors.append(
+                f"output-spec.md exception {label!r} names font {font_cell!r}, "
+                "which is not one of the ramp fonts"
+            )
+            continue
+        # A Sizes cell may qualify itself after a comma ("7 to 11, half steps
+        # allowed"); the size itself is the part before it.
+        match = SIZE_RANGE_RE.match(sizes_cell.split(",", 1)[0].strip())
+        if match:
+            low = float(match.group(1))
+            high = float(match.group(2)) if match.group(2) else low
+            for klass in named:
+                contract.ranges.append((klass, low, high))
+    if not contract.ranges:
+        errors.append(
+            "output-spec.md type ramp has no named font-size exceptions table; "
+            "every off-ramp size needs a documented home"
+        )
+    return contract
 
 
 def section(markdown: str, heading: str) -> str:
@@ -563,61 +835,76 @@ def check_type_ramp(errors: list[str], skill_markdown: str, spec_markdown: str) 
                 "for the type ramp"
             )
 
-    ramp = section(spec_markdown, "### Type ramp per size class")
-    if not ramp:
-        errors.append("output-spec.md has no '### Type ramp per size class' section")
+    contract = read_type_contract(errors, spec_markdown)
+    if contract is None:
         return
 
-    rows = table_rows(ramp)
-    canonical: set[float] = set()
-    for role in TYPE_RAMP_ROLES:
-        row = next((cells for cells in rows if cells and cells[0].startswith(role)), None)
-        if row is None:
-            errors.append(f"output-spec.md type ramp is missing the {role!r} role row")
-            continue
-        sizes = [cell for cell in row[1:] if re.fullmatch(r"\d+(?:\.\d+)?", cell)]
-        if len(sizes) != 3:
-            errors.append(
-                f"output-spec.md type ramp row {role!r} has {len(sizes)} numeric "
-                "sizes; expected three (standard, presentation, print)"
-            )
-            continue
-        canonical.update(float(size) for size in sizes)
+    for value, tag in font_sizes(skill_markdown):
+        violation = contract.violation(tag, value)
+        if violation:
+            errors.append(f"SKILL.md uses {violation}")
 
-    # Scope the size parsing to the exceptions table. The ramp rows above it end
-    # in a bare number too, and reading those as exceptions would let any ramp
-    # value stand in for a missing exceptions table.
-    header = re.search(r"^\|\s*Exception\s*\|", ramp, re.MULTILINE)
-    ranges: list[tuple[float, float]] = []
-    for cells in table_rows(ramp[header.start() :] if header else ""):
-        if len(cells) < 2:
+
+def check_legacy_type_sizes(errors: list[str], spec_markdown: str, root: Path) -> None:
+    """The registered legacy sizes match what the shipped files actually carry."""
+    contract = read_type_contract(errors, spec_markdown)
+    if contract is None:
+        return
+
+    registry: dict[str, list[float]] = {}
+    for cells in table_rows(section(spec_markdown, LEGACY_SIZE_HEADING)):
+        if len(cells) < 2 or not cells[0].startswith("`"):
             continue
-        # A Sizes cell may qualify itself after a comma ("7 to 11, half steps
-        # allowed"); the size itself is the part before it.
-        match = SIZE_RANGE_RE.match(cells[-1].split(",", 1)[0].strip())
-        if match:
-            low = float(match.group(1))
-            high = float(match.group(2)) if match.group(2) else low
-            ranges.append((low, high))
-    if not ranges:
+        name = cells[0].strip("`")
+        registry[name] = sorted(float(size) for size in cells[1].split(","))
+    if not registry:
         errors.append(
-            "output-spec.md type ramp has no named font-size exceptions table; "
-            "every off-ramp size needs a documented home"
+            f"output-spec.md has no '{LEGACY_SIZE_HEADING}' table; the shipped "
+            "off-contract sizes need a written home"
         )
+        return
 
-    for raw in sorted(set(FONT_SIZE_RE.findall(skill_markdown)), key=float):
-        value = float(raw)
-        if value in canonical:
+    measured: dict[str, list[float]] = {}
+    for directory, prefixes in TYPE_SIZE_SURFACES:
+        for path in sorted((root / directory).iterdir()):
+            if path.suffix.lower() not in TYPE_SIZE_SUFFIXES:
+                continue
+            if not path.name.startswith(prefixes):
+                continue
+            markup = path.read_text(encoding="utf-8")
+            off = [
+                value
+                for value, tag in diagram_font_sizes(markup)
+                if contract.off_ramp(tag, value)
+            ]
+            if off:
+                measured[f"{path.parent.name}/{path.name}"] = sorted(off)
+
+    for name in sorted(set(registry) | set(measured)):
+        want = registry.get(name)
+        got = measured.get(name)
+        if want == got:
             continue
-        in_exception = any(
-            low <= value <= high and (value * 2) % 1 == 0 for low, high in ranges
-        )
-        if not in_exception:
+        if want is None:
             errors.append(
-                f"SKILL.md uses font-size={format_size(value)}, which is neither a "
-                "canonical role size from the output-spec type ramp nor a half step "
-                "inside a named exception range"
+                f"{name} carries off-contract font sizes "
+                f"{format_sizes(got)} that the registered legacy list in "
+                "output-spec.md does not cover"
             )
+        elif got is None:
+            errors.append(
+                f"output-spec.md registers legacy font sizes {format_sizes(want)} "
+                f"for {name}, which no longer carries any; drop the row"
+            )
+        else:
+            errors.append(
+                f"{name} carries off-contract font sizes {format_sizes(got)} but "
+                f"output-spec.md registers {format_sizes(want)}"
+            )
+
+
+def format_sizes(values: list[float]) -> str:
+    return ", ".join(format_size(value) for value in values)
 
 
 MANIFEST_DESCRIPTIONS = (
@@ -754,6 +1041,9 @@ def main() -> int:
         SKILL.read_text(encoding="utf-8"),
         OUTPUT_SPEC_REFERENCE.read_text(encoding="utf-8"),
     )
+    check_legacy_type_sizes(
+        errors, OUTPUT_SPEC_REFERENCE.read_text(encoding="utf-8"), ROOT
+    )
     check_routing_surfaces(errors, ROOT)
     check_export_font_parity(errors, ROOT)
     if errors:
@@ -766,7 +1056,7 @@ def main() -> int:
         "reference links, asset citations, packaged support files, routing surfaces, "
         "manifest descriptions, Factory install contract, type-count routing, "
         "High-Level invariants, onboarding trust boundary, Line dark-skin contract, "
-        "export font parity, type-ramp contract"
+        "export font parity, type-ramp contract, registered legacy type sizes"
     )
     return 0
 

--- a/scripts/verify-docs-sync.py
+++ b/scripts/verify-docs-sync.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Verify that routing and browsing surfaces stay in sync with the skill.
 
-Ten drift classes, each of which has shipped before:
+Twelve drift classes, each of which has shipped before:
 
 1. The SKILL.md frontmatter description is the only text an agent sees before
    deciding to load the skill — every visual type in the selection table must
@@ -23,6 +23,11 @@ Ten drift classes, each of which has shipped before:
 10. The High-Level reproducibility checklist must agree with its canvas formula
    and retain sequential numbering.
 11. The canonical dark Line example must keep the dark-skin tokens and canvas.
+12. The SKILL.md 4px-grid section and the output-spec type ramp must agree: the
+   grid table carries no font-size row, the grid section links to
+   references/output-spec.md, the ramp table keeps its five type roles across all
+   three presets, and every font-size in SKILL.md's §6 patterns is a canonical
+   role size or falls inside a named exception.
 """
 
 from __future__ import annotations
@@ -41,6 +46,7 @@ README = ROOT / "README.md"
 HIGH_LEVEL_REFERENCE = ROOT / "skills/diagram-design/references/type-high-level.md"
 ONBOARDING_REFERENCE = ROOT / "skills/diagram-design/references/onboarding.md"
 LINE_DARK_EXAMPLE = ROOT / "skills/diagram-design/assets/example-line-dark.html"
+OUTPUT_SPEC_REFERENCE = ROOT / "skills/diagram-design/references/output-spec.md"
 VARIANTS = ("", "-dark", "-full")
 VISUAL_TYPE_COUNT = 40
 AGENT_SKILLS_DESCRIPTION_MAX = 1024
@@ -507,6 +513,113 @@ def check_high_level_reference(errors: list[str], markdown: str) -> None:
         )
 
 
+TYPE_RAMP_ROLES = ("Title", "Node name", "Sublabel", "Arrow label", "Eyebrow / tag")
+FONT_SIZE_RE = re.compile(r'font-size="(\d+(?:\.\d+)?)"')
+SIZE_RANGE_RE = re.compile(r"^(\d+(?:\.\d+)?)(?: to (\d+(?:\.\d+)?))?$")
+
+
+def section(markdown: str, heading: str) -> str:
+    """Text from *heading* to the next `### ` heading, heading excluded."""
+    start = markdown.find(heading)
+    if start < 0:
+        return ""
+    body = markdown[start + len(heading) :]
+    end = re.search(r"^### ", body, re.MULTILINE)
+    return body[: end.start()] if end else body
+
+
+def table_rows(text: str) -> list[list[str]]:
+    """Markdown table rows as cell lists, header and separator rows dropped."""
+    rows: list[list[str]] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        if all(re.fullmatch(r":?-{2,}:?", cell) for cell in cells):
+            continue
+        rows.append(cells)
+    return rows
+
+
+def format_size(value: float) -> str:
+    return f"{value:g}"
+
+
+def check_type_ramp(errors: list[str], skill_markdown: str, spec_markdown: str) -> None:
+    """The grid section and the output-spec role ramp are one contract."""
+    grid = section(skill_markdown, "### 4px grid")
+    if not grid:
+        errors.append("SKILL.md has no '### 4px grid' section")
+    else:
+        if re.search(r"^\|\s*Font sizes", grid, re.MULTILINE):
+            errors.append(
+                "SKILL.md 4px-grid table carries a 'Font sizes' row; type sizes "
+                "belong to the role ramp in references/output-spec.md, not the grid"
+            )
+        if "references/output-spec.md" not in grid:
+            errors.append(
+                "SKILL.md 4px-grid section does not link to references/output-spec.md "
+                "for the type ramp"
+            )
+
+    ramp = section(spec_markdown, "### Type ramp per size class")
+    if not ramp:
+        errors.append("output-spec.md has no '### Type ramp per size class' section")
+        return
+
+    rows = table_rows(ramp)
+    canonical: set[float] = set()
+    for role in TYPE_RAMP_ROLES:
+        row = next((cells for cells in rows if cells and cells[0].startswith(role)), None)
+        if row is None:
+            errors.append(f"output-spec.md type ramp is missing the {role!r} role row")
+            continue
+        sizes = [cell for cell in row[1:] if re.fullmatch(r"\d+(?:\.\d+)?", cell)]
+        if len(sizes) != 3:
+            errors.append(
+                f"output-spec.md type ramp row {role!r} has {len(sizes)} numeric "
+                "sizes; expected three (standard, presentation, print)"
+            )
+            continue
+        canonical.update(float(size) for size in sizes)
+
+    # Scope the size parsing to the exceptions table. The ramp rows above it end
+    # in a bare number too, and reading those as exceptions would let any ramp
+    # value stand in for a missing exceptions table.
+    header = re.search(r"^\|\s*Exception\s*\|", ramp, re.MULTILINE)
+    ranges: list[tuple[float, float]] = []
+    for cells in table_rows(ramp[header.start() :] if header else ""):
+        if len(cells) < 2:
+            continue
+        # A Sizes cell may qualify itself after a comma ("7 to 11, half steps
+        # allowed"); the size itself is the part before it.
+        match = SIZE_RANGE_RE.match(cells[-1].split(",", 1)[0].strip())
+        if match:
+            low = float(match.group(1))
+            high = float(match.group(2)) if match.group(2) else low
+            ranges.append((low, high))
+    if not ranges:
+        errors.append(
+            "output-spec.md type ramp has no named font-size exceptions table; "
+            "every off-ramp size needs a documented home"
+        )
+
+    for raw in sorted(set(FONT_SIZE_RE.findall(skill_markdown)), key=float):
+        value = float(raw)
+        if value in canonical:
+            continue
+        in_exception = any(
+            low <= value <= high and (value * 2) % 1 == 0 for low, high in ranges
+        )
+        if not in_exception:
+            errors.append(
+                f"SKILL.md uses font-size={format_size(value)}, which is neither a "
+                "canonical role size from the output-spec type ramp nor a half step "
+                "inside a named exception range"
+            )
+
+
 MANIFEST_DESCRIPTIONS = (
     (Path(".claude-plugin/plugin.json"), ("description",)),
     (Path(".claude-plugin/marketplace.json"), ("description",)),
@@ -636,6 +749,11 @@ def main() -> int:
         errors, ONBOARDING_REFERENCE.read_text(encoding="utf-8")
     )
     check_line_dark_skin(errors, LINE_DARK_EXAMPLE.read_text(encoding="utf-8"))
+    check_type_ramp(
+        errors,
+        SKILL.read_text(encoding="utf-8"),
+        OUTPUT_SPEC_REFERENCE.read_text(encoding="utf-8"),
+    )
     check_routing_surfaces(errors, ROOT)
     check_export_font_parity(errors, ROOT)
     if errors:
@@ -648,7 +766,7 @@ def main() -> int:
         "reference links, asset citations, packaged support files, routing surfaces, "
         "manifest descriptions, Factory install contract, type-count routing, "
         "High-Level invariants, onboarding trust boundary, Line dark-skin contract, "
-        "export font parity"
+        "export font parity, type-ramp contract"
     )
     return 0
 

--- a/skills/diagram-design/SKILL.md
+++ b/skills/diagram-design/SKILL.md
@@ -349,20 +349,19 @@ Expand SVG `viewBox` height by ~60px.
 
 ### 4px grid
 
-**All values — font sizes, padding, node dimensions, gaps, x/y coords — divisible by 4.** Non-negotiable.
+**Layout geometry, divisible by 4:** x/y coords, node dimensions, gaps, padding. Type sizes and radii use the ramps below, not the grid.
 
 | Category | Allowed values |
 |---|---|
-| Font sizes | 8, 12, 16, 20, 24, 28, 32, 40 |
+| Font sizes | 7, 8, 9, 10, 11, 12, 14, 16, 24, 32, 40 |
 | Node width / height | 80, 96, 112, 120, 128, 140, 144, 160, 180, 200, 240, 320 |
-| x / y coordinates | multiples of 4 |
 | Gap between nodes | 20, 24, 32, 40, 48 |
 | Padding inside boxes | 8, 12, 16 |
 | Border radius | 4, 6, 8 |
 
 Exempt: stroke widths (0.8, 1, 1.2), opacity values, and the 22×22 dot-pattern.
 
-Quick check: if a coordinate ends in 1, 2, 3, 5, 6, 7, 9 — fix it.
+Quick check: any coordinate with a remainder mod 4 is wrong.
 
 ### Complexity budget (per diagram)
 
@@ -489,7 +488,7 @@ Run before producing any diagram.
 - [ ] Legend is a horizontal bottom strip, not floating?
 - [ ] No vertical `writing-mode` text?
 - [ ] `viewBox` expanded for the legend strip (~60px)?
-- [ ] Every font size, coord, width, height, gap divisible by 4?
+- [ ] Layout geometry on the 4px grid, type sizes on the ramp?
 - [ ] From the installed skill directory, did `python3 scripts/self_check.py <file>` pass? (Accessible-SVG contract, single-file safety, motion basics.)
 - [ ] If animated, does the complete static/no-JS frame work, does reduced motion hide/disable playback, and is the controller copied verbatim from `assets/template-motion.html`? From a repository checkout, also run `python3 <repo-root>/scripts/verify-motion.py path/to/generated.html` plus the skin linter; from an installed skill, manually check print and static-query states on top of the self-check.
 

--- a/skills/diagram-design/SKILL.md
+++ b/skills/diagram-design/SKILL.md
@@ -353,7 +353,7 @@ Expand SVG `viewBox` height by ~60px.
 
 | Category | Allowed values |
 |---|---|
-| Font sizes | 7, 8, 9, 10, 11, 12, 14, 16, 24, 32, 40 |
+| Font sizes | 7, 8, 9, 10, 11, 12, 14, 16, 20, 24, 28, 32, 40 |
 | Node width / height | 80, 96, 112, 120, 128, 140, 144, 160, 180, 200, 240, 320 |
 | Gap between nodes | 20, 24, 32, 40, 48 |
 | Padding inside boxes | 8, 12, 16 |

--- a/skills/diagram-design/SKILL.md
+++ b/skills/diagram-design/SKILL.md
@@ -349,19 +349,14 @@ Expand SVG `viewBox` height by ~60px.
 
 ### 4px grid
 
-**Layout geometry, divisible by 4:** x/y coords, node dimensions, gaps, padding. Type sizes and radii use the ramps below, not the grid.
+**Structural geometry, divisible by 4:** node origins, widths, heights, gaps, padding. Off-grid by design: type sizes (role ramp in `references/output-spec.md`), radii, data-derived positions, text baselines, arrow markers, `.5` offsets that keep 1px strokes crisp, stroke widths, opacity, and the 22×22 dot-pattern.
 
 | Category | Allowed values |
 |---|---|
-| Font sizes | 7, 8, 9, 10, 11, 12, 14, 16, 20, 24, 28, 32, 40 |
 | Node width / height | 80, 96, 112, 120, 128, 140, 144, 160, 180, 200, 240, 320 |
 | Gap between nodes | 20, 24, 32, 40, 48 |
 | Padding inside boxes | 8, 12, 16 |
 | Border radius | 4, 6, 8 |
-
-Exempt: stroke widths (0.8, 1, 1.2), opacity values, and the 22×22 dot-pattern.
-
-Quick check: any coordinate with a remainder mod 4 is wrong.
 
 ### Complexity budget (per diagram)
 
@@ -488,7 +483,7 @@ Run before producing any diagram.
 - [ ] Legend is a horizontal bottom strip, not floating?
 - [ ] No vertical `writing-mode` text?
 - [ ] `viewBox` expanded for the legend strip (~60px)?
-- [ ] Layout geometry on the 4px grid, type sizes on the ramp?
+- [ ] Node origins, dimensions, gaps, padding on the 4px grid; type sizes on the role ramp?
 - [ ] From the installed skill directory, did `python3 scripts/self_check.py <file>` pass? (Accessible-SVG contract, single-file safety, motion basics.)
 - [ ] If animated, does the complete static/no-JS frame work, does reduced motion hide/disable playback, and is the controller copied verbatim from `assets/template-motion.html`? From a repository checkout, also run `python3 <repo-root>/scripts/verify-motion.py path/to/generated.html` plus the skin linter; from an installed skill, manually check print and static-query states on top of the self-check.
 

--- a/skills/diagram-design/references/output-spec.md
+++ b/skills/diagram-design/references/output-spec.md
@@ -71,6 +71,16 @@ Node names shrink relative to the canvas as it grows — resist that. Scale the 
 | Node box min height | 48 | 64 | 48 |
 | Min gap between nodes | 24 | 40 | 24 |
 
+Every `font-size` is one of the role values above for the preset in use, or one of these named exceptions:
+
+| Exception | Sizes |
+|---|---|
+| Dense annotation: legend keys, axis ticks, chart data labels, source lines, in-box tags (Geist Mono) | 7 to 11, half steps allowed |
+| Group or entity heading (Geist 600) | 14 |
+| Decorative watermark numerals at or under 0.08 opacity | any |
+
+Anything else is a bug in the diagram, not a new size.
+
 Presentation ramp implies fewer nodes — 16px names in 64px boxes eat the canvas. If a `slide-16x9` layout won't fit, that's the size dial telling you the detail dial is set too high; drop a level rather than shrinking the type.
 
 ### Safe areas

--- a/skills/diagram-design/references/output-spec.md
+++ b/skills/diagram-design/references/output-spec.md
@@ -76,34 +76,38 @@ Every `font-size` is one of the role values above for the preset in use, or one 
 | Exception | Font | Sizes |
 |---|---|---|
 | Dense annotation: legend keys, axis ticks, chart data labels, source lines, in-box tags | Geist Mono or Geist regular | 7 to 11, half steps allowed |
+| Chart series or row name: bar category, line or bump series, gantt row, matrix header | Geist 600 | 10 to 11 |
 | Group or entity heading | Geist 600 | 14 |
 | Decorative watermark numerals at or under 0.08 opacity | any | any |
 
-An exception is bound to the font beside it, weight included: Geist at 600 or heavier is the node-name voice, lighter Geist is annotation. So a Geist 600 node name cannot borrow the dense-annotation range, and a Geist Mono tick cannot borrow the 14 reserved for headings.
+An exception is bound to the font beside it, weight included: Geist at 600 or heavier is the node-name voice, lighter Geist is annotation. So a Geist 600 node name cannot borrow the dense-annotation range down to 7, and a Geist Mono tick cannot borrow the 14 reserved for headings. A chart row carries a name in the same Geist 600 voice at a rank the ramp has no row for, which is why it has an exception of its own rather than a licence to shrink: `type-bar.md`, `type-gantt.md` and `type-line.md` all set that name at 10 or 11.
 
 Anything else is a bug in the diagram, not a new size. The one standing carve-out is the closed inventory below.
 
 ### Registered legacy sizes
 
-Twenty-one declared sizes across thirteen files predate this contract. They are recorded here so the rule above is exact rather than aspirational, and frozen so the list cannot quietly grow. `scripts/verify-docs-sync.py` reads these rows against the files and fails if one gains an off-ramp size, loses one, or drops off disk.
+Thirty-three declared sizes across sixteen files predate this contract. They are recorded here so the rule above is exact rather than aspirational, and frozen so the list cannot quietly grow. `scripts/verify-docs-sync.py` reads these rows against the files and fails if one gains an off-ramp size, loses one, or drops off disk.
 
-That sweep matches on size alone, not on role. Shipped examples set type through CSS classes as well as attributes, so attributing every element to a role across the whole tree is not reliable; the size floor is. It reads the `<svg>` and any CSS rule worn by an element inside it, so the prose around a diagram does not count as diagram type.
+Each is registered against the font carrying it, because that is what the sweep checks. It classifies every element first, resolving `class` attributes through the stylesheet, `var(--font-mono)` back to the family it names, and a `{node-name}` token to the ramp row that owns it, then applies only the exceptions open to that font. The canonical role sizes stay one union, so a size on the ramp for any role is on contract wherever it appears. An element whose font it cannot read gets no exception at all. It reads the `<svg>` and any CSS rule worn by an element inside it, so the prose around a diagram does not count as diagram type.
 
 | File | Sizes | What they are |
 |---|---|---|
-| `assets/example-data-flow.html` | 5, 6 | chip text and role label, both set in CSS |
-| `assets/example-data-flow-dark.html` | 5, 6 | chip text and role label, both set in CSS |
-| `assets/example-data-flow-full.html` | 5, 6 | chip text and role label, both set in CSS |
-| `assets/example-paved-road-animated.html` | 13 | boundary node name |
-| `assets/example-process.html` | 6 | role chip |
-| `assets/example-process-dark.html` | 6 | role chip |
-| `assets/example-process-full.html` | 6 | role chip |
-| `assets/example-quadrant-consultant.html` | 13 | inline dot glyph in a `tspan` |
-| `assets/example-queue-animated.html` | 13, 22, 24 | state caption and two fill counters |
-| `assets/example-treemap.html` | 13, 13 | cell names |
-| `assets/example-treemap-dark.html` | 13, 13 | cell names |
-| `assets/example-treemap-full.html` | 13, 13 | cell names |
-| `references/type-treemap.md` | 13 | the cell-name line of the documented pattern |
+| `assets/example-data-flow.html` | Geist Mono 5, Geist Mono 6 | chip text and role label, both set in CSS |
+| `assets/example-data-flow-dark.html` | Geist Mono 5, Geist Mono 6 | chip text and role label, both set in CSS |
+| `assets/example-data-flow-full.html` | Geist Mono 5, Geist Mono 6 | chip text and role label, both set in CSS |
+| `assets/example-nested.html` | Instrument Serif 14, Instrument Serif 14 | two italic serif asides |
+| `assets/example-nested-dark.html` | Instrument Serif 14, Instrument Serif 14 | two italic serif asides |
+| `assets/example-nested-full.html` | Instrument Serif 14, Instrument Serif 14 | two italic serif asides |
+| `assets/example-paved-road-animated.html` | Geist 600 13 | boundary node name |
+| `assets/example-process.html` | Geist Mono 6 | role chip |
+| `assets/example-process-dark.html` | Geist Mono 6 | role chip |
+| `assets/example-process-full.html` | Geist Mono 6 | role chip |
+| `assets/example-quadrant-consultant.html` | Geist 600 13 | inline dot glyph in a `tspan` |
+| `assets/example-queue-animated.html` | Geist 600 13, Geist 600 22, Geist 600 24 | state caption and two fill counters |
+| `assets/example-treemap.html` | Geist 600 7, Geist 600 7, Geist 600 13, Geist 600 13 | two cell index glyphs and two cell names |
+| `assets/example-treemap-dark.html` | Geist 600 7, Geist 600 7, Geist 600 13, Geist 600 13 | two cell index glyphs and two cell names |
+| `assets/example-treemap-full.html` | Geist 600 7, Geist 600 7, Geist 600 13, Geist 600 13 | two cell index glyphs and two cell names |
+| `references/type-treemap.md` | Geist 600 13 | the cell-name line of the documented pattern |
 
 New diagrams get no rows here. Bringing one of these onto the ramp is a visual change to a shipped example and belongs in its own PR.
 

--- a/skills/diagram-design/references/output-spec.md
+++ b/skills/diagram-design/references/output-spec.md
@@ -73,13 +73,39 @@ Node names shrink relative to the canvas as it grows — resist that. Scale the 
 
 Every `font-size` is one of the role values above for the preset in use, or one of these named exceptions:
 
-| Exception | Sizes |
-|---|---|
-| Dense annotation: legend keys, axis ticks, chart data labels, source lines, in-box tags (Geist Mono) | 7 to 11, half steps allowed |
-| Group or entity heading (Geist 600) | 14 |
-| Decorative watermark numerals at or under 0.08 opacity | any |
+| Exception | Font | Sizes |
+|---|---|---|
+| Dense annotation: legend keys, axis ticks, chart data labels, source lines, in-box tags | Geist Mono or Geist regular | 7 to 11, half steps allowed |
+| Group or entity heading | Geist 600 | 14 |
+| Decorative watermark numerals at or under 0.08 opacity | any | any |
 
-Anything else is a bug in the diagram, not a new size.
+An exception is bound to the font beside it, weight included: Geist at 600 or heavier is the node-name voice, lighter Geist is annotation. So a Geist 600 node name cannot borrow the dense-annotation range, and a Geist Mono tick cannot borrow the 14 reserved for headings.
+
+Anything else is a bug in the diagram, not a new size. The one standing carve-out is the closed inventory below.
+
+### Registered legacy sizes
+
+Twenty-one declared sizes across thirteen files predate this contract. They are recorded here so the rule above is exact rather than aspirational, and frozen so the list cannot quietly grow. `scripts/verify-docs-sync.py` reads these rows against the files and fails if one gains an off-ramp size, loses one, or drops off disk.
+
+That sweep matches on size alone, not on role. Shipped examples set type through CSS classes as well as attributes, so attributing every element to a role across the whole tree is not reliable; the size floor is. It reads the `<svg>` and any CSS rule worn by an element inside it, so the prose around a diagram does not count as diagram type.
+
+| File | Sizes | What they are |
+|---|---|---|
+| `assets/example-data-flow.html` | 5, 6 | chip text and role label, both set in CSS |
+| `assets/example-data-flow-dark.html` | 5, 6 | chip text and role label, both set in CSS |
+| `assets/example-data-flow-full.html` | 5, 6 | chip text and role label, both set in CSS |
+| `assets/example-paved-road-animated.html` | 13 | boundary node name |
+| `assets/example-process.html` | 6 | role chip |
+| `assets/example-process-dark.html` | 6 | role chip |
+| `assets/example-process-full.html` | 6 | role chip |
+| `assets/example-quadrant-consultant.html` | 13 | inline dot glyph in a `tspan` |
+| `assets/example-queue-animated.html` | 13, 22, 24 | state caption and two fill counters |
+| `assets/example-treemap.html` | 13, 13 | cell names |
+| `assets/example-treemap-dark.html` | 13, 13 | cell names |
+| `assets/example-treemap-full.html` | 13, 13 | cell names |
+| `references/type-treemap.md` | 13 | the cell-name line of the documented pattern |
+
+New diagrams get no rows here. Bringing one of these onto the ramp is a visual change to a shipped example and belongs in its own PR.
 
 Presentation ramp implies fewer nodes — 16px names in 64px boxes eat the canvas. If a `slide-16x9` layout won't fit, that's the size dial telling you the detail dial is set too high; drop a level rather than shrinking the type.
 


### PR DESCRIPTION
for #181 .

§7 called "divisible by 4" non-negotiable while §6 specifies `font-size="7"` , `font-size="9"` and `rx="6"` , so §7 is the part that is wrong . this changes §7 , not the assets .

- the grid rule now covers layout geometry only , so x/y coords , node dimensions , gaps , padding
- font sizes get a ramp of 7, 8, 9, 10, 11, 12, 14, 16, 24, 32, 40 , what §5 , §6 and the assets already use . 19 stragglers across 12 files , all one offs
- radius stays 4, 6, 8 and is no longer claimed to be on the grid
- the quick check was arithmetically wrong , replaced with a remainder check
- §9's checklist line reworded , it asked for something no diagram built from §6 can confirm

not fixed: 3,727 x/y coords across 130 files are still off grid . that needs a `verify-grid.py` plus either 130 file edits or a baseline , so it is a separate call .

`SKILL.md` is 39,993 bytes , under the 40,000 cap . all 47 gates green locally , no manifest versions touched .

closes #181

