### PR TITLE
fix(ci): allow patch bumps without skill metadata changes

### DIFF
--- a/.github/workflows/auto-bump.yml
+++ b/.github/workflows/auto-bump.yml
@@ -125,14 +125,19 @@ jobs:
           set -euo pipefail
           python3 scripts/verify-plugin-package.py "$SOURCE_SHA"
 
-          expected=$(printf '%s\n' \
+          expected_without_skill=$(printf '%s\n' \
+            .claude-plugin/plugin.json \
+            .codex-plugin/plugin.json \
+            .factory-plugin/plugin.json | LC_ALL=C sort)
+          expected_with_skill=$(printf '%s\n' \
             .claude-plugin/plugin.json \
             .codex-plugin/plugin.json \
             .factory-plugin/plugin.json \
             skills/diagram-design/SKILL.md | LC_ALL=C sort)
           actual=$(git diff --name-only | LC_ALL=C sort)
-          if [ "$actual" != "$expected" ]; then
-            echo "Bump changed files outside the release allowlist:" >&2
+          if [ "$actual" != "$expected_without_skill" ] \
+            && [ "$actual" != "$expected_with_skill" ]; then
+            echo "Bump changed unexpected files or omitted a required manifest:" >&2
             git diff --name-only >&2
             exit 1
           fi
@@ -199,13 +204,18 @@ jobs:
         run: |
           set -euo pipefail
           patch=_version-bump/version-bump.patch
-          expected=$(printf '%s\n' \
+          expected_without_skill=$(printf '%s\n' \
+            .claude-plugin/plugin.json \
+            .codex-plugin/plugin.json \
+            .factory-plugin/plugin.json | LC_ALL=C sort)
+          expected_with_skill=$(printf '%s\n' \
             .claude-plugin/plugin.json \
             .codex-plugin/plugin.json \
             .factory-plugin/plugin.json \
             skills/diagram-design/SKILL.md | LC_ALL=C sort)
           patch_paths=$(git apply --numstat "$patch" | cut -f3- | LC_ALL=C sort)
-          if [ "$patch_paths" != "$expected" ]; then
+          if [ "$patch_paths" != "$expected_without_skill" ] \
+            && [ "$patch_paths" != "$expected_with_skill" ]; then
             echo "Artifact contains paths outside the release allowlist" >&2
             exit 1
           fi
@@ -213,7 +223,7 @@ jobs:
           git apply --check --whitespace=error "$patch"
           git apply --index --whitespace=error "$patch"
           staged_paths=$(git diff --cached --name-only | LC_ALL=C sort)
-          if [ "$staged_paths" != "$expected" ] \
+          if [ "$staged_paths" != "$patch_paths" ] \
             || [ -n "$(git diff --cached --summary)" ]; then
             echo "Artifact changed unexpected paths or file modes" >&2
             exit 1

--- a/scripts/test-plugin-package.py
+++ b/scripts/test-plugin-package.py
@@ -16,6 +16,7 @@ from typing import Iterator, Optional
 ROOT = Path(__file__).resolve().parent.parent
 VERIFY_SCRIPT = ROOT / "scripts/verify-plugin-package.py"
 BUMP_SCRIPT = ROOT / "scripts/bump-plugin-version.py"
+AUTO_BUMP_WORKFLOW = ROOT / ".github/workflows/auto-bump.yml"
 PLUGIN_NAME = "diagram-design"
 
 
@@ -553,9 +554,51 @@ def test_bumper() -> None:
         print("OK: version bumper fails closed on SKILL.md drift, manifests untouched")
 
 
+def test_auto_bump_workflow_allowlists() -> None:
+    workflow = AUTO_BUMP_WORKFLOW.read_text(encoding="utf-8")
+    expected = {
+        "expected_without_skill": tuple(
+            sorted(relative.as_posix() for relative in BUMP.MANIFEST_PATHS)
+        ),
+        "expected_with_skill": tuple(
+            sorted(
+                relative.as_posix()
+                for relative in (*BUMP.MANIFEST_PATHS, BUMP.SKILL_PATH)
+            )
+        ),
+    }
+
+    for variable, expected_paths in expected.items():
+        marker = f"{variable}=$(printf '%s" + "\\n' \\" + "\n"
+        chunks = workflow.split(marker)
+        if len(chunks) != 3:
+            raise AssertionError(
+                f"expected prepare and publish assignments for {variable}; "
+                f"found {len(chunks) - 1}"
+            )
+        for job, chunk in zip(("prepare", "publish"), chunks[1:]):
+            body, separator, _ = chunk.partition("| LC_ALL=C sort)")
+            if not separator:
+                raise AssertionError(f"could not parse {job} {variable} allowlist")
+            actual_paths = tuple(
+                sorted(
+                    line.strip().removesuffix("\\").strip()
+                    for line in body.splitlines()
+                    if line.strip()
+                )
+            )
+            if actual_paths != expected_paths:
+                raise AssertionError(
+                    f"{job} {variable} allowlist is {actual_paths}; "
+                    f"expected {expected_paths}"
+                )
+    print("OK: prepare and publish workflow allowlists match bumper paths")
+
+
 def main() -> int:
     test_verifier()
     test_bumper()
+    test_auto_bump_workflow_allowlists()
     print("All plugin package tests passed")
     return 0
 

--- a/scripts/test-plugin-package.py
+++ b/scripts/test-plugin-package.py
@@ -479,6 +479,11 @@ def test_bumper() -> None:
         with tempfile.TemporaryDirectory() as scratch:
             root = Path(scratch)
             seed_package(root)
+            version_paths = (*BUMP.MANIFEST_PATHS, BUMP.SKILL_PATH)
+            before = {
+                relative: (root / relative).read_text(encoding="utf-8")
+                for relative in version_paths
+            }
             actual = BUMP.bump(root, part)
             versions = {
                 json.loads((root / relative).read_text(encoding="utf-8"))["version"]
@@ -494,6 +499,19 @@ def test_bumper() -> None:
                 raise AssertionError(
                     f"{part} bump left SKILL.md metadata.version off "
                     f"{expected_minor!r}: {skill_text!r}"
+                )
+            changed = {
+                relative
+                for relative in version_paths
+                if (root / relative).read_text(encoding="utf-8") != before[relative]
+            }
+            expected_changed = set(BUMP.MANIFEST_PATHS)
+            if part != "patch":
+                expected_changed.add(BUMP.SKILL_PATH)
+            if changed != expected_changed:
+                raise AssertionError(
+                    f"{part} bump changed {sorted(map(str, changed))}; expected "
+                    f"{sorted(map(str, expected_changed))}"
                 )
             print(f"OK: {part} bump produced {expected} and synced SKILL.md")
 


### PR DESCRIPTION
## Summary

- allow patch releases to update the three package manifests without requiring an unchanged `SKILL.md` to appear in the patch
- retain the four-path allowlist for minor and major releases, where `metadata.version` changes
- require the publisher to stage exactly the paths independently validated from the artifact
- add regression coverage for the exact files changed by patch, minor, and major bumps

## Why

The post-merge Auto Version Bump run `34058415620` failed after #180 because a patch bump correctly left `SKILL.md` metadata at `2.6`, while the workflow incorrectly required that unchanged file in the diff.

## Validation

- all 52 commands in `.maintainer-policy.json`
- `actionlint .github/workflows/auto-bump.yml`
- end-to-end prepare/publish artifact simulations for patch and minor bumps

No plugin manifest version changes are included; ADR 0009 remains satisfied.