### PR TITLE
fix(ci): detect real plugin version bumps

### DIFF
--- a/.github/workflows/auto-bump.yml
+++ b/.github/workflows/auto-bump.yml
@@ -47,25 +47,27 @@ jobs:
         with:
           python-version: "3.12"
 
-      # Skip when the tip of main already carries a version change (a manual
-      # bump, or this workflow's own commit triggering another run).
+      # Skip only when the tip of main changes the synchronized version fields
+      # (a manual bump, or this workflow's own commit triggering another run).
+      # Feature merges may legitimately update other manifest metadata.
       - name: Check whether main already bumped
         id: guard
         shell: bash
         run: |
+          set -euo pipefail
           source_sha=$(git rev-parse HEAD)
           echo "source_sha=${source_sha}" >> "$GITHUB_OUTPUT"
-          if git rev-parse --verify --quiet HEAD^ >/dev/null \
-            && ! git diff --quiet HEAD^ HEAD -- \
-              .claude-plugin/plugin.json \
-              .codex-plugin/plugin.json \
-              .factory-plugin/plugin.json; then
+          version_changed=false
+          if git rev-parse --verify --quiet HEAD^ >/dev/null; then
+            version_changed=$(python3 scripts/plugin_version_history.py changed HEAD^ HEAD)
+          fi
+          if [ "$version_changed" = "true" ]; then
             echo "should_bump=false" >> "$GITHUB_OUTPUT"
           else
             echo "should_bump=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Inspect every commit since the previous manifest bump. This preserves
+      # Inspect every commit since the previous version bump. This preserves
       # the strongest release label when multiple merges coalesce into one run.
       - name: Determine bump size across all unversioned merges
         if: steps.guard.outputs.should_bump == 'true'
@@ -76,14 +78,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          last_bump=$(git log -1 --format=%H "$SOURCE_SHA" -- \
-            .claude-plugin/plugin.json \
-            .codex-plugin/plugin.json \
-            .factory-plugin/plugin.json)
-          if [ -z "$last_bump" ]; then
-            echo "No previous manifest bump found" >&2
-            exit 1
-          fi
+          last_bump=$(python3 scripts/plugin_version_history.py last-bump "$SOURCE_SHA")
 
           part=patch
           while IFS= read -r commit; do

--- a/scripts/plugin_version_history.py
+++ b/scripts/plugin_version_history.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Inspect synchronized plugin-version changes across git history."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence, Tuple
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATHS = (
+    Path(".claude-plugin/plugin.json"),
+    Path(".codex-plugin/plugin.json"),
+    Path(".factory-plugin/plugin.json"),
+)
+SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+
+
+class VersionHistoryError(ValueError):
+    """Raised when version history cannot be inspected safely."""
+
+
+def git(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise VersionHistoryError(f"git {' '.join(args)} failed: {detail}")
+    return result.stdout.strip()
+
+
+def versions_at(root: Path, ref: str) -> Tuple[str, ...]:
+    versions = []
+    for relative in MANIFEST_PATHS:
+        raw = git(root, "show", f"{ref}:{relative.as_posix()}")
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise VersionHistoryError(
+                f"{relative} at {ref} is not valid JSON: {exc}"
+            ) from exc
+        if not isinstance(payload, dict):
+            raise VersionHistoryError(f"{relative} at {ref} must contain an object")
+        version = payload.get("version")
+        if not isinstance(version, str) or SEMVER.fullmatch(version) is None:
+            raise VersionHistoryError(
+                f"{relative} at {ref} has an invalid version: {version!r}"
+            )
+        versions.append(version)
+    if len(set(versions)) != 1:
+        rendered = ", ".join(
+            f"{path}={version}" for path, version in zip(MANIFEST_PATHS, versions)
+        )
+        raise VersionHistoryError(
+            f"manifest versions at {ref} are not synchronized: {rendered}"
+        )
+    return tuple(versions)
+
+
+def versions_changed(root: Path, before: str, after: str) -> bool:
+    return versions_at(root, before) != versions_at(root, after)
+
+
+def first_parent(root: Path, commit: str) -> str | None:
+    fields = git(root, "rev-list", "--parents", "-n", "1", commit).split()
+    return fields[1] if len(fields) > 1 else None
+
+
+def last_version_bump(root: Path, source: str) -> str:
+    commits = git(
+        root,
+        "rev-list",
+        "--first-parent",
+        source,
+        "--",
+        *(path.as_posix() for path in MANIFEST_PATHS),
+    ).splitlines()
+    for commit in commits:
+        parent = first_parent(root, commit)
+        if parent is not None and versions_changed(root, parent, commit):
+            return commit
+    raise VersionHistoryError(
+        f"no synchronized plugin version bump found at {source}"
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    changed = subparsers.add_parser(
+        "changed", help="print whether synchronized versions differ between two refs"
+    )
+    changed.add_argument("before")
+    changed.add_argument("after")
+    last = subparsers.add_parser(
+        "last-bump", help="print the newest first-parent commit with a version change"
+    )
+    last.add_argument("source")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        if args.command == "changed":
+            changed = versions_changed(ROOT, args.before, args.after)
+            print("true" if changed else "false")
+        else:
+            print(last_version_bump(ROOT, args.source))
+    except VersionHistoryError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-plugin-package.py
+++ b/scripts/test-plugin-package.py
@@ -643,6 +643,16 @@ def test_version_history() -> None:
             pass
         else:
             raise AssertionError("malformed history was treated as a normal comparison")
+
+        payload["version"] = "1.2.4"
+        write_json(path, payload)
+        desynchronized = commit_all(root, "desynchronize valid manifest versions")
+        try:
+            VERSION_HISTORY.versions_changed(root, next_release, desynchronized)
+        except VERSION_HISTORY.VersionHistoryError:
+            pass
+        else:
+            raise AssertionError("valid but unequal versions were treated as synchronized")
         print("OK: version history ignores manifest metadata-only commits")
 
 

--- a/scripts/test-plugin-package.py
+++ b/scripts/test-plugin-package.py
@@ -16,6 +16,7 @@ from typing import Iterator, Optional
 ROOT = Path(__file__).resolve().parent.parent
 VERIFY_SCRIPT = ROOT / "scripts/verify-plugin-package.py"
 BUMP_SCRIPT = ROOT / "scripts/bump-plugin-version.py"
+VERSION_HISTORY_SCRIPT = ROOT / "scripts/plugin_version_history.py"
 AUTO_BUMP_WORKFLOW = ROOT / ".github/workflows/auto-bump.yml"
 PLUGIN_NAME = "diagram-design"
 
@@ -32,6 +33,7 @@ def load_module(name: str, path: Path) -> ModuleType:
 
 VERIFY = load_module("verify_plugin_package", VERIFY_SCRIPT)
 BUMP = load_module("bump_plugin_version", BUMP_SCRIPT)
+VERSION_HISTORY = load_module("plugin_version_history", VERSION_HISTORY_SCRIPT)
 
 
 def write_json(path: Path, payload: dict) -> None:
@@ -595,10 +597,60 @@ def test_auto_bump_workflow_allowlists() -> None:
     print("OK: prepare and publish workflow allowlists match bumper paths")
 
 
+def commit_all(root: Path, message: str) -> str:
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-qm", message], cwd=root, check=True)
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=root, text=True
+    ).strip()
+
+
+def test_version_history() -> None:
+    with package_repo() as root:
+        base = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=root, text=True
+        ).strip()
+        BUMP.bump(root)
+        release = commit_all(root, "release 1.2.4")
+
+        for relative in BUMP.MANIFEST_PATHS:
+            path = root / relative
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            payload["description"] = "Create editorial diagrams from imported sources."
+            write_json(path, payload)
+        metadata_only = commit_all(root, "update manifest descriptions")
+
+        if not VERSION_HISTORY.versions_changed(root, base, release):
+            raise AssertionError("release version change was not detected")
+        if VERSION_HISTORY.versions_changed(root, release, metadata_only):
+            raise AssertionError("description-only manifest change was treated as a release")
+        if VERSION_HISTORY.last_version_bump(root, metadata_only) != release:
+            raise AssertionError("description-only commit hid the previous real release")
+
+        BUMP.bump(root)
+        next_release = commit_all(root, "release 1.2.5")
+        if VERSION_HISTORY.last_version_bump(root, next_release) != next_release:
+            raise AssertionError("newest real release was not selected")
+
+        path = root / BUMP.MANIFEST_PATHS[0]
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["version"] = "not-semver"
+        write_json(path, payload)
+        malformed = commit_all(root, "break one manifest version")
+        try:
+            VERSION_HISTORY.versions_changed(root, next_release, malformed)
+        except VERSION_HISTORY.VersionHistoryError:
+            pass
+        else:
+            raise AssertionError("malformed history was treated as a normal comparison")
+        print("OK: version history ignores manifest metadata-only commits")
+
+
 def main() -> int:
     test_verifier()
     test_bumper()
     test_auto_bump_workflow_allowlists()
+    test_version_history()
     print("All plugin package tests passed")
     return 0
 


### PR DESCRIPTION
## Summary

- distinguish synchronized version-field changes from description-only manifest edits
- find the last real first-parent version bump when computing release labels
- fail closed on malformed or desynchronized history
- add git-backed regression coverage for metadata-only commits

This repairs the skipped post-merge bumps for PRs #191 and #192. Once merged, the normal protected Auto Version Bump workflow should produce the pending patch release 2.6.19.

## Verification

- actionlint .github/workflows/auto-bump.yml
- python3 scripts/test-plugin-package.py
- all 58 commands in .maintainer-policy.json