### PR TITLE
fix(export): keep exported SVG font imports in sync

### DIFF
--- a/scripts/verify-docs-sync.py
+++ b/scripts/verify-docs-sync.py
@@ -556,6 +556,53 @@ def check_manifest_descriptions(errors: list[str], root: Path) -> None:
                     )
 
 
+def font_families(url: str) -> set[str]:
+    """The `family=` parameters a Google Fonts css2 URL actually requests."""
+    return {
+        part.split(":", 1)[0]
+        for part in url.replace("&amp;", "&").split("&")
+        if part.startswith("family=")
+    }
+
+
+def check_export_font_parity(errors: list[str], root: Path) -> None:
+    """The exported SVG must request every face the shipped HTML link does.
+
+    The two strings live in different files and drifted apart once already: the
+    CJK faces reached assets/template.html but never the @import in export.md,
+    so a Korean or Chinese diagram exported to .svg silently lost its type. That
+    failure only shows up on a machine other than the author's, which is exactly
+    the case the faces are in the link to prevent.
+    """
+    template = root / "skills/diagram-design/assets/template.html"
+    export = root / "skills/diagram-design/references/export.md"
+    for path in (template, export):
+        if not path.is_file():
+            errors.append(f"font-parity surface is missing: {path.name}")
+            return
+
+    link = re.search(r'href="([^"]*fonts\.googleapis\.com[^"]*)"',
+                     template.read_text(encoding="utf-8"))
+    imported = re.search(r"@import url\('([^']+)'\)",
+                         export.read_text(encoding="utf-8"))
+    if not link or not imported:
+        errors.append(
+            "could not locate the font link in assets/template.html or the "
+            "@import in references/export.md"
+        )
+        return
+
+    missing = sorted(font_families(link.group(1)) - font_families(imported.group(1)))
+    if missing:
+        names = ", ".join(name.removeprefix("family=").replace("+", " ")
+                          for name in missing)
+        errors.append(
+            f"references/export.md @import omits {names}, which "
+            f"assets/template.html requests; an exported .svg would resolve "
+            f"those scripts through whatever font the viewer happens to have"
+        )
+
+
 def main() -> int:
     errors: list[str] = []
     check_description(errors)
@@ -581,6 +628,7 @@ def main() -> int:
     )
     check_line_dark_skin(errors, LINE_DARK_EXAMPLE.read_text(encoding="utf-8"))
     check_routing_surfaces(errors, ROOT)
+    check_export_font_parity(errors, ROOT)
     if errors:
         print("FAIL docs sync")
         for error in errors:
@@ -590,7 +638,8 @@ def main() -> int:
         "OK docs sync: description hooks, gallery reachability, README tree, "
         "reference links, asset citations, packaged support files, routing surfaces, "
         "manifest descriptions, Factory install contract, type-count routing, "
-        "High-Level invariants, onboarding trust boundary, Line dark-skin contract"
+        "High-Level invariants, onboarding trust boundary, Line dark-skin contract, "
+        "export font parity"
     )
     return 0
 

--- a/skills/diagram-design/references/export.md
+++ b/skills/diagram-design/references/export.md
@@ -35,7 +35,7 @@ If the user explicitly asks for "a screenshot of the whole page including the ca
    - Inject Google Fonts `@import` so the SVG renders with correct typography in a browser. **XML-escape the `&` separators as `&amp;`** — a standalone `.svg` is parsed as strict XML, where a bare `&` starts an entity reference and makes the whole file fail to parse. (Don't copy the raw URL from the HTML `<link href>`; that ampersand form is only valid in HTML.)
      ```svg
      <defs>
-       <style>@import url('https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&amp;family=Geist:wght@400;500;600&amp;family=Geist+Mono:wght@400;500;600&amp;display=swap');</style>
+       <style>@import url('https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&amp;family=Geist:wght@400;500;600&amp;family=Geist+Mono:wght@400;500;600&amp;family=Noto+Sans+KR:wght@400;500;600&amp;family=Noto+Serif+KR:wght@400&amp;family=Noto+Sans+TC:wght@400;500;600&amp;family=Noto+Serif+TC:wght@400&amp;display=swap');</style>
      </defs>
      ```
      If the SVG already contains a `<defs>` block, **merge** the `<style>` into it (don't add a second `<defs>`).


### PR DESCRIPTION
Closes #195.

The `@import` that `export.md` step 3 injects requested three Latin faces while `assets/template.html` requested seven. The four missing ones were all the CJK faces, so a Korean or Chinese diagram exported to `.svg` lost its type — quietly, and only on a machine other than the author's.

## The fix

`references/export.md` — the `@import` now requests the same families as the shipped link, with the `&amp;` separators the surrounding prose already requires:

```
…family=Geist+Mono:wght@400;500;600
&amp;family=Noto+Sans+KR:wght@400;500;600&amp;family=Noto+Serif+KR:wght@400
&amp;family=Noto+Sans+TC:wght@400;500;600&amp;family=Noto+Serif+TC:wght@400
&amp;display=swap
```

`css2` slices CJK by unicode-range, so a Latin-only diagram downloads nothing extra — the same argument `#korean-labels` already makes for keeping the link short.

## The gate

`scripts/verify-docs-sync.py` gains `check_export_font_parity`: the families in `export.md`'s `@import` must be a superset of those in `assets/template.html`'s `<link>`.

It lives in `verify-docs-sync.py` rather than a new script on purpose. A new `verify-*.py` would need matching entries in `ci.yml`, the CONTRIBUTING gate table, and `.maintainer-policy.json` — and `test-maintainer-policy.py` asserts those three agree, so the cheap change is the one that reuses a gate already wired into all of them. This is also the same class of check the file already performs: two surfaces that must not drift apart.

## The gate demonstrably catches the reported bug

Reverting only `export.md` to its state on `main` and re-running the gate:

```
FAIL docs sync
  - references/export.md @import omits Noto Sans KR, Noto Sans TC, Noto Serif KR,
    Noto Serif TC, which assets/template.html requests; an exported .svg would
    resolve those scripts through whatever font the viewer happens to have
```

Exit 1 on the pre-fix tree, exit 0 with the fix. A gate that has never been seen to fail is a gate nobody has verified, so it seemed worth doing before opening this.

## Why the parity direction is superset, not equality

`template.html` is the source of truth for what ships. An export may legitimately request more (a future terminal or print variant), but never less — dropping a face is the failure this is about. Equality would also break the moment anything is added to the export side alone.

## Scope

Two files. No new script, no CI wiring, no manifest versions touched. Reads as a patch to me; label it otherwise if you disagree.
