### PR TITLE
feat: host-aware install doctor for Playwright, Cowork, marketplace, and Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,12 @@ Kiro copies imported skills into `.kiro/skills/` for a workspace or `~/.kiro/ski
 
 > **One-time migration:** an existing standalone `npx skills add` copy will not start following the Codex marketplace automatically. Remove that standalone copy, then use the Codex marketplace commands above. Likewise, uninstall a personal Cowork copy and reinstall Diagram Design from your organization's marketplace. Future marketplace version bumps then flow through each client's native update path.
 
+### Troubleshooting an install
+
+If PNG export silently fails or the skill won't load after installing, run the doctor: `/diagram-design:doctor` in Claude Code or Codex, `/doctor` in Pi, or ask `run diagram-design doctor` in any host. It is read-only — it never installs packages or edits files — and prints a one-shot `Next actions` list.
+
+The doctor is host-aware. It auto-detects the host it runs under, or you can force a profile with `--host claude-code|cowork|codex|cursor|pi`. Beyond the Python and Playwright+Chromium checks for PNG export, it detects how Diagram Design was installed (marketplace, git, or copied) and prints the matching update or reinstall recipe from this section; advises confirming the active marketplace plugin version against the installed `SKILL.md` `metadata.version`; warns when a Pi git install tracks an unpinned branch; and, under Cowork, checks that the install goes through a private organization mirror rather than the public repository. Add `--strict` to turn warnings into a failing exit and `--json` for a machine-readable report. The full contract lives in [`references/doctor.md`](skills/diagram-design/references/doctor.md).
+
 ### Editable install
 
 Managed installs are convenient, but changes to `references/style-guide.md` may be replaced by package updates. Saved profiles in `~/.diagram-design/profiles/` survive updates, and projects with a `.diagram-design` marker are unaffected. Clone the repo and install the local path if you plan to customize the working style guide directly:

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -1,6 +1,6 @@
 ---
 description: Run one-shot environment diagnostics for Diagram Design readiness
-argument-hint: "[--strict] [--json]"
+argument-hint: "[--strict] [--json] [--host claude-code|cowork|codex|cursor|pi|auto]"
 allowed-tools:
   - Read
   - Bash
@@ -13,7 +13,7 @@ Full argument string: `$ARGUMENTS`
 
 ## Required behavior
 
-1. Locate and apply the exact checks and output contract from `references/doctor.md`.
+1. Locate and apply the exact checks and output contract from `references/doctor.md`, including host-profile and install-channel resolution (`--host`, default `auto`) and the host-specific checks for marketplace version alignment, Pi pinning, and the Cowork organization mirror.
 2. Keep this command read-only: do not install dependencies, do not edit files, and do not run destructive git operations.
 3. If a check command fails, capture stderr, mark the check `warn` or `fail` per the reference, and continue remaining checks.
 4. Print the compact summary line plus per-check statuses, and include `Next actions` only when needed.

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -90,7 +90,7 @@ Pi still registers the **repo root**: `pi install <clone-path>`.
 
 Ask in any host: `run diagram-design doctor` or `/diagram-design:doctor` / `/doctor`.
 
-The procedure is [`references/doctor.md`](../skills/diagram-design/references/doctor.md). It must not install packages. Typical local setup for PNG export:
+The procedure is [`references/doctor.md`](../skills/diagram-design/references/doctor.md). It must not install packages. The doctor auto-detects the host profile and install channel; pass `--host claude-code|cowork|codex|cursor|pi` to force a profile when detection is ambiguous (for example, diagnosing a Cowork mirror or a Pi unpinned-ref install from outside that host). Typical local setup for PNG export:
 
 ```bash
 python -m pip install playwright

--- a/prompts/doctor.md
+++ b/prompts/doctor.md
@@ -1,6 +1,6 @@
 ---
 description: Run one-shot environment diagnostics for Diagram Design readiness
-argument-hint: "[--strict] [--json]"
+argument-hint: "[--strict] [--json] [--host claude-code|cowork|codex|cursor|pi|auto]"
 ---
 
 Run environment diagnostics for Diagram Design. Locate the available `diagram-design` skill using its `SKILL.md` path advertised by Pi. Read that `SKILL.md`, then read `references/doctor.md` relative to its directory. Treat that reference as the source of truth. Do not assume the package lives under the current working directory.
@@ -9,7 +9,7 @@ Full argument string: `$ARGUMENTS`
 
 ## Required behavior
 
-1. Run the exact checks and output contract defined in `references/doctor.md`.
+1. Run the exact checks and output contract defined in `references/doctor.md`, including host-profile and install-channel resolution (`--host`, default `auto`; under Pi prefer `--host pi` when detection is ambiguous) and the host-specific checks for marketplace version alignment, Pi install pinning, and the Cowork organization mirror.
 2. Keep diagnostics read-only: do not install dependencies, do not edit files, and do not run destructive git commands.
 3. If a check command fails, capture stderr, classify as `warn` or `fail` per the reference, and continue remaining checks.
 4. Print the summary line plus per-check statuses, and include `Next actions` only when warn/fail exists.

--- a/scripts/test-verify-doctor.py
+++ b/scripts/test-verify-doctor.py
@@ -200,6 +200,122 @@ def main() -> int:
             if python_cmd is not None:
                 raise AssertionError(f"expected no python command, got {python_cmd!r}")
         print("OK: an empty PATH fails without naming a command")
+        host, evidence = verify.detect_host(installed_root, environ={"CLAUDECODE": "1"})
+        if host != "claude-code" or "CLAUDECODE" not in evidence:
+            raise AssertionError(f"expected claude-code from env marker; got {host} ({evidence})")
+        host, _ = verify.detect_host(
+            installed_root, environ={"COWORK_SESSION_ID": "abc", "CLAUDECODE": "1"}
+        )
+        if host != "cowork":
+            raise AssertionError(f"cowork markers must outrank claude-code; got {host}")
+        host, evidence = verify.detect_host(
+            root / ".cursor" / "skills" / "diagram-design", environ={}
+        )
+        if host != "cursor":
+            raise AssertionError(f"expected cursor from path hint; got {host} ({evidence})")
+        host, _ = verify.detect_host(installed_root, environ={})
+        if host is not None:
+            raise AssertionError(f"expected unknown host without markers; got {host}")
+        print("OK: host detection honors env markers, precedence, and path hints")
+
+        channel, _ = verify.detect_install_channel(root)
+        if channel != verify.CHANNEL_MAINTAINER:
+            raise AssertionError(f"seeded repo should be maintainer-checkout; got {channel}")
+        git_root = root / "git-install"
+        touch(git_root / "SKILL.md", "# Installed skill\n")
+        (git_root / ".git").mkdir(parents=True)
+        channel, _ = verify.detect_install_channel(git_root)
+        if channel != verify.CHANNEL_GIT:
+            raise AssertionError(f"git metadata should classify as git channel; got {channel}")
+        marketplace_root = root / "plugins" / "diagram-design"
+        touch(marketplace_root / "SKILL.md", '# Skill\nmetadata:\n  version: "2.6"\n')
+        channel, _ = verify.detect_install_channel(marketplace_root)
+        if channel != verify.CHANNEL_MARKETPLACE:
+            raise AssertionError(f"plugin cache path should classify as marketplace; got {channel}")
+        channel, _ = verify.detect_install_channel(installed_root)
+        if channel != verify.CHANNEL_COPIED:
+            raise AssertionError(f"plain copy should classify as copied; got {channel}")
+        print("OK: install channel detection covers maintainer/git/marketplace/copied")
+
+        for host_name, channel_name, needle in (
+            ("pi", verify.CHANNEL_GIT, "pi update --extensions"),
+            ("cowork", verify.CHANNEL_MARKETPLACE, "mirror"),
+            ("codex", verify.CHANNEL_MARKETPLACE, "codex plugin marketplace upgrade"),
+            ("claude-code", verify.CHANNEL_MARKETPLACE, "/plugin install diagram-design@diagram-design"),
+            ("cursor", verify.CHANNEL_COPIED, "newer checkout"),
+        ):
+            recipe = verify.update_recipe(host_name, channel_name)
+            if needle not in recipe:
+                raise AssertionError(
+                    f"update recipe for ({host_name}, {channel_name}) missing {needle!r}: {recipe}"
+                )
+        print("OK: update recipes match each host/channel pair")
+
+        fix = verify.playwright_fix(None, None)
+        if fix != verify.PLAYWRIGHT_INSTALL_HINT:
+            raise AssertionError(f"bare playwright fix must stay copy-pastable: {fix}")
+        fix = verify.playwright_fix("claude-code", verify.CHANNEL_MARKETPLACE)
+        for needle in (verify.PLAYWRIGHT_INSTALL_HINT, "/reload-plugins", "restart the"):
+            if needle not in fix:
+                raise AssertionError(f"host-aware playwright fix missing {needle!r}: {fix}")
+        print("OK: playwright fix stays copy-pastable and gains host-specific one-shot hints")
+
+        check = verify.check_marketplace_version(marketplace_root, "claude-code", verify.CHANNEL_MARKETPLACE)
+        expect_status(check, verify.PASS, "metadata.version is 2.6")
+        versionless_root = root / "plugins" / "versionless"
+        touch(versionless_root / "SKILL.md", "# Skill without metadata\n")
+        check = verify.check_marketplace_version(
+            versionless_root, "claude-code", verify.CHANNEL_MARKETPLACE
+        )
+        expect_status(check, verify.WARN, "metadata.version")
+        check = verify.check_marketplace_version(root, None, verify.CHANNEL_MAINTAINER)
+        expect_status(check, verify.PASS, "not applicable")
+        print("OK: marketplace version alignment advises, warns on unreadable metadata, and skips non-marketplace")
+
+        touch(git_root / ".git" / "HEAD", "ref: refs/heads/main\n")
+        check = verify.check_pi_install_pinning(git_root, "pi", verify.CHANNEL_GIT)
+        expect_status(check, verify.WARN, "unpinned git branch")
+        touch(git_root / ".git" / "HEAD", "0123456789abcdef0123456789abcdef01234567\n")
+        check = verify.check_pi_install_pinning(git_root, "pi", verify.CHANNEL_GIT)
+        expect_status(check, verify.PASS, "pinned")
+        check = verify.check_pi_install_pinning(git_root, "claude-code", verify.CHANNEL_GIT)
+        expect_status(check, verify.PASS, "not pi")
+        check = verify.check_pi_install_pinning(marketplace_root, "pi", verify.CHANNEL_MARKETPLACE)
+        expect_status(check, verify.PASS, "not applicable")
+        print("OK: Pi pinning warns on branch refs and passes on pinned or non-git installs")
+
+        missing_skill_root = root / "cowork-broken"
+        missing_skill_root.mkdir()
+        check = verify.check_cowork_mirror(missing_skill_root, "cowork", verify.CHANNEL_COPIED)
+        expect_status(check, verify.FAIL, "private or internal mirror")
+        touch(
+            git_root / ".git" / "config",
+            "[remote \"origin\"]\n\turl = https://github.com/cathrynlavery/diagram-design\n",
+        )
+        check = verify.check_cowork_mirror(git_root, "cowork", verify.CHANNEL_GIT)
+        expect_status(check, verify.WARN, "public repository")
+        check = verify.check_cowork_mirror(marketplace_root, "cowork", verify.CHANNEL_MARKETPLACE)
+        expect_status(check, verify.PASS, "resolves under Cowork")
+        check = verify.check_cowork_mirror(missing_skill_root, None, verify.CHANNEL_COPIED)
+        expect_status(check, verify.PASS, "not cowork")
+        print("OK: Cowork mirror check fails without skill resolution and warns on public-repo remotes")
+
+        check = verify.check_common_path_mistakes(
+            missing_skill_root, unrelated_project, "claude-code", verify.CHANNEL_MARKETPLACE
+        )
+        if check.status != verify.WARN or "/plugin install diagram-design@diagram-design" not in (check.fix or ""):
+            raise AssertionError(
+                f"missing skill after marketplace install must print the reinstall recipe: {check}"
+            )
+        print("OK: missing skill after a marketplace install prints the one-shot reinstall recipe")
+
+        args = verify.parse_args(["--host", "pi", "--strict"])
+        if args.host != "pi" or not args.strict:
+            raise AssertionError(f"--host parsing failed: {args}")
+        args = verify.parse_args([])
+        if args.host != verify.AUTO_HOST:
+            raise AssertionError(f"default host must be auto; got {args.host}")
+        print("OK: --host flag parses and defaults to auto")
 
         summary_checks = [
             verify.CheckResult("a", verify.PASS, "ok"),

--- a/scripts/test-verify-doctor.py
+++ b/scripts/test-verify-doctor.py
@@ -9,6 +9,7 @@ import io
 import sys
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parent.parent
 VERIFY = ROOT / "scripts" / "verify-doctor.py"
@@ -66,6 +67,58 @@ def expect_status(check, status: str, needle: str) -> None:
         raise AssertionError(
             f"expected ({status}, contains {needle!r}); got ({check.status}, {check.message!r})"
         )
+
+
+def check_full_git_installs(verify, root: Path) -> None:
+    for name, host_arg, environ, expected_channel in (
+        ("pi-explicit", "pi", {}, verify.CHANNEL_GIT),
+        ("pi-env", verify.AUTO_HOST, {"PI_SESSION_ID": "test"}, verify.CHANNEL_GIT),
+        (".pi/agent/git/diagram-design", verify.AUTO_HOST, {}, verify.CHANNEL_GIT),
+        ("maintainer", verify.AUTO_HOST, {}, verify.CHANNEL_MAINTAINER),
+    ):
+        install_root = root / name
+        seed_repo(verify, install_root)
+        for head in ("ref: refs/heads/main", "0123456789abcdef0123456789abcdef01234567"):
+            touch(install_root / ".git/HEAD", head + "\n")
+            # Isolate machine readiness while exercising host resolution, channel
+            # detection, pinning, and reporting together on a full repository.
+            report = io.StringIO()
+            with (
+                patch.dict(verify.os.environ, environ, clear=True),
+                patch.object(
+                    verify, "check_python_runtime",
+                    return_value=(verify.CheckResult("Python", verify.PASS, "ready"), "python3"),
+                ),
+                patch.object(
+                    verify, "check_playwright",
+                    return_value=verify.CheckResult("Playwright", verify.PASS, "ready"),
+                ),
+                contextlib.redirect_stdout(report),
+            ):
+                exit_code = verify.run_doctor(
+                    install_root, install_root, strict=True, emit_json=True, host_arg=host_arg
+                )
+            output = report.getvalue()
+            is_pi = expected_channel == verify.CHANNEL_GIT
+            unpinned = head.startswith("ref:")
+            expected_exit = 1 if is_pi and unpinned else 0
+            if exit_code != expected_exit:
+                raise AssertionError(f"{name}: expected exit {expected_exit}; got {exit_code}: {output}")
+            needles = [f'"install_channel": "{expected_channel}"']
+            if is_pi:
+                needles.extend([
+                    '"host": "pi"',
+                    "pi update --extensions",
+                    "unpinned git branch" if unpinned else "pinned to a fixed git ref",
+                ])
+                if "git pull" in output or "unpinned-ref check is not applicable" in output:
+                    raise AssertionError(f"{name}: Pi install received maintainer guidance: {output}")
+            else:
+                needles.extend(["git pull", "Host profile is not pi"])
+            for needle in needles:
+                if needle not in output:
+                    raise AssertionError(f"{name}: report missing {needle!r}: {output}")
+    print("OK: full Pi Git installs honor explicit/env/path host context; maintainer checkouts stay distinct")
 
 
 def main() -> int:
@@ -236,6 +289,7 @@ def main() -> int:
         if channel != verify.CHANNEL_COPIED:
             raise AssertionError(f"plain copy should classify as copied; got {channel}")
         print("OK: install channel detection covers maintainer/git/marketplace/copied")
+        check_full_git_installs(verify, root)
 
         for host_name, channel_name, needle in (
             ("pi", verify.CHANNEL_GIT, "pi update --extensions"),

--- a/scripts/verify-doctor.py
+++ b/scripts/verify-doctor.py
@@ -331,8 +331,11 @@ def detect_host(root: Path, environ: dict[str, str] | None = None) -> tuple[str 
     return None, "no host markers detected; pass --host to select a profile"
 
 
-def detect_install_channel(root: Path) -> tuple[str, str]:
+def detect_install_channel(root: Path, host: str | None = None) -> tuple[str, str]:
     """Classify how this installation arrived: maintainer checkout, git, marketplace, or copy."""
+    # Pi Git packages contain the full repository, including maintainer markers.
+    if host == "pi" and (root / ".git").exists():
+        return CHANNEL_GIT, "Pi host profile and .git metadata at the installation root"
     if is_maintainer_checkout(root):
         return CHANNEL_MAINTAINER, "maintainer repository markers are present"
     if (root / ".git").exists():
@@ -783,7 +786,7 @@ def run_doctor(
         host, host_evidence = detect_host(root)
     else:
         host, host_evidence = host_arg, "selected via --host"
-    channel, channel_evidence = detect_install_channel(root)
+    channel, channel_evidence = detect_install_channel(root, host)
 
     checks: list[CheckResult] = []
 

--- a/scripts/verify-doctor.py
+++ b/scripts/verify-doctor.py
@@ -11,6 +11,7 @@ import argparse
 import json
 import os
 import platform
+import re
 import shutil
 import subprocess
 import sys
@@ -26,6 +27,62 @@ MAINTAINER_MARKERS = (
     Path(".github/workflows/ci.yml"),
     Path("scripts/verify-plugin-package.py"),
 )
+
+HOST_PROFILES = ("claude-code", "cowork", "codex", "cursor", "pi")
+AUTO_HOST = "auto"
+
+PUBLIC_REPO_SLUG = "cathrynlavery/diagram-design"
+
+# Ordered: Cowork first because Cowork sessions can also carry Claude Code markers.
+HOST_ENV_MARKERS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("cowork", ("COWORK_SESSION_ID", "CLAUDE_COWORK_SESSION")),
+    ("claude-code", ("CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT")),
+    ("cursor", ("CURSOR_AGENT", "CURSOR_TRACE_ID")),
+    ("codex", ("CODEX_HOME", "CODEX_SANDBOX")),
+    ("pi", ("PI_SESSION_ID", "PI_HOME")),
+)
+
+HOST_PATH_HINTS: tuple[tuple[str, str], ...] = (
+    ("cowork", "cowork"),
+    ("claude-code", ".claude"),
+    ("codex", ".codex"),
+    ("cursor", ".cursor"),
+    ("pi", ".pi"),
+)
+
+CHANNEL_MAINTAINER = "maintainer-checkout"
+CHANNEL_GIT = "git"
+CHANNEL_MARKETPLACE = "marketplace"
+CHANNEL_COPIED = "copied"
+
+MARKETPLACE_PATH_SEGMENTS = frozenset(
+    {"plugins", "plugin-cache", "marketplace", "marketplaces"}
+)
+
+SKILL_VERSION_PATTERN = re.compile(
+    r'^\s*version:\s*"?([0-9][0-9A-Za-z.\-]*)"?\s*$', re.MULTILINE
+)
+
+PLAYWRIGHT_INSTALL_HINT = "pip install playwright && playwright install chromium"
+
+HOST_PLAYWRIGHT_HINTS = {
+    "claude-code": (
+        "Run it in the same Python environment Claude Code invokes, then run "
+        "/reload-plugins so the session picks it up."
+    ),
+    "cowork": (
+        "Install inside the Cowork session environment; sandboxed sessions do not "
+        "see packages installed on the host machine."
+    ),
+    "codex": "Run it in the Codex workspace environment, then start a new session.",
+    "cursor": (
+        "Run it in the Cursor agent terminal so the interpreter matches the one "
+        "used for PNG export."
+    ),
+    "pi": (
+        "Run it in the interpreter Pi uses, then run /reload in the open session."
+    ),
+}
 
 EXPECTED_SCRIPTS = (
     Path("scripts/verify-drawio-import.py"),
@@ -190,13 +247,33 @@ def check_python_runtime() -> tuple[CheckResult, str | None]:
     )
 
 
-def check_playwright(python_cmd: str | None) -> CheckResult:
+def playwright_fix(host: str | None = None, channel: str | None = None) -> str:
+    """Compose the one-shot Playwright remediation for the resolved host/channel."""
+    hints: list[str] = []
+    host_hint = HOST_PLAYWRIGHT_HINTS.get(host or "")
+    if host_hint:
+        hints.append(host_hint)
+    if channel == CHANNEL_MARKETPLACE:
+        hints.append(
+            "If PNG export still fails after a marketplace install, restart the "
+            "session so the host reloads the plugin environment."
+        )
+    if not hints:
+        return PLAYWRIGHT_INSTALL_HINT
+    return f"{PLAYWRIGHT_INSTALL_HINT} ({' '.join(hints)})"
+
+
+def check_playwright(
+    python_cmd: str | None,
+    host: str | None = None,
+    channel: str | None = None,
+) -> CheckResult:
     if python_cmd is None:
         return CheckResult(
             name="Playwright PNG export readiness",
             status=FAIL,
             message="Playwright check skipped because no Python command was available.",
-            fix="Resolve Python first; then install with: pip install playwright && playwright install chromium",
+            fix="Resolve Python first; then install with: " + playwright_fix(host, channel),
         )
 
     import_probe = run_command([python_cmd, "-c", "import playwright; print(playwright.__version__)"])
@@ -205,7 +282,7 @@ def check_playwright(python_cmd: str | None) -> CheckResult:
             name="Playwright PNG export readiness",
             status=WARN,
             message="Playwright package is not available in the active Python interpreter.",
-            fix="pip install playwright && playwright install chromium",
+            fix=playwright_fix(host, channel),
         )
 
     chromium_probe = run_command(
@@ -234,7 +311,280 @@ def check_playwright(python_cmd: str | None) -> CheckResult:
         name="Playwright PNG export readiness",
         status=WARN,
         message=f"Playwright is installed but Chromium is not ready: {detail}",
-        fix="pip install playwright && playwright install chromium",
+        fix=playwright_fix(host, channel),
+    )
+
+
+def detect_host(root: Path, environ: dict[str, str] | None = None) -> tuple[str | None, str]:
+    """Best-effort host detection from environment markers, then install path."""
+    env = os.environ if environ is None else environ
+    for host, markers in HOST_ENV_MARKERS:
+        for marker in markers:
+            if env.get(marker):
+                return host, f"environment variable {marker} is set"
+
+    segments = [part.lower() for part in root.resolve().parts]
+    for host, hint in HOST_PATH_HINTS:
+        if any(hint in segment for segment in segments):
+            return host, f"installation path contains {hint!r}"
+
+    return None, "no host markers detected; pass --host to select a profile"
+
+
+def detect_install_channel(root: Path) -> tuple[str, str]:
+    """Classify how this installation arrived: maintainer checkout, git, marketplace, or copy."""
+    if is_maintainer_checkout(root):
+        return CHANNEL_MAINTAINER, "maintainer repository markers are present"
+    if (root / ".git").exists():
+        return CHANNEL_GIT, ".git metadata is present at the installation root"
+    segments = {part.lower() for part in root.resolve().parts}
+    marketplace_hits = sorted(segments & MARKETPLACE_PATH_SEGMENTS)
+    if marketplace_hits:
+        return (
+            CHANNEL_MARKETPLACE,
+            f"installation path contains marketplace cache segment {marketplace_hits[0]!r}",
+        )
+    return CHANNEL_COPIED, "no git metadata or marketplace cache path detected"
+
+
+def update_recipe(host: str | None, channel: str | None) -> str:
+    """Return the copy-pastable update/reinstall recipe for the resolved host/channel."""
+    if channel == CHANNEL_MAINTAINER:
+        return (
+            "Maintainer checkout: update with `git pull` and re-run the "
+            "CONTRIBUTING validation gates."
+        )
+    if channel == CHANNEL_MARKETPLACE:
+        if host == "cowork":
+            return (
+                "Cowork updates flow through your organization's private mirror: "
+                "merge a plugin version-bump PR to the mirror's default branch to "
+                "trigger sync, then reinstall from the organization marketplace if "
+                "the plugin is missing (README: Install -> Claude Cowork)."
+            )
+        if host == "codex":
+            return (
+                "Update with: codex plugin marketplace upgrade diagram-design, "
+                "then start a new session."
+            )
+        return (
+            "Update via /plugin -> Marketplaces -> diagram-design -> Enable "
+            "auto-update, then run /reload-plugins when prompted. Reinstall with: "
+            "/plugin install diagram-design@diagram-design."
+        )
+    if channel == CHANNEL_GIT:
+        if host == "pi":
+            return (
+                "Update with: pi update --extensions, then run /reload in an open "
+                "Pi session."
+            )
+        return (
+            "Update with: git pull inside the installation checkout, then reload "
+            "the skill in your host."
+        )
+    if host == "cursor":
+        return (
+            "Agent-installed copy: ask the agent to reinstall, or replace the "
+            "copied skills/diagram-design directory from a newer checkout."
+        )
+    return (
+        "Copied install: replace the skills/diagram-design directory from a newer "
+        "checkout to update."
+    )
+
+
+def check_host_install_channel(
+    host: str | None,
+    host_evidence: str,
+    channel: str,
+    channel_evidence: str,
+) -> CheckResult:
+    host_label = host or "unknown"
+    return CheckResult(
+        name="Host profile and install channel",
+        status=PASS,
+        message=(
+            f"Host profile: {host_label} ({host_evidence}). Install channel: "
+            f"{channel} ({channel_evidence}). Update recipe: "
+            f"{update_recipe(host, channel)}"
+        ),
+    )
+
+
+def read_skill_metadata_version(root: Path) -> str | None:
+    skill = resolve_skill_file(root)
+    if skill is None:
+        return None
+    match = SKILL_VERSION_PATTERN.search(skill.read_text(encoding="utf-8"))
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def check_marketplace_version(
+    root: Path,
+    host: str | None,
+    channel: str,
+) -> CheckResult:
+    name = "Marketplace plugin version alignment"
+    if channel != CHANNEL_MARKETPLACE:
+        return CheckResult(
+            name=name,
+            status=PASS,
+            message=(
+                f"Install channel is {channel}; marketplace version alignment is "
+                "not applicable."
+            ),
+        )
+
+    version = read_skill_metadata_version(root)
+    if version is None:
+        return CheckResult(
+            name=name,
+            status=WARN,
+            message=(
+                "Could not read metadata.version from the installed SKILL.md, so the "
+                "active plugin version cannot be compared."
+            ),
+            fix=update_recipe(host, channel),
+        )
+
+    return CheckResult(
+        name=name,
+        status=PASS,
+        message=(
+            f"Installed SKILL.md metadata.version is {version}. Confirm the active "
+            "plugin version your host reports (for example /plugin in Claude Code) "
+            "matches before debugging stale-behavior reports; marketplace "
+            "auto-update can lag until the session reloads."
+        ),
+    )
+
+
+def git_remote_urls(root: Path) -> list[str]:
+    config = root / ".git" / "config"
+    if not config.is_file():
+        return []
+    return re.findall(r"url\s*=\s*(\S+)", config.read_text(encoding="utf-8"))
+
+
+def git_head_ref(root: Path) -> str | None:
+    head = root / ".git" / "HEAD"
+    if not head.is_file():
+        return None
+    return head.read_text(encoding="utf-8").strip()
+
+
+def check_pi_install_pinning(root: Path, host: str | None, channel: str) -> CheckResult:
+    name = "Pi install pinning"
+    if host != "pi":
+        return CheckResult(
+            name=name,
+            status=PASS,
+            message=(
+                "Host profile is not pi; the unpinned-ref check only applies to Pi "
+                "git installs (run with --host pi to force it)."
+            ),
+        )
+    if channel != CHANNEL_GIT:
+        return CheckResult(
+            name=name,
+            status=PASS,
+            message=(
+                f"Install channel is {channel}, not a git checkout; the "
+                "unpinned-ref check is not applicable."
+            ),
+        )
+
+    head = git_head_ref(root)
+    if head is None:
+        return CheckResult(
+            name=name,
+            status=WARN,
+            message="Could not read .git/HEAD to determine whether the Pi install is pinned.",
+            fix=(
+                "Reinstall from a readable git checkout, or pin a tag or commit "
+                "before pi install."
+            ),
+        )
+
+    if head.startswith("ref: refs/heads/"):
+        branch = head.removeprefix("ref: refs/heads/")
+        return CheckResult(
+            name=name,
+            status=WARN,
+            message=(
+                f"Pi install tracks the unpinned git branch {branch!r}; "
+                "pi update --extensions moves it to whatever that branch points at, "
+                "which can change behavior between sessions."
+            ),
+            fix=(
+                "Pin for reproducibility: check out a release tag or commit in the "
+                "package checkout before pi install, or review upstream changes "
+                "before running pi update --extensions."
+            ),
+        )
+
+    return CheckResult(
+        name=name,
+        status=PASS,
+        message="Pi install is pinned to a fixed git ref (detached tag or commit).",
+    )
+
+
+def check_cowork_mirror(root: Path, host: str | None, channel: str) -> CheckResult:
+    name = "Cowork organization mirror"
+    mirror_fix = (
+        "Mirror the public repository into a private or internal repository owned "
+        "by your organization, add it via Organization settings -> Plugins -> Add "
+        "plugin -> GitHub, enable Sync automatically, and install Diagram Design "
+        "from the resulting organization marketplace (README: Install -> Claude "
+        "Cowork)."
+    )
+    if host != "cowork":
+        return CheckResult(
+            name=name,
+            status=PASS,
+            message=(
+                "Host profile is not cowork; the organization-mirror check only "
+                "applies to Cowork (run with --host cowork to force it)."
+            ),
+        )
+
+    if resolve_skill_file(root) is None:
+        return CheckResult(
+            name=name,
+            status=FAIL,
+            message=(
+                "Cowork could not resolve the installed skill (no SKILL.md under "
+                "the installation root). Cowork organization marketplaces require "
+                "a private or internal mirror of this public repository; without "
+                "one, skill resolution fails after install."
+            ),
+            fix=mirror_fix,
+        )
+
+    public_remotes = [url for url in git_remote_urls(root) if PUBLIC_REPO_SLUG in url]
+    if public_remotes:
+        return CheckResult(
+            name=name,
+            status=WARN,
+            message=(
+                "This Cowork install points directly at the public repository "
+                f"({public_remotes[0]}). Organization marketplaces require a "
+                "private or internal mirror, so updates will not sync through "
+                "Cowork from this remote."
+            ),
+            fix=mirror_fix,
+        )
+
+    return CheckResult(
+        name=name,
+        status=PASS,
+        message=(
+            "Skill resolves under Cowork and the install does not point directly "
+            "at the public repository."
+        ),
     )
 
 
@@ -317,7 +667,12 @@ def check_routing_surfaces(root: Path) -> CheckResult:
     )
 
 
-def check_common_path_mistakes(root: Path, cwd: Path) -> CheckResult:
+def check_common_path_mistakes(
+    root: Path,
+    cwd: Path,
+    host: str | None = None,
+    channel: str | None = None,
+) -> CheckResult:
     warnings: list[str] = []
     fixes: list[str] = []
 
@@ -325,7 +680,10 @@ def check_common_path_mistakes(root: Path, cwd: Path) -> CheckResult:
         warnings.append(
             "Diagram Design SKILL.md was not found under the resolved installation root."
         )
-        fixes.append("Reinstall or update Diagram Design, then run the doctor again.")
+        skill_fix = "Reinstall or update Diagram Design, then run the doctor again."
+        if channel is not None:
+            skill_fix += " " + update_recipe(host, channel)
+        fixes.append(skill_fix)
 
     if platform.system().lower().startswith("win") and " " in str(cwd):
         warnings.append(
@@ -369,7 +727,13 @@ def summarize(checks: list[CheckResult], strict: bool) -> tuple[str, dict[str, i
     return status, counts, exit_code
 
 
-def print_report(checks: list[CheckResult], strict: bool, emit_json: bool) -> int:
+def print_report(
+    checks: list[CheckResult],
+    strict: bool,
+    emit_json: bool,
+    host: str | None = None,
+    channel: str | None = None,
+) -> int:
     status, counts, exit_code = summarize(checks, strict)
     print(
         f"Doctor summary: {status} ({counts[PASS]} pass, {counts[WARN]} warn, {counts[FAIL]} fail)"
@@ -393,6 +757,8 @@ def print_report(checks: list[CheckResult], strict: bool, emit_json: bool) -> in
             "checks": [asdict(check) for check in checks],
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "strict": strict,
+            "host": host or "unknown",
+            "install_channel": channel or "unknown",
             "platform": {
                 "system": platform.system(),
                 "release": platform.release(),
@@ -406,17 +772,33 @@ def print_report(checks: list[CheckResult], strict: bool, emit_json: bool) -> in
     return exit_code
 
 
-def run_doctor(root: Path, cwd: Path, strict: bool, emit_json: bool) -> int:
+def run_doctor(
+    root: Path,
+    cwd: Path,
+    strict: bool,
+    emit_json: bool,
+    host_arg: str = AUTO_HOST,
+) -> int:
+    if host_arg == AUTO_HOST:
+        host, host_evidence = detect_host(root)
+    else:
+        host, host_evidence = host_arg, "selected via --host"
+    channel, channel_evidence = detect_install_channel(root)
+
     checks: list[CheckResult] = []
 
     python_check, python_cmd = check_python_runtime()
     checks.append(python_check)
-    checks.append(check_playwright(python_cmd))
+    checks.append(check_playwright(python_cmd, host, channel))
+    checks.append(check_host_install_channel(host, host_evidence, channel, channel_evidence))
     checks.append(check_expected_scripts(root))
     checks.append(check_routing_surfaces(root))
-    checks.append(check_common_path_mistakes(root, cwd))
+    checks.append(check_marketplace_version(root, host, channel))
+    checks.append(check_pi_install_pinning(root, host, channel))
+    checks.append(check_cowork_mirror(root, host, channel))
+    checks.append(check_common_path_mistakes(root, cwd, host, channel))
 
-    return print_report(checks, strict, emit_json)
+    return print_report(checks, strict, emit_json, host, channel)
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -433,6 +815,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_true",
         help="Emit machine-readable JSON report after the human summary.",
     )
+    parser.add_argument(
+        "--host",
+        choices=(AUTO_HOST, *HOST_PROFILES),
+        default=AUTO_HOST,
+        help=(
+            "Host profile to diagnose against (default: auto-detect from "
+            "environment markers and installation path)."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -440,7 +831,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(sys.argv[1:] if argv is None else argv)
     root = ROOT
     cwd = Path.cwd()
-    return run_doctor(root, cwd, args.strict, args.json)
+    return run_doctor(root, cwd, args.strict, args.json, args.host)
 
 
 if __name__ == "__main__":

--- a/skills/diagram-design/references/doctor.md
+++ b/skills/diagram-design/references/doctor.md
@@ -11,7 +11,10 @@ place to invoke the doctor and must not be treated as a repository-path error.
 Use two diagnostic modes:
 
 - **Installed-skill mode** (default): check the runtime and the resolved skill
-  installation. Do not require maintainer-only repository files.
+  installation. Do not require maintainer-only repository files. This mode
+  still runs every host-aware check below — install-channel detection,
+  marketplace version alignment, Pi pinning, and the Cowork mirror check all
+  diagnose installed skills, not just maintainer checkouts.
 - **Maintainer-checkout mode**: use this only when the resolved installation
   root contains `CONTRIBUTING.md`, `.github/workflows/ci.yml`, and
   `scripts/verify-plugin-package.py`. Add the repository integrity checks below.
@@ -22,8 +25,38 @@ Optional flags:
 
 - `--strict` — treat warnings as failures in the final summary.
 - `--json` — print a machine-readable JSON report in addition to human summary.
+- `--host <claude-code|cowork|codex|cursor|pi|auto>` — select the host profile
+  the diagnostics target. Default is `auto`.
 
-If no flags are provided, run in standard mode.
+If no flags are provided, run in standard mode with `--host auto`.
+
+## Host profile resolution
+
+When `--host` is `auto` (or absent), resolve the host profile best-effort and
+say so in the report:
+
+1. Environment markers first, checking Cowork before Claude Code because a
+   Cowork session can also carry Claude Code markers: `COWORK_SESSION_ID` /
+   `CLAUDE_COWORK_SESSION` → `cowork`; `CLAUDECODE` / `CLAUDE_CODE_ENTRYPOINT`
+   → `claude-code`; `CURSOR_AGENT` / `CURSOR_TRACE_ID` → `cursor`;
+   `CODEX_HOME` / `CODEX_SANDBOX` → `codex`; `PI_SESSION_ID` / `PI_HOME` → `pi`.
+2. Then installation-path hints: a path segment containing `cowork`, `.claude`,
+   `.codex`, `.cursor`, or `.pi` selects the matching profile.
+3. Otherwise report the host as `unknown` and suggest passing `--host`.
+
+An explicit `--host` value always wins over detection.
+
+## Install channel resolution
+
+Classify how the resolved installation arrived, and report the evidence:
+
+- `maintainer-checkout` — all maintainer markers above are present.
+- `git` — `.git` metadata exists at the installation root (editable installs,
+  `pi install <git-url>` checkouts).
+- `marketplace` — the installation path contains a marketplace cache segment
+  (`plugins`, `plugin-cache`, `marketplace`, `marketplaces`).
+- `copied` — none of the above (agent-installed or hand-copied skill
+  directories).
 
 ## Required checks
 
@@ -45,9 +78,37 @@ Run all checks in this order and report each as `pass`, `warn`, or `fail`.
 - Check whether Chromium is installed for Playwright (`playwright install --help` availability is sufficient for command presence; prefer also checking browser cache when practical).
 - If missing, mark `warn` and print exact setup hint:
   - `pip install playwright && playwright install chromium`
+- Append the host-specific hint for the resolved profile, in parentheses after
+  the command, so silent PNG failures get a one-shot fix:
+  - `claude-code` — run it in the Python environment Claude Code invokes, then `/reload-plugins`.
+  - `cowork` — install inside the Cowork session environment; sandboxed sessions do not see host-machine packages.
+  - `codex` — run it in the Codex workspace environment, then start a new session.
+  - `cursor` — run it in the Cursor agent terminal so the interpreter matches the export interpreter.
+  - `pi` — run it in the interpreter Pi uses, then `/reload`.
+- When the install channel is `marketplace`, also advise restarting the session
+  so the host reloads the plugin environment.
 - Never auto-install dependencies.
 
-3. Expected script presence (maintainer-checkout mode only)
+3. Host profile and install channel
+- Report the resolved host profile and install channel with their evidence.
+- Print the matching update/reinstall recipe (all cited from the README Install
+  section):
+  - `marketplace` + `claude-code` — enable auto-update via `/plugin` →
+    **Marketplaces** → **diagram-design**, run `/reload-plugins` when prompted;
+    reinstall with `/plugin install diagram-design@diagram-design`.
+  - `marketplace` + `codex` — `codex plugin marketplace upgrade diagram-design`,
+    then start a new session.
+  - `marketplace` + `cowork` — updates sync from the organization's private
+    mirror when a plugin version-bump PR merges to its default branch.
+  - `git` + `pi` — `pi update --extensions`, then `/reload` in an open session.
+  - `git` (other hosts) — `git pull` in the checkout, then reload the skill.
+  - `copied` — replace the copied `skills/diagram-design` directory from a
+    newer checkout (for `cursor`, re-running the agent install also works).
+  - `maintainer-checkout` — `git pull` and re-run the CONTRIBUTING gates.
+- This check is informational (`pass`); it exists so warn/fail checks can
+  reference a concrete recipe.
+
+4. Expected script presence (maintainer-checkout mode only)
 - Verify these repository scripts exist:
   - `scripts/verify-drawio-import.py`
   - `scripts/verify-mermaid-import.py`
@@ -59,7 +120,7 @@ Run all checks in this order and report each as `pass`, `warn`, or `fail`.
 - In installed-skill mode, report that maintainer scripts are not applicable;
   their absence is not a warning or failure.
 
-4. Plugin wiring surfaces (maintainer-checkout mode only)
+5. Plugin wiring surfaces (maintainer-checkout mode only)
 - Verify Claude command files exist and point to their references:
   - `commands/export-diagram.md` -> `references/export.md`
   - `commands/import-drawio.md` -> `references/import-drawio.md`
@@ -78,7 +139,41 @@ Run all checks in this order and report each as `pass`, `warn`, or `fail`.
 - In installed-skill mode, report that maintainer command/prompt wiring is not
   applicable; partial or absent repository routing trees are not failures.
 
-5. Common path mistakes
+6. Marketplace plugin version alignment (installed-skill mode included)
+- Only applicable when the install channel is `marketplace`; otherwise report
+  `pass` with a not-applicable message.
+- Read `metadata.version` from the resolved `SKILL.md` and advise confirming
+  the active plugin version the host reports (for example `/plugin` in Claude
+  Code) matches it before debugging stale-behavior reports — marketplace
+  auto-update can lag until the session reloads.
+- `warn` when `metadata.version` cannot be read, with the reinstall recipe as
+  the fix.
+
+7. Pi install pinning (installed-skill mode included)
+- Only applicable when the host profile is `pi` and the install channel is
+  `git`; otherwise report `pass` with a not-applicable message.
+- Read `.git/HEAD` (read-only). A `ref: refs/heads/<branch>` head means the
+  install tracks an unpinned branch: `warn` that `pi update --extensions`
+  moves it to whatever that branch points at, and suggest pinning to a release
+  tag or commit before `pi install` (or reviewing upstream changes before
+  updating).
+- A detached tag or commit head is `pass` (pinned).
+
+8. Cowork organization mirror (installed-skill mode included)
+- Only applicable when the host profile is `cowork`; otherwise report `pass`
+  with a not-applicable message.
+- If the resolved `SKILL.md` is missing, mark `fail`: Cowork organization
+  marketplaces require a private or internal mirror of this public repository,
+  and skill resolution fails after install without one. The fix cites the
+  documented mirror steps (README: Install → Claude Cowork): mirror the public
+  repository into an organization-owned private/internal repository, add it via
+  **Organization settings → Plugins → Add plugin → GitHub**, enable **Sync
+  automatically**, and install from the resulting organization marketplace.
+- If `.git/config` shows a remote pointing directly at the public
+  `cathrynlavery/diagram-design` repository, mark `warn` with the same mirror
+  fix — updates will not sync through Cowork from the public remote.
+
+9. Common path mistakes
 - Verify `SKILL.md` beneath the resolved installation root. Do not search for it
   relative to the user's current project and do not instruct users to enter the
   maintainer repository.
@@ -86,7 +181,9 @@ Run all checks in this order and report each as `pass`, `warn`, or `fail`.
 - Detect references to local installed skill paths that do not exist (if command output includes one).
 - Mark these as `warn` with a precise fix suggestion.
 - A missing resolved `SKILL.md` should suggest reinstalling or updating Diagram
-  Design, not changing into a repository checkout.
+  Design, not changing into a repository checkout, and should append the
+  update/reinstall recipe for the resolved host and install channel so a
+  "skill not found" failure after a marketplace install gets a one-shot fix.
 
 ## Output contract
 
@@ -103,7 +200,7 @@ Always print:
 3. A `Next actions` section only when warn/fail exists.
 
 4. If `--json` is present, append JSON object with:
-- `status`, `counts`, `checks[]` (`name`, `status`, `message`, `fix` optional), `timestamp`.
+- `status`, `counts`, `checks[]` (`name`, `status`, `message`, `fix` optional), `timestamp`, `host`, `install_channel`.
 
 ## Safety and behavior rules
 
@@ -115,13 +212,14 @@ Always print:
 ## Example result
 
 ```text
-Doctor summary: WARN (6 pass, 2 warn, 0 fail)
+Doctor summary: WARN (8 pass, 1 warn, 0 fail)
 [PASS] Python 3.11.9 found at /usr/bin/python3
 [WARN] Playwright package not found in active interpreter
-[PASS] scripts/verify-drawio-import.py present
+[PASS] Host profile: claude-code (environment variable CLAUDECODE is set). Install channel: marketplace (...)
+[PASS] Installed SKILL.md metadata.version is 2.6. Confirm the active plugin version your host reports ...
 ...
 
 Next actions
-- Install PNG export dependencies: pip install playwright && playwright install chromium
+- pip install playwright && playwright install chromium (Run it in the same Python environment Claude Code invokes, then run /reload-plugins so the session picks it up. If PNG export still fails after a marketplace install, restart the session so the host reloads the plugin environment.)
 - Re-run: /diagram-design:doctor --strict
 ```


### PR DESCRIPTION
## What does this PR do?

Extends the existing doctor (no parallel tool) so installed-skill mode diagnoses host-specific install/update shapes, per the direction in #189: an optional `--host` profile (`claude-code`, `cowork`, `codex`, `cursor`, `pi`, `auto` with env-marker/path auto-detection), install-channel detection (maintainer-checkout / git / marketplace / copied) with the matching update-or-reinstall recipe, host-specific Playwright+Chromium hints for silent PNG failures, a marketplace check advising confirmation of the active plugin version vs `SKILL.md` `metadata.version`, a Pi unpinned-git-ref warning, and a Cowork check that fails with the documented private-org mirror steps when skill resolution breaks (and warns when the install points directly at the public repo). A missing `SKILL.md` now appends the host/channel one-shot reinstall recipe. Diagnostics remain read-only — nothing is auto-installed.

Touched surfaces, kept in sync: `scripts/verify-doctor.py`, `scripts/test-verify-doctor.py`, `skills/diagram-design/references/doctor.md`, `commands/doctor.md`, `prompts/doctor.md`, README (new *Troubleshooting an install* subsection under Install), and cookbook R1. No plugin manifest versions were touched (ADR 0009). Does not touch #185 or #181 scope.

## Visual proof

Not applicable — tooling/scripts/docs only; no diagram, example, or template output changes.

## Validation gates

- [x] `python3 scripts/verify-doctor.py` (exit 0; host/channel resolution and new checks report correctly)
- [x] `python3 scripts/test-verify-doctor.py` (existing cases plus new adversarial cases for host detection precedence, channel classification, recipes, Playwright fix composition, marketplace version alignment, Pi pinning, Cowork mirror, and `--host` parsing)
- [x] `python3 scripts/verify-docs-sync.py` and `python3 scripts/test-verify-docs-sync.py`
- [x] `python3 scripts/verify-plugin-package.py --require-no-bump upstream/main` and `python3 scripts/test-plugin-package.py`
- [x] `npx --yes @anthropic-ai/claude-code@2.1.229 plugin validate . --strict` (edited command frontmatter stays valid)
- [x] Docs updated in the same PR where behavior changed

## Checklist

- [x] No new entries added to `scripts/lint-skin-baseline.txt`
- [x] Generated and source files are consistent (verifier ↔ reference ↔ command ↔ prompt in one change)
- [x] Accessible SVG contract satisfied for new/changed examples (not applicable — no examples changed)
- [x] Rendered screenshots are attached for every new/changed diagram variant, or visual proof is marked not applicable
- [x] Code of Conduct respected

## Related issues

Closes #189

---

AI was used for assistance in implementing this change.