### PR TITLE
docs: add GitHub Copilot marketplace install

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ codex plugin add diagram-design@diagram-design
 
 Codex refreshes configured Git marketplaces at startup. To fetch immediately, run `codex plugin marketplace upgrade diagram-design` and start a new session.
 
+**GitHub Copilot:**
+
+```bash
+copilot plugin marketplace add cathrynlavery/diagram-design
+copilot plugin install diagram-design@diagram-design
+```
+
+Copilot installs the shared Diagram Design skill plus its doctor, export, import, and profile capabilities from the existing repository marketplace. Confirm discovery with `copilot skill list` (or `/skills` in an interactive session), then ask for a diagram in natural language. To fetch a merged update, run `copilot plugin marketplace update diagram-design`, then `copilot plugin update diagram-design@diagram-design`.
+
 **Factory Droid:**
 
 ```bash
@@ -178,15 +187,16 @@ pi install ~/code/diagram-design
 ln -s ~/code/diagram-design/skills/diagram-design ~/.claude/skills/diagram-design
 
 # Other Agent Skills hosts: create only the roots you use
-mkdir -p ~/.agents/skills ~/.cursor/skills ~/.cline/skills ~/.kiro/skills ~/.config/opencode/skills
+mkdir -p ~/.agents/skills ~/.cursor/skills ~/.cline/skills ~/.kiro/skills ~/.config/opencode/skills ~/.copilot/skills
 ln -s ~/code/diagram-design/skills/diagram-design ~/.agents/skills/diagram-design
 ln -s ~/code/diagram-design/skills/diagram-design ~/.cursor/skills/diagram-design
 ln -s ~/code/diagram-design/skills/diagram-design ~/.cline/skills/diagram-design
 ln -s ~/code/diagram-design/skills/diagram-design ~/.kiro/skills/diagram-design
 ln -s ~/code/diagram-design/skills/diagram-design ~/.config/opencode/skills/diagram-design
+ln -s ~/code/diagram-design/skills/diagram-design ~/.copilot/skills/diagram-design
 ```
 
-The shared skill lives at `skills/diagram-design/`. Pi discovers it through the repo's standard `skills/` package directory; Claude Code, Codex, Factory Droid, and other Agent Skills-compatible tools use the same files.
+The shared skill lives at `skills/diagram-design/`. Pi discovers it through the repo's standard `skills/` package directory; Claude Code, GitHub Copilot, Codex, Factory Droid, and other Agent Skills-compatible tools use the same files.
 
 ---
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -39,9 +39,9 @@ This repository does not duplicate `SKILL.md` into host-specific loader stubs. F
 | **Cline CLI / VS Code** | `~/.cline/skills/`, `~/.agents/skills/`, workspace `.cline/skills/`, or workspace `.agents/skills/` | Link the inner skill and enable it from the Skills view when needed. |
 | **Kiro** | Workspace `.kiro/skills/` or global `~/.kiro/skills/` | Link the inner skill, or import its GitHub subdirectory URL; imported skills are copied and must be re-imported to update. |
 | **OpenCode** | Project `.opencode/skills/` or global `~/.config/opencode/skills/` | Link or copy the inner skill; copied installs must be replaced to update. |
-| **GitHub Copilot** | Project `.github/skills/`, `.agents/skills/`, or `.claude/skills/`; user `~/.copilot/skills/`, `~/.agents/skills/`, or `~/.claude/skills/` | Link the inner skill into one applicable root. |
+| **GitHub Copilot** | Marketplace plugin; project `.github/skills/`, `.agents/skills/`, or `.claude/skills/`; user `~/.copilot/skills/`, `~/.agents/skills/`, or `~/.claude/skills/` | Use the marketplace for managed updates or link the inner skill for editable work. |
 
-Marketplace installs (Claude `/plugin`, `codex plugin add`, `droid plugin install`) stay the right path if you do **not** need to edit `style-guide.md` in-tree. Use profiles instead.
+Marketplace installs (Claude `/plugin`, `copilot plugin install`, `codex plugin add`, `droid plugin install`) stay the right path if you do **not** need to edit `style-guide.md` in-tree. Use profiles instead.
 
 ### Unix (user-global inner skill)
 


### PR DESCRIPTION
## What does this PR do?

Documents the managed GitHub Copilot marketplace install and update path that the repository already supports, and aligns the editable-install cookbook with that capability.

This is deliberately documentation-only. Copilot CLI 1.0.84-3 recognizes the existing `.claude-plugin/marketplace.json`, installs `diagram-design@diagram-design` at v2.6.21, and discovers the shared `skills/diagram-design/` package plus the existing doctor, export, import, and profile capabilities. The current package and marketplace gates already validate the exact shared root Copilot consumes, so this PR does not add another manifest or duplicate any skill/command content.

## Why no root Agent Plugins 1.0 manifest?

[Agent Plugins 1.0 became generally available in Copilot on 2026-08-12](https://github.blog/changelog/2026-08-12-agent-plugins-1-0-in-vs-code-copilot-cli-and-the-copilot-app/), after the feedback on #21. I tested the current portable root shape as well as the existing package:

- Current `main`, direct repository install: succeeds, but Copilot warns that direct installs are deprecated in favor of marketplaces.
- Current `main`, existing marketplace: succeeds without that warning; `copilot skill list` exposes `diagram-design` plus `doctor`, `export-diagram`, all three import capabilities, and `profile`.
- Current `main` plus a minimal root Agent Plugins 1.0 `plugin.json`: the main `diagram-design` skill loads, but the current CLI no longer exposes the existing root `commands/` capabilities under the portable layout.

Adding the portable manifest alone would therefore reduce the installed surface. A complete migration would require a separately reviewed `com.github.copilot/` command layout, while GitHub explicitly continues to support existing legacy plugins. The smallest non-regressing contribution is to document the verified marketplace path already present.

## How this differs from #21

- no always-on `.github/copilot-instructions.md`
- no copied or rewritten `SKILL.md` content
- no custom prompt files, agents, hooks, MCP servers, or canvas extension
- no obsolete prompt metadata or tool identifiers
- no claim that a skill installer provisions files outside the installed package

## Live Copilot evidence

Using a fresh isolated `COPILOT_HOME`:

```text
$ copilot plugin marketplace add cathrynlavery/diagram-design
Marketplace "diagram-design" added successfully.

$ copilot plugin install diagram-design@diagram-design
Plugin "diagram-design" installed successfully. Installed 1 skill.

$ copilot plugin list
Installed plugins:
  • diagram-design@diagram-design (v2.6.21)
```

I then asked Copilot to use the installed skill to create a minimal Browser → API → Database architecture diagram, run the packaged self-check, and export SVG only. It produced a 7,153-byte standalone HTML file and a valid 5,567-byte SVG; the self-check passed.

The documented update sequence was also exercised successfully:

```text
copilot plugin marketplace update diagram-design
copilot plugin update diagram-design@diagram-design
```

## Visual proof

Not applicable — installation documentation only; no diagram, example, template, or rendered output changes.

## Validation gates

All 58 commands in `.maintainer-policy.json` `gates.local_commands` pass on the exact committed head, including:

- `python3 scripts/test-plugin-package.py`
- `python3 scripts/test-maintainer-policy.py`
- `python3 scripts/verify-plugin-package.py --require-no-bump origin/main`
- `npx --yes @anthropic-ai/claude-code@2.1.229 plugin validate . --strict`
- `python3 scripts/verify-docs-sync.py`
- `python3 scripts/test-verify-docs-sync.py`
- the full lint, render, import, geometry, chart, screenshot, thumbnail, and generated-icon gates

Manifest versions remain unchanged per ADR 0009.

## Checklist

- [x] No new entries added to `scripts/lint-skin-baseline.txt`
- [x] Generated and source files are consistent
- [x] Accessible SVG contract not affected
- [x] Visual proof marked not applicable
- [x] Code of Conduct respected

## Related issues

Follow-up to #21.
